### PR TITLE
Improved: Added MSRV for 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "periodical"
 version = "0.2.0"
 authors = ["Mældrøm <maeldroem@proton.me>"]
 edition = "2024"
+rust-version = "1.87.0"
 description = "Management of all kinds of time intervals, use it to manage schedules, find overlaps, and more!"
 documentation = "https://docs.rs/periodical"
 repository = "https://github.com/maeldroem/periodical"


### PR DESCRIPTION
# Explanation

Setting an MSRV provides the minimum version required for projects that would like to use the library.

# Changelog

## Added

- MSRV set to Rust 1.87.0
