### PR TITLE
Added conversion methods from standard types to periodical-specific item

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ periodical = "0.1.0"
 - [ ] Fuzzing
 - [ ] [Cargo mutants](https://lib.rs/crates/cargo-mutants)
 - [ ] Full-fledged documentation
-- [ ] Conversion methods to create `periodical`-specific types from standard types
+- [x] Conversion methods to create `periodical`-specific types from standard types
 
 ## 0.1.1
 

--- a/src/intervals/meta.rs
+++ b/src/intervals/meta.rs
@@ -50,8 +50,8 @@ pub enum Relativity {
     Relative,
     /// Bounds are set using specific timestamps
     Absolute,
-    /// Uses concepts rather than bounds, like [open](super::interval::OpenInterval)
-    /// and [empty](super::interval::EmptyInterval) intervals
+    /// Uses concepts rather than bounds, like [open](super::special::OpenInterval)
+    /// and [empty](super::special::EmptyInterval) intervals
     Any,
 }
 
@@ -86,6 +86,16 @@ impl Display for OpeningDirection {
     }
 }
 
+impl From<bool> for OpeningDirection {
+    fn from(goes_to_future: bool) -> Self {
+        if goes_to_future {
+            OpeningDirection::ToFuture
+        } else {
+            OpeningDirection::ToPast
+        }
+    }
+}
+
 /// Time interval duration
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Duration {
@@ -99,6 +109,12 @@ impl Display for Duration {
             Self::Finite(duration) => write!(f, "Finite duration: {duration}"),
             Self::Infinite => write!(f, "Infinite duration"),
         }
+    }
+}
+
+impl From<chrono::Duration> for Duration {
+    fn from(duration: chrono::Duration) -> Self {
+        Duration::Finite(duration)
     }
 }
 
@@ -135,6 +151,16 @@ impl Display for BoundInclusivity {
         match self {
             Self::Inclusive => write!(f, "Inclusive bound"),
             Self::Exclusive => write!(f, "Exclusive bound"),
+        }
+    }
+}
+
+impl From<bool> for BoundInclusivity {
+    fn from(is_inclusive: bool) -> Self {
+        if is_inclusive {
+            BoundInclusivity::Inclusive
+        } else {
+            BoundInclusivity::Exclusive
         }
     }
 }

--- a/src/intervals/ops/relativity_conversion.rs
+++ b/src/intervals/ops/relativity_conversion.rs
@@ -173,7 +173,7 @@ impl ToAbsolute for ClosedRelativeInterval {
     type AbsoluteType = ClosedAbsoluteInterval;
 
     fn to_absolute(&self, reference_time: DateTime<Utc>) -> Self::AbsoluteType {
-        ClosedAbsoluteInterval::unchecked_with_inclusivity(
+        ClosedAbsoluteInterval::unchecked_new_with_inclusivity(
             reference_time + self.offset,
             self.from_inclusivity,
             reference_time + self.offset + self.length,
@@ -186,7 +186,7 @@ impl ToAbsolute for HalfOpenRelativeInterval {
     type AbsoluteType = HalfOpenAbsoluteInterval;
 
     fn to_absolute(&self, reference_time: DateTime<Utc>) -> Self::AbsoluteType {
-        HalfOpenAbsoluteInterval::with_inclusivity(
+        HalfOpenAbsoluteInterval::new_with_inclusivity(
             reference_time + self.offset,
             self.reference_time_inclusivity,
             self.opening_direction,
@@ -301,7 +301,7 @@ impl ToRelative for ClosedAbsoluteInterval {
     type RelativeType = ClosedRelativeInterval;
 
     fn to_relative(&self, reference_time: DateTime<Utc>) -> Self::RelativeType {
-        ClosedRelativeInterval::with_inclusivity(
+        ClosedRelativeInterval::new_with_inclusivity(
             self.from - reference_time,
             self.from_inclusivity,
             self.to - self.from,
@@ -314,7 +314,7 @@ impl ToRelative for HalfOpenAbsoluteInterval {
     type RelativeType = HalfOpenRelativeInterval;
 
     fn to_relative(&self, reference_time: DateTime<Utc>) -> Self::RelativeType {
-        HalfOpenRelativeInterval::with_inclusivity(
+        HalfOpenRelativeInterval::new_with_inclusivity(
             self.reference_time - reference_time,
             self.reference_time_inclusivity,
             self.opening_direction,

--- a/src/intervals/special.rs
+++ b/src/intervals/special.rs
@@ -4,6 +4,7 @@
 
 use std::error::Error;
 use std::fmt::Display;
+use std::ops::RangeFull;
 
 use chrono::Duration;
 
@@ -72,6 +73,12 @@ impl HasRelativeBounds for OpenInterval {
 
     fn rel_end(&self) -> RelativeEndBound {
         RelativeEndBound::InfiniteFuture
+    }
+}
+
+impl From<RangeFull> for OpenInterval {
+    fn from(_value: RangeFull) -> Self {
+        OpenInterval
     }
 }
 
@@ -177,6 +184,12 @@ impl HasEmptiableRelativeBounds for EmptyInterval {
 impl Emptiable for EmptyInterval {
     fn is_empty(&self) -> bool {
         true
+    }
+}
+
+impl From<()> for EmptyInterval {
+    fn from(_value: ()) -> Self {
+        EmptyInterval
     }
 }
 


### PR DESCRIPTION
# Explanation

Those conversion methods allow parsing from standard data to types that the crate can use/comprehend.

This is useful for converting data coming from databases for example.

# Changelog

## Added

- Conversion methods from standard types for absolute, relative, and special intervals
- Conversion methods from standard types for interval meta

## Changed

- `with_inclusivity` method on `AbsoluteClosedInterval`, `RelativeClosedInterval`, `AbsoluteHalfOpenInterval`, `RelativeHalfOpenInterval` renamed to `new_with_inclusivity` for clarity