### PR TITLE
Improved: Epsilon support for interval durations

### DIFF
--- a/src/intervals/meta.rs
+++ b/src/intervals/meta.rs
@@ -458,6 +458,27 @@ impl Duration {
             .checked_sub(&interpreted_epsilon)
             .map(|dur| dur.max(chrono::Duration::zero()))
     }
+
+    /// Returns the [`chrono::Duration`] of the [`Finite`](Duration::Finite) variant and strips the epsilon duration
+    ///
+    /// Consumes `self`, then simply returns the [`chrono::Duration`] stored in the [`Finite`](Duration::Finite)
+    /// variant, without using the stored [`Epsilon`]. Puts the result in an [`Option`].
+    /// If instead `self` is another variant, the method returns [`None`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use periodical::intervals::meta::{Duration, Epsilon};
+    /// assert_eq!(
+    ///     Duration::Finite(chrono::Duration::hours(2), Epsilon::Both).finite_strip_epsilon(),
+    ///     Some(chrono::Duration::hours(2)),
+    /// );
+    /// assert_eq!(Duration::Infinite.finite_strip_epsilon(), None);
+    /// ```
+    #[must_use]
+    pub fn finite_strip_epsilon(self) -> Option<chrono::Duration> {
+        Some(self.finite()?.0)
+    }
 }
 
 impl Display for Duration {

--- a/src/intervals/meta.rs
+++ b/src/intervals/meta.rs
@@ -312,6 +312,21 @@ impl Display for Epsilon {
     }
 }
 
+/// Converts `(BoundInclusivity, BoundInclusivity)` into [`Epsilon`]
+///
+/// The tuple elements represent the start bound inclusivity and end bound inclusivity, respectively.
+/// Exclusive bounds, [`BoundInclusivity::Exclusive`], create an epsilon.
+impl From<(BoundInclusivity, BoundInclusivity)> for Epsilon {
+    fn from((start_inclusivity, end_inclusivity): (BoundInclusivity, BoundInclusivity)) -> Self {
+        match (start_inclusivity, end_inclusivity) {
+            (BoundInclusivity::Inclusive, BoundInclusivity::Inclusive) => Epsilon::None,
+            (BoundInclusivity::Exclusive, BoundInclusivity::Inclusive) => Epsilon::Start,
+            (BoundInclusivity::Inclusive, BoundInclusivity::Exclusive) => Epsilon::End,
+            (BoundInclusivity::Exclusive, BoundInclusivity::Exclusive) => Epsilon::Both,
+        }
+    }
+}
+
 /// Converts `(bool, bool)` into [`Epsilon`]
 ///
 /// The first tuple element represents whether the start bound has an epsilon,
@@ -367,8 +382,8 @@ impl Duration {
     /// # Examples
     ///
     /// ```
-    /// # use periodical::intervals::meta::Duration;
-    /// assert!(Duration::Finite(chrono::Duration::hours(1)).is_finite());
+    /// # use periodical::intervals::meta::{Duration, Epsilon};
+    /// assert!(Duration::Finite(chrono::Duration::hours(1), Epsilon::None).is_finite());
     /// ```
     #[must_use]
     pub fn is_finite(&self) -> bool {
@@ -388,7 +403,7 @@ impl Duration {
     ///     Duration::Finite(chrono::Duration::hours(2), Epsilon::End).finite(),
     ///     Some((chrono::Duration::hours(2), Epsilon::End)),
     /// );
-    /// assert_eq!(Duration::Infinite, None);
+    /// assert_eq!(Duration::Infinite.finite(), None);
     /// ```
     #[must_use]
     pub fn finite(self) -> Option<(chrono::Duration, Epsilon)> {

--- a/src/intervals/meta.rs
+++ b/src/intervals/meta.rs
@@ -2,6 +2,7 @@
 //!
 //! Contains information about intervals such as [`Relativity`], [`Openness`], [`OpeningDirection`], and more.
 
+use std::error::Error;
 use std::fmt::Display;
 
 #[cfg(feature = "arbitrary")]
@@ -147,19 +148,215 @@ impl From<bool> for OpeningDirection {
     }
 }
 
+/// Infinitesimal duration variation of an interval
+///
+/// Represents the infinitesimal duration variation(s) created by [exclusive bounds](BoundInclusivity::Exclusive).
+///
+/// An infinitesimal duration is represented by an epsilon sign, hence the name.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+pub enum Epsilon {
+    /// No epsilon
+    #[default]
+    None,
+    /// Epsilon variation on start bound
+    Start,
+    /// Epsilon variation on end bound
+    End,
+    /// Epsilon variation on both bounds
+    Both,
+}
+
+impl Epsilon {
+    /// Returns whether an epsilon is present
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use periodical::intervals::meta::Epsilon;
+    /// assert!(Epsilon::Start.has_epsilon());
+    /// assert!(Epsilon::End.has_epsilon());
+    /// assert!(Epsilon::Both.has_epsilon());
+    /// assert!(!Epsilon::None.has_epsilon());
+    /// ```
+    #[must_use]
+    pub fn has_epsilon(&self) -> bool {
+        !matches!(self, Self::None)
+    }
+
+    /// Returns whether the start bound has an epsilon
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use periodical::intervals::meta::Epsilon;
+    /// assert!(Epsilon::Start.has_epsilon_on_start());
+    /// assert!(Epsilon::Both.has_epsilon_on_start());
+    /// assert!(!Epsilon::None.has_epsilon_on_start());
+    /// assert!(!Epsilon::End.has_epsilon_on_start());
+    /// ```
+    #[must_use]
+    pub fn has_epsilon_on_start(&self) -> bool {
+        matches!(self, Self::Start | Self::Both)
+    }
+
+    /// Returns whether the end bound has an epsilon
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use periodical::intervals::meta::Epsilon;
+    /// assert!(Epsilon::End.has_epsilon_on_end());
+    /// assert!(Epsilon::Both.has_epsilon_on_end());
+    /// assert!(!Epsilon::None.has_epsilon_on_end());
+    /// assert!(!Epsilon::Start.has_epsilon_on_end());
+    /// ```
+    #[must_use]
+    pub fn has_epsilon_on_end(&self) -> bool {
+        matches!(self, Self::End | Self::Both)
+    }
+
+    /// Interprets the epsilon as a specific duration using different duration interpretations per bound
+    ///
+    /// # Errors
+    ///
+    /// If `start_epsilon_duration` + `end_epsilon_duration` overflows,
+    /// the method returns [`DurationOverflow`](EpsilonInterpretationDurationError::DurationOverflow).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use periodical::intervals::meta::{Epsilon, EpsilonInterpretationDurationError};
+    /// let start_epsilon_duration = chrono::Duration::seconds(1);
+    /// let end_epsilon_duration = chrono::Duration::seconds(2);
+    ///
+    /// assert_eq!(
+    ///     Epsilon::None.interpret_as_duration_bound_specific(start_epsilon_duration, end_epsilon_duration),
+    ///     Ok(chrono::Duration::zero()),
+    /// );
+    /// assert_eq!(
+    ///     Epsilon::Start.interpret_as_duration_bound_specific(start_epsilon_duration, end_epsilon_duration),
+    ///     Ok(start_epsilon_duration),
+    /// );
+    /// assert_eq!(
+    ///     Epsilon::End.interpret_as_duration_bound_specific(start_epsilon_duration, end_epsilon_duration),
+    ///     Ok(end_epsilon_duration),
+    /// );
+    /// assert_eq!(
+    ///     Epsilon::Both.interpret_as_duration_bound_specific(start_epsilon_duration, end_epsilon_duration),
+    ///     Ok(start_epsilon_duration + end_epsilon_duration)
+    /// );
+    /// ```
+    pub fn interpret_as_duration_bound_specific(
+        &self,
+        start_epsilon_duration: chrono::Duration,
+        end_epsilon_duration: chrono::Duration,
+    ) -> Result<chrono::Duration, EpsilonInterpretationDurationError> {
+        match self {
+            Self::None => Ok(chrono::Duration::zero()),
+            Self::Start => Ok(start_epsilon_duration),
+            Self::End => Ok(end_epsilon_duration),
+            Self::Both => start_epsilon_duration
+                .checked_add(&end_epsilon_duration)
+                .ok_or(EpsilonInterpretationDurationError::DurationOverflow),
+        }
+    }
+
+    /// Interprets the epsilon as a specific duration using the given duration
+    ///
+    /// # Errors
+    ///
+    /// If `epsilon_duration * 2` overflows,
+    /// the method returns [`DurationOverflow`](EpsilonInterpretationDurationError::DurationOverflow).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use periodical::intervals::meta::{Epsilon, EpsilonInterpretationDurationError};
+    /// let epsilon_duration = chrono::Duration::seconds(1);
+    ///
+    /// assert_eq!(
+    ///     Epsilon::None.interpret_as_duration(epsilon_duration),
+    ///     Ok(chrono::Duration::zero()),
+    /// );
+    /// assert_eq!(
+    ///     Epsilon::Start.interpret_as_duration(epsilon_duration),
+    ///     Ok(epsilon_duration),
+    /// );
+    /// assert_eq!(
+    ///     Epsilon::End.interpret_as_duration(epsilon_duration),
+    ///     Ok(epsilon_duration),
+    /// );
+    /// assert_eq!(
+    ///     Epsilon::Both.interpret_as_duration(epsilon_duration),
+    ///     Ok(epsilon_duration * 2),
+    /// );
+    /// ```
+    pub fn interpret_as_duration(
+        &self,
+        epsilon_duration: chrono::Duration,
+    ) -> Result<chrono::Duration, EpsilonInterpretationDurationError> {
+        self.interpret_as_duration_bound_specific(epsilon_duration, epsilon_duration)
+    }
+}
+
+impl Display for Epsilon {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "No epsilons"),
+            Self::Start => write!(f, "Epsilon on start bound"),
+            Self::End => write!(f, "Epsilon on end bound"),
+            Self::Both => write!(f, "Epsilon on both bounds"),
+        }
+    }
+}
+
+/// Converts `(bool, bool)` into [`Epsilon`]
+///
+/// The first tuple element represents whether the start bound has an epsilon,
+/// the second tuple element represents whether the end bound has an epsilon.
+impl From<(bool, bool)> for Epsilon {
+    fn from((start_has_epsilon, end_has_epsilon): (bool, bool)) -> Self {
+        match (start_has_epsilon, end_has_epsilon) {
+            (false, false) => Epsilon::None,
+            (true, false) => Epsilon::Start,
+            (false, true) => Epsilon::End,
+            (true, true) => Epsilon::Both,
+        }
+    }
+}
+
+/// Errors that can occur when [`Epsilon`] is interpreted as a duration
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum EpsilonInterpretationDurationError {
+    /// Duration interpretation overflowed
+    DurationOverflow,
+}
+
+impl Display for EpsilonInterpretationDurationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::DurationOverflow => write!(f, "Epsilon interpretation made `chrono::Duration` overflow"),
+        }
+    }
+}
+
+impl Error for EpsilonInterpretationDurationError {}
+
 /// Interval duration
 ///
 /// Supports `chrono`'s [`Duration`](chrono::Duration) for finite durations and supports
 /// representation for infinite durations.
 ///
-/// In the future this enumerator will contain more variants to account for infinitesimal durations
-/// (also known as _epsilon_) differences created by the use of [exclusive bounds](BoundInclusivity::Exclusive).
+/// [`Finite`](Duration::Finite) supports infinitesimal duration variations, also known as [`Epsilon`]s,
+/// created by the use of [exclusive bounds](BoundInclusivity::Exclusive).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum Duration {
     /// Finite duration
-    Finite(chrono::Duration),
+    Finite(chrono::Duration, Epsilon),
     /// Infinite duration
     Infinite,
 }
@@ -175,26 +372,83 @@ impl Duration {
     /// ```
     #[must_use]
     pub fn is_finite(&self) -> bool {
-        matches!(self, Duration::Finite(_))
+        matches!(self, Duration::Finite(..))
     }
 
     /// Returns the content of the [`Finite`](Duration::Finite) variant
     ///
     /// Consumes `self` and puts the content of the [`Finite`](Duration::Finite) variant
     /// in an [`Option`]. If instead `self` is another variant, the method returns [`None`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use periodical::intervals::meta::{Duration, Epsilon};
+    /// assert_eq!(
+    ///     Duration::Finite(chrono::Duration::hours(2), Epsilon::End).finite(),
+    ///     Some((chrono::Duration::hours(2), Epsilon::End)),
+    /// );
+    /// assert_eq!(Duration::Infinite, None);
+    /// ```
     #[must_use]
-    pub fn finite(self) -> Option<chrono::Duration> {
+    pub fn finite(self) -> Option<(chrono::Duration, Epsilon)> {
         match self {
-            Self::Finite(duration) => Some(duration),
+            Self::Finite(duration, epsilon) => Some((duration, epsilon)),
             Self::Infinite => None,
         }
+    }
+
+    /// Returns the content of the [`Finite`](Duration::Finite) variant and subtracts interpreted epsilon duration
+    /// from it
+    ///
+    /// Consumes `self`, then uses the content of the [`Finite`](Duration::Finite) variant to compute the final
+    /// interpreted duration, using [`Epsilon::interpret_as_duration`] under the hood,
+    /// and puts the result in an [`Option`]. If instead `self` is another variant, the method returns [`None`].
+    ///
+    /// If [`Epsilon::interpret_as_duration`] returns an [`Err`], then the method returns [`None`].
+    ///
+    /// If the duration is small or if the interpreted [`Epsilon`]\(s) are larger than the duration, resulting
+    /// in a negative duration, the duration defaults to [an empty duration](chrono::Duration::zero).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use periodical::intervals::meta::{Duration, Epsilon};
+    /// let epsilon_duration = chrono::Duration::seconds(1);
+    /// let large_epsilon_duration = chrono::Duration::hours(2);
+    ///
+    /// assert_eq!(
+    ///     Duration::Finite(chrono::Duration::hours(1), Epsilon::End)
+    ///     .finite_interpret_epsilon(epsilon_duration),
+    ///     Some(chrono::Duration::minutes(59) + chrono::Duration::seconds(59)),
+    /// );
+    /// assert_eq!(
+    ///     Duration::Infinite.finite_interpret_epsilon(epsilon_duration),
+    ///     None,
+    /// );
+    /// assert_eq!(
+    ///     Duration::Finite(chrono::Duration::hours(1), Epsilon::Start)
+    ///     .finite_interpret_epsilon(large_epsilon_duration),
+    ///     Some(chrono::Duration::zero()),
+    /// );
+    /// ```
+    #[must_use]
+    pub fn finite_interpret_epsilon(self, epsilon_duration: chrono::Duration) -> Option<chrono::Duration> {
+        let (duration, epsilon) = self.finite()?;
+        let Ok(interpreted_epsilon) = epsilon.interpret_as_duration(epsilon_duration) else {
+            return None;
+        };
+
+        duration
+            .checked_sub(&interpreted_epsilon)
+            .map(|dur| dur.max(chrono::Duration::zero()))
     }
 }
 
 impl Display for Duration {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Finite(duration) => write!(f, "Finite duration: {duration}"),
+            Self::Finite(duration, epsilon) => write!(f, "Finite duration: {duration} ({epsilon})"),
             Self::Infinite => write!(f, "Infinite duration"),
         }
     }
@@ -202,7 +456,13 @@ impl Display for Duration {
 
 impl From<chrono::Duration> for Duration {
     fn from(duration: chrono::Duration) -> Self {
-        Duration::Finite(duration)
+        Duration::Finite(duration, Epsilon::default())
+    }
+}
+
+impl From<(chrono::Duration, Epsilon)> for Duration {
+    fn from((duration, epsilon): (chrono::Duration, Epsilon)) -> Self {
+        Duration::Finite(duration, epsilon)
     }
 }
 

--- a/src/intervals/meta_tests.rs
+++ b/src/intervals/meta_tests.rs
@@ -7,10 +7,199 @@ fn opening_direction_from_bool() {
 }
 
 #[test]
+fn epsilon_has_epsilon() {
+    assert!(!Epsilon::None.has_epsilon());
+    assert!(Epsilon::Start.has_epsilon());
+    assert!(Epsilon::End.has_epsilon());
+    assert!(Epsilon::Both.has_epsilon());
+}
+
+#[test]
+fn epsilon_has_epsilon_on_start() {
+    assert!(!Epsilon::None.has_epsilon_on_start());
+    assert!(Epsilon::Start.has_epsilon_on_start());
+    assert!(!Epsilon::End.has_epsilon_on_start());
+    assert!(Epsilon::Both.has_epsilon_on_start());
+}
+
+#[test]
+fn epsilon_has_epsilon_on_end() {
+    assert!(!Epsilon::None.has_epsilon_on_end());
+    assert!(!Epsilon::Start.has_epsilon_on_end());
+    assert!(Epsilon::End.has_epsilon_on_end());
+    assert!(Epsilon::Both.has_epsilon_on_end());
+}
+
+#[test]
+fn epsilon_interpret_as_duration_bound_specific_none() {
+    assert_eq!(
+        Epsilon::None.interpret_as_duration_bound_specific(chrono::Duration::seconds(1), chrono::Duration::seconds(2)),
+        Ok(chrono::Duration::zero()),
+    );
+}
+
+#[test]
+fn epsilon_interpret_as_duration_bound_specific_start() {
+    assert_eq!(
+        Epsilon::Start.interpret_as_duration_bound_specific(chrono::Duration::seconds(1), chrono::Duration::seconds(2)),
+        Ok(chrono::Duration::seconds(1)),
+    );
+}
+
+#[test]
+fn epsilon_interpret_as_duration_bound_specific_end() {
+    assert_eq!(
+        Epsilon::End.interpret_as_duration_bound_specific(chrono::Duration::seconds(1), chrono::Duration::seconds(2)),
+        Ok(chrono::Duration::seconds(2)),
+    );
+}
+
+#[test]
+fn epsilon_interpret_as_duration_bound_specific_both() {
+    assert_eq!(
+        Epsilon::Both.interpret_as_duration_bound_specific(chrono::Duration::seconds(1), chrono::Duration::seconds(2)),
+        Ok(chrono::Duration::seconds(3)),
+    );
+}
+
+#[test]
+fn epsilon_interpret_as_duration_none() {
+    assert_eq!(
+        Epsilon::None.interpret_as_duration(chrono::Duration::seconds(1)),
+        Ok(chrono::Duration::zero())
+    );
+}
+
+#[test]
+fn epsilon_interpret_as_duration_start() {
+    assert_eq!(
+        Epsilon::Start.interpret_as_duration(chrono::Duration::seconds(1)),
+        Ok(chrono::Duration::seconds(1))
+    );
+}
+
+#[test]
+fn epsilon_interpret_as_duration_end() {
+    assert_eq!(
+        Epsilon::End.interpret_as_duration(chrono::Duration::seconds(1)),
+        Ok(chrono::Duration::seconds(1))
+    );
+}
+
+#[test]
+fn epsilon_interpret_as_duration_both() {
+    assert_eq!(
+        Epsilon::Both.interpret_as_duration(chrono::Duration::seconds(1)),
+        Ok(chrono::Duration::seconds(2))
+    );
+}
+
+#[test]
+fn epsilon_from_bound_inclusivity_pair_inclusive_inclusive() {
+    assert_eq!(
+        Epsilon::from((BoundInclusivity::Inclusive, BoundInclusivity::Inclusive)),
+        Epsilon::None
+    );
+}
+
+#[test]
+fn epsilon_from_bound_inclusivity_pair_exclusive_inclusive() {
+    assert_eq!(
+        Epsilon::from((BoundInclusivity::Exclusive, BoundInclusivity::Inclusive)),
+        Epsilon::Start
+    );
+}
+
+#[test]
+fn epsilon_from_bound_inclusivity_pair_inclusive_exclusive() {
+    assert_eq!(
+        Epsilon::from((BoundInclusivity::Inclusive, BoundInclusivity::Exclusive)),
+        Epsilon::End
+    );
+}
+
+#[test]
+fn epsilon_from_bound_inclusivity_pair_exclusive_exclusive() {
+    assert_eq!(
+        Epsilon::from((BoundInclusivity::Exclusive, BoundInclusivity::Exclusive)),
+        Epsilon::Both
+    );
+}
+
+#[test]
+fn epsilon_from_bool_pair_false_false() {
+    assert_eq!(Epsilon::from((false, false)), Epsilon::None);
+}
+
+#[test]
+fn epsilon_from_bool_pair_true_false() {
+    assert_eq!(Epsilon::from((true, false)), Epsilon::Start);
+}
+
+#[test]
+fn epsilon_from_bool_pair_false_true() {
+    assert_eq!(Epsilon::from((false, true)), Epsilon::End);
+}
+
+#[test]
+fn epsilon_from_bool_pair_true_true() {
+    assert_eq!(Epsilon::from((true, true)), Epsilon::Both);
+}
+
+#[test]
+fn interval_duration_is_finite() {
+    assert!(Duration::Finite(chrono::Duration::zero(), Epsilon::None).is_finite());
+    assert!(!Duration::Infinite.is_finite());
+}
+
+#[test]
+fn interval_duration_finite() {
+    assert_eq!(
+        Duration::Finite(chrono::Duration::hours(2), Epsilon::End).finite(),
+        Some((chrono::Duration::hours(2), Epsilon::End)),
+    );
+    assert_eq!(Duration::Infinite.finite(), None);
+}
+
+#[test]
+fn interval_duration_finite_interpret_duration_on_finite() {
+    assert_eq!(
+        Duration::Finite(chrono::Duration::hours(1), Epsilon::End)
+            .finite_interpret_epsilon(chrono::Duration::seconds(1)),
+        Some(chrono::Duration::minutes(59) + chrono::Duration::seconds(59)),
+    );
+}
+
+#[test]
+fn interval_duration_finite_interpret_duration_on_infinite() {
+    assert_eq!(
+        Duration::Infinite.finite_interpret_epsilon(chrono::Duration::seconds(1)),
+        None,
+    );
+}
+
+#[test]
+fn interval_duration_finite_interpret_duration_on_finite_large_epsilon() {
+    assert_eq!(
+        Duration::Finite(chrono::Duration::hours(1), Epsilon::Start)
+            .finite_interpret_epsilon(chrono::Duration::hours(2)),
+        Some(chrono::Duration::zero()),
+    );
+}
+
+#[test]
 fn interval_duration_from_duration() {
     assert_eq!(
         Duration::from(chrono::Duration::zero()),
-        Duration::Finite(chrono::Duration::zero())
+        Duration::Finite(chrono::Duration::zero(), Epsilon::default())
+    );
+}
+
+#[test]
+fn interval_duration_from_duration_and_epsilon() {
+    assert_eq!(
+        Duration::from((chrono::Duration::hours(2), Epsilon::End)),
+        Duration::Finite(chrono::Duration::hours(2), Epsilon::End),
     );
 }
 

--- a/src/intervals/meta_tests.rs
+++ b/src/intervals/meta_tests.rs
@@ -188,6 +188,19 @@ fn interval_duration_finite_interpret_duration_on_finite_large_epsilon() {
 }
 
 #[test]
+fn interval_duration_finite_strip_epsilon_finite() {
+    assert_eq!(
+        Duration::Finite(chrono::Duration::hours(2), Epsilon::Both).finite_strip_epsilon(),
+        Some(chrono::Duration::hours(2)),
+    );
+}
+
+#[test]
+fn interval_duration_finite_strip_epsilon_infinite() {
+    assert_eq!(Duration::Infinite.finite_strip_epsilon(), None);
+}
+
+#[test]
 fn interval_duration_from_duration() {
     assert_eq!(
         Duration::from(chrono::Duration::zero()),

--- a/src/intervals/relative.rs
+++ b/src/intervals/relative.rs
@@ -21,7 +21,7 @@ use chrono::Duration;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use crate::intervals::meta::Interval;
+use crate::intervals::meta::{Epsilon, Interval};
 
 use super::meta::{BoundInclusivity, Duration as IntervalDuration, OpeningDirection, Openness, Relativity};
 use super::prelude::*;
@@ -1496,6 +1496,7 @@ impl HasDuration for RelativeBounds {
                         .offset()
                         .checked_sub(&finite_start.offset())
                         .unwrap_or(Duration::zero()),
+                    Epsilon::from((finite_start.inclusivity(), finite_end.inclusivity())),
                 )
             },
         }
@@ -1706,7 +1707,7 @@ impl HasDuration for EmptiableRelativeBounds {
     fn duration(&self) -> IntervalDuration {
         match self {
             Self::Bound(bound) => bound.duration(),
-            Self::Empty => IntervalDuration::Finite(Duration::zero()),
+            Self::Empty => IntervalDuration::Finite(Duration::zero(), Epsilon::None),
         }
     }
 }
@@ -2176,7 +2177,10 @@ impl HasRelativity for BoundedRelativeInterval {
 
 impl HasDuration for BoundedRelativeInterval {
     fn duration(&self) -> IntervalDuration {
-        IntervalDuration::Finite(self.length)
+        IntervalDuration::Finite(
+            self.length,
+            Epsilon::from((self.from_inclusivity(), self.to_inclusivity())),
+        )
     }
 }
 

--- a/src/intervals/special.rs
+++ b/src/intervals/special.rs
@@ -12,7 +12,7 @@ use chrono::Duration;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use crate::intervals::meta::Interval;
+use crate::intervals::meta::{Epsilon, Interval};
 
 use super::absolute::{
     AbsoluteBounds, AbsoluteEndBound, AbsoluteInterval, AbsoluteStartBound, EmptiableAbsoluteBounds, HasAbsoluteBounds,
@@ -159,7 +159,7 @@ impl HasRelativity for EmptyInterval {
 
 impl HasDuration for EmptyInterval {
     fn duration(&self) -> IntervalDuration {
-        IntervalDuration::Finite(Duration::zero())
+        IntervalDuration::Finite(Duration::zero(), Epsilon::None)
     }
 }
 

--- a/src/intervals/special_tests.rs
+++ b/src/intervals/special_tests.rs
@@ -5,7 +5,7 @@ use crate::intervals::absolute::{
     EmptiableAbsoluteBounds, HasAbsoluteBounds, HasEmptiableAbsoluteBounds,
 };
 use crate::intervals::meta::{
-    Duration as IntervalDuration, Emptiable, HasDuration, HasOpenness, HasRelativity, Openness, Relativity,
+    Duration as IntervalDuration, Emptiable, Epsilon, HasDuration, HasOpenness, HasRelativity, Openness, Relativity,
 };
 use crate::intervals::relative::{
     BoundedRelativeInterval, EmptiableRelativeBounds, HasEmptiableRelativeBounds, HasRelativeBounds, RelativeBounds,
@@ -116,7 +116,10 @@ fn empty_interval_relativity() {
 
 #[test]
 fn empty_interval_duration() {
-    assert_eq!(EmptyInterval.duration(), IntervalDuration::Finite(Duration::zero()));
+    assert_eq!(
+        EmptyInterval.duration(),
+        IntervalDuration::Finite(Duration::zero(), Epsilon::None)
+    );
 }
 
 #[test]


### PR DESCRIPTION
# Explanation

Infinitesimal durations are useful to represent "gaps" created by exclusive bounds. Storing it in the `Finite` variant of the interval `Duration` allows for treating those infinitesimal durations (epsilons) as one wants.

In most contexts, you can simply ignore epsilons in order to get the correct duration of an event, like a day. A day lasts 24 hours, but spans from midnight inclusive to midnight exclusive.

In the context of having transitioned to using `periodical`, you perhaps want to keep retrocompatibility with the approach of removing a single second to represent an exclusive bound, therefore you can also convert epsilons into a concrete duration.

# Changelog

## Added

- `Epsilon` structure for support of infinitesimal duration variations
- Conversion methods for `Epsilon`
- Conversion methods for interval `Duration` using `Epsilon`
- Specific methods to retrieve duration information from interval `Duration` depending on how to handle (or not) the `Epsilon` contained in the `Duration::Finite` variant

## Changed

- Interval `Duration::Finite` variant now contains `Epsilon`
