### PR TITLE
Added convenience methods

### DIFF
--- a/src/intervals/absolute.rs
+++ b/src/intervals/absolute.rs
@@ -4398,6 +4398,851 @@ impl HalfBoundedAbsoluteInterval {
         }
     }
 
+    /// Creates a new [`HalfBoundedAbsoluteInterval`] that spans from now on
+    ///
+    /// The given inclusivity refers to whether we should include or exclude the current time.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// # use periodical::intervals::meta::BoundInclusivity;
+    /// let from_now_on = HalfBoundedAbsoluteInterval::since_now(BoundInclusivity::Inclusive);
+    /// ```
+    #[must_use]
+    pub fn since_now(inclusivity: BoundInclusivity) -> Self {
+        Self::new_with_inclusivity(Utc::now(), inclusivity, OpeningDirection::ToFuture)
+    }
+
+    /// Creates a new [`HalfBoundedAbsoluteInterval`] that spans until now
+    ///
+    /// The given inclusivity refers to whether we should include or exclude the current time.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// # use periodical::intervals::meta::BoundInclusivity;
+    /// let until_now = HalfBoundedAbsoluteInterval::until_now(BoundInclusivity::Inclusive);
+    /// ```
+    #[must_use]
+    pub fn until_now(inclusivity: BoundInclusivity) -> Self {
+        Self::new_with_inclusivity(Utc::now(), inclusivity, OpeningDirection::ToPast)
+    }
+
+    /// Creates a new [`HalfBoundedAbsoluteInterval`] that spans since the start of the given day in the given timezone
+    ///
+    /// The start of the resulting interval is [inclusive](BoundInclusivity::Inclusive).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ReferenceTimeInTimeGap`](HalfBoundedAbsoluteIntervalCreationError::ReferenceTimeInTimeGap) if
+    /// the given date's start (midnight) is positioned inside a time gap[^1].
+    ///
+    /// [^1]: See [`MappedLocalTime::None`](https://docs.rs/chrono/latest/chrono/offset/enum.LocalResult.html#variant.None)
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chrono::{DateTime, Duration, FixedOffset, NaiveDate, Utc};
+    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// # use periodical::intervals::meta::{BoundInclusivity, OpeningDirection};
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    ///
+    /// let from_first_of_may = HalfBoundedAbsoluteInterval::since_date(
+    ///     NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
+    ///     offset_tz,
+    /// ).unwrap();
+    ///
+    /// assert_eq!(from_first_of_may.reference_time(), "2026-04-30 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(from_first_of_may.reference_inclusivity(), BoundInclusivity::Inclusive);
+    /// assert_eq!(from_first_of_may.opening_direction(), OpeningDirection::ToFuture);
+    /// # Ok::<(), chrono::format::ParseError>(())
+    /// ```
+    pub fn since_date<Tz>(naive_date: NaiveDate, tz: Tz) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        let reference_time = naive_date
+            .and_time(NAIVE_TIME_MIDNIGHT)
+            .and_local_timezone(tz)
+            .earliest()
+            .ok_or(HalfBoundedAbsoluteIntervalCreationError::ReferenceTimeInTimeGap)?
+            .with_timezone(&Utc);
+
+        Ok(Self::new(reference_time, OpeningDirection::ToFuture))
+    }
+
+    /// Creates a new [`HalfBoundedAbsoluteInterval`] that spans until the start of the given day in the given timezone
+    ///
+    /// The end of the resulting interval is [exclusive](BoundInclusivity::Exclusive).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ReferenceTimeInTimeGap`](HalfBoundedAbsoluteIntervalCreationError::ReferenceTimeInTimeGap) if
+    /// the given date's start (midnight) is positioned inside a time gap[^1].
+    ///
+    /// [^1]: See [`MappedLocalTime::None`](https://docs.rs/chrono/latest/chrono/offset/enum.LocalResult.html#variant.None)
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chrono::{DateTime, Duration, FixedOffset, NaiveDate, Utc};
+    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// # use periodical::intervals::meta::{BoundInclusivity, OpeningDirection};
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    ///
+    /// let until_first_of_may = HalfBoundedAbsoluteInterval::until_date(
+    ///     NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
+    ///     offset_tz,
+    /// ).unwrap();
+    ///
+    /// assert_eq!(until_first_of_may.reference_time(), "2026-04-30 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(until_first_of_may.reference_inclusivity(), BoundInclusivity::Exclusive);
+    /// assert_eq!(until_first_of_may.opening_direction(), OpeningDirection::ToPast);
+    /// # Ok::<(), chrono::format::ParseError>(())
+    /// ```
+    pub fn until_date<Tz>(naive_date: NaiveDate, tz: Tz) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        let reference_time = naive_date
+            .and_time(NAIVE_TIME_MIDNIGHT)
+            .and_local_timezone(tz)
+            .earliest()
+            .ok_or(HalfBoundedAbsoluteIntervalCreationError::ReferenceTimeInTimeGap)?
+            .with_timezone(&Utc);
+
+        Ok(Self::new_with_inclusivity(
+            reference_time,
+            BoundInclusivity::Exclusive,
+            OpeningDirection::ToPast,
+        ))
+    }
+
+    /// Creates a new [`HalfBoundedAbsoluteInterval`] that spans since today in the given timezone
+    ///
+    /// See [`since_date`](HalfBoundedAbsoluteInterval::since_date) for more details.
+    ///
+    /// # Errors
+    ///
+    /// See [`since_date`](HalfBoundedAbsoluteInterval::since_date) for more details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chrono::{Duration, FixedOffset};
+    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    ///
+    /// let since_today = HalfBoundedAbsoluteInterval::since_today(offset_tz).unwrap();
+    /// ```
+    pub fn since_today<Tz>(tz: Tz) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::since_date(naive_date_today(&tz), tz)
+    }
+
+    /// Creates a new [`HalfBoundedAbsoluteInterval`] that spans until today in the given timezone
+    ///
+    /// See [`until_date`](HalfBoundedAbsoluteInterval::until_date) for more details.
+    ///
+    /// # Errors
+    ///
+    /// See [`until_date`](HalfBoundedAbsoluteInterval::until_date) for more details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chrono::{Duration, FixedOffset};
+    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    ///
+    /// let until_today = HalfBoundedAbsoluteInterval::until_today(offset_tz).unwrap();
+    /// ```
+    pub fn until_today<Tz>(tz: Tz) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::until_date(naive_date_today(&tz), tz)
+    }
+
+    /// Creates a new [`HalfBoundedAbsoluteInterval`] that spans since tomorrow in the given timezone
+    ///
+    /// See [`since_date`](HalfBoundedAbsoluteInterval::since_date) for more details.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OutOfRangeReferenceDate`](HalfBoundedAbsoluteIntervalCreationError::OutOfRangeReferenceDate) if
+    /// [`checked_add_naive_duration_to_naive_date`] returns [`None`].
+    ///
+    /// See [`since_date`](HalfBoundedAbsoluteInterval::since_date) for more errors that could occur,
+    /// as this method uses it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chrono::{Duration, FixedOffset};
+    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    ///
+    /// let since_tomorrow = HalfBoundedAbsoluteInterval::since_tomorrow(offset_tz).unwrap();
+    /// ```
+    pub fn since_tomorrow<Tz>(tz: Tz) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::since_date(
+            checked_add_naive_duration_to_naive_date(naive_date_today(&tz), NaiveDuration::Days(1))
+                .ok_or(HalfBoundedAbsoluteIntervalCreationError::OutOfRangeReferenceDate)?,
+            tz,
+        )
+    }
+
+    /// Creates a new [`HalfBoundedAbsoluteInterval`] that spans until tomorrow in the given timezone
+    ///
+    /// See [`until_date`](HalfBoundedAbsoluteInterval::until_date) for more details.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OutOfRangeReferenceDate`](HalfBoundedAbsoluteIntervalCreationError::OutOfRangeReferenceDate) if
+    /// [`checked_add_naive_duration_to_naive_date`] returns [`None`].
+    ///
+    /// See [`until_date`](HalfBoundedAbsoluteInterval::until_date) for more errors that could occur,
+    /// as this method uses it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chrono::{Duration, FixedOffset};
+    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    ///
+    /// let until_tomorrow = HalfBoundedAbsoluteInterval::until_tomorrow(offset_tz).unwrap();
+    /// ```
+    pub fn until_tomorrow<Tz>(tz: Tz) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::until_date(
+            checked_add_naive_duration_to_naive_date(naive_date_today(&tz), NaiveDuration::Days(1))
+                .ok_or(HalfBoundedAbsoluteIntervalCreationError::OutOfRangeReferenceDate)?,
+            tz,
+        )
+    }
+
+    /// Creates a new [`HalfBoundedAbsoluteInterval`] that spans since yesterday in the given timezone
+    ///
+    /// See [`since_date`](HalfBoundedAbsoluteInterval::since_date) for more details.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OutOfRangeReferenceDate`](HalfBoundedAbsoluteIntervalCreationError::OutOfRangeReferenceDate) if
+    /// [`checked_sub_naive_duration_to_naive_date`] returns [`None`].
+    ///
+    /// See [`since_date`](HalfBoundedAbsoluteInterval::since_date) for more errors that could occur,
+    /// as this method uses it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chrono::{Duration, FixedOffset};
+    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    ///
+    /// let since_yesterday = HalfBoundedAbsoluteInterval::since_yesterday(offset_tz).unwrap();
+    /// ```
+    pub fn since_yesterday<Tz>(tz: Tz) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::since_date(
+            checked_sub_naive_duration_to_naive_date(naive_date_today(&tz), NaiveDuration::Days(1))
+                .ok_or(HalfBoundedAbsoluteIntervalCreationError::OutOfRangeReferenceDate)?,
+            tz,
+        )
+    }
+
+    /// Creates a new [`HalfBoundedAbsoluteInterval`] that spans until yesterday in the given timezone
+    ///
+    /// See [`since_date`](HalfBoundedAbsoluteInterval::since_date) for more details.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OutOfRangeReferenceDate`](HalfBoundedAbsoluteIntervalCreationError::OutOfRangeReferenceDate) if
+    /// [`checked_sub_naive_duration_to_naive_date`] returns [`None`].
+    ///
+    /// See [`since_date`](HalfBoundedAbsoluteInterval::since_date) for more errors that could occur,
+    /// as this method uses it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chrono::{Duration, FixedOffset};
+    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    ///
+    /// let until_yesterday = HalfBoundedAbsoluteInterval::until_yesterday(offset_tz).unwrap();
+    /// ```
+    pub fn until_yesterday<Tz>(tz: Tz) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::until_date(
+            checked_sub_naive_duration_to_naive_date(naive_date_today(&tz), NaiveDuration::Days(1))
+                .ok_or(HalfBoundedAbsoluteIntervalCreationError::OutOfRangeReferenceDate)?,
+            tz,
+        )
+    }
+
+    /// Creates a new [`HalfBoundedAbsoluteInterval`] that spans since the given week in the given timezone
+    ///
+    /// See [`since_date`](HalfBoundedAbsoluteInterval::since_date) for more details.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OutOfRangeReferenceDate`](HalfBoundedAbsoluteIntervalCreationError::OutOfRangeReferenceDate) if
+    /// the week's first day is out of range.
+    ///
+    /// See [`since_date`](HalfBoundedAbsoluteInterval::since_date) for more errors that could occur,
+    /// as this method uses it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chrono::{DateTime, Duration, FixedOffset, NaiveDate, Utc, Weekday};
+    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// # use periodical::intervals::meta::{BoundInclusivity, OpeningDirection};
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    ///
+    /// let interval = HalfBoundedAbsoluteInterval::since_week(
+    ///     NaiveDate::from_ymd_opt(2026, 5, 1).unwrap().week(Weekday::Mon),
+    ///     offset_tz,
+    /// ).unwrap();
+    ///
+    /// assert_eq!(interval.reference_time(), "2026-04-26 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(interval.reference_inclusivity(), BoundInclusivity::Inclusive);
+    /// assert_eq!(interval.opening_direction(), OpeningDirection::ToFuture);
+    /// # Ok::<(), chrono::format::ParseError>(())
+    /// ```
+    pub fn since_week<Tz>(week: NaiveWeek, tz: Tz) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::since_date(
+            week.checked_first_day()
+                .ok_or(HalfBoundedAbsoluteIntervalCreationError::OutOfRangeReferenceDate)?,
+            tz,
+        )
+    }
+
+    /// Creates a new [`HalfBoundedAbsoluteInterval`] that spans until the given week in the given timezone
+    ///
+    /// See [`until_date`](HalfBoundedAbsoluteInterval::until_date) for more details.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OutOfRangeReferenceDate`](HalfBoundedAbsoluteIntervalCreationError::OutOfRangeReferenceDate) if
+    /// the week's first day is out of range.
+    ///
+    /// See [`until_date`](HalfBoundedAbsoluteInterval::until_date) for more errors that could occur,
+    /// as this method uses it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chrono::{DateTime, Duration, FixedOffset, NaiveDate, Utc, Weekday};
+    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// # use periodical::intervals::meta::{BoundInclusivity, OpeningDirection};
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    ///
+    /// let interval = HalfBoundedAbsoluteInterval::until_week(
+    ///     NaiveDate::from_ymd_opt(2026, 5, 1).unwrap().week(Weekday::Mon),
+    ///     offset_tz,
+    /// ).unwrap();
+    ///
+    /// assert_eq!(interval.reference_time(), "2026-04-26 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(interval.reference_inclusivity(), BoundInclusivity::Exclusive);
+    /// assert_eq!(interval.opening_direction(), OpeningDirection::ToPast);
+    /// # Ok::<(), chrono::format::ParseError>(())
+    /// ```
+    pub fn until_week<Tz>(week: NaiveWeek, tz: Tz) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::until_date(
+            week.checked_first_day()
+                .ok_or(HalfBoundedAbsoluteIntervalCreationError::OutOfRangeReferenceDate)?,
+            tz,
+        )
+    }
+
+    /// Creates a new [`HalfBoundedAbsoluteInterval`] that spans since the current week in the given timezone
+    ///
+    /// See [`since_week`](HalfBoundedAbsoluteInterval::since_week) for more details.
+    ///
+    /// # Errors
+    ///
+    /// See [`since_week`](HalfBoundedAbsoluteInterval::since_week) for more details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chrono::{Duration, FixedOffset, Weekday};
+    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    ///
+    /// let since_this_week = HalfBoundedAbsoluteInterval::since_this_week(Weekday::Mon, offset_tz).unwrap();
+    /// ```
+    pub fn since_this_week<Tz>(week_start: Weekday, tz: Tz) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::since_week(naive_date_today(&tz).week(week_start), tz)
+    }
+
+    /// Creates a new [`HalfBoundedAbsoluteInterval`] that spans until the current week in the given timezone
+    ///
+    /// See [`until_week`](HalfBoundedAbsoluteInterval::until_week) for more details.
+    ///
+    /// # Errors
+    ///
+    /// See [`until_week`](HalfBoundedAbsoluteInterval::until_week) for more details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chrono::{Duration, FixedOffset, Weekday};
+    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    ///
+    /// let until_this_week = HalfBoundedAbsoluteInterval::until_this_week(Weekday::Mon, offset_tz).unwrap();
+    pub fn until_this_week<Tz>(week_start: Weekday, tz: Tz) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::until_week(naive_date_today(&tz).week(week_start), tz)
+    }
+
+    /// Creates a new [`HalfBoundedAbsoluteInterval`] that spans since the given ISO week in the given timezone
+    ///
+    /// See [`since_date`](HalfBoundedAbsoluteInterval::since_date) for more details.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OutOfRangeReferenceDate`](HalfBoundedAbsoluteIntervalCreationError::OutOfRangeReferenceDate) if
+    /// the week's first day is out of range.
+    ///
+    /// See [`since_date`](HalfBoundedAbsoluteInterval::since_date) for more errors that could occur,
+    /// as this method uses it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chrono::{Datelike, DateTime, Duration, FixedOffset, NaiveDate, Utc, Weekday};
+    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// # use periodical::intervals::meta::{BoundInclusivity, OpeningDirection};
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    ///
+    /// let interval = HalfBoundedAbsoluteInterval::since_iso_week(
+    ///     NaiveDate::from_ymd_opt(2026, 5, 1).unwrap().iso_week(),
+    ///     offset_tz,
+    /// ).unwrap();
+    ///
+    /// assert_eq!(interval.reference_time(), "2026-04-26 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(interval.reference_inclusivity(), BoundInclusivity::Inclusive);
+    /// assert_eq!(interval.opening_direction(), OpeningDirection::ToFuture);
+    /// # Ok::<(), chrono::format::ParseError>(())
+    /// ```
+    pub fn since_iso_week<Tz>(iso_week: IsoWeek, tz: Tz) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::since_date(
+            NaiveDate::from_isoywd_opt(iso_week.year(), iso_week.week(), Weekday::Mon)
+                .ok_or(HalfBoundedAbsoluteIntervalCreationError::OutOfRangeReferenceDate)?,
+            tz,
+        )
+    }
+
+    /// Creates a new [`HalfBoundedAbsoluteInterval`] that spans until the given ISO week in the given timezone
+    ///
+    /// See [`until_date`](HalfBoundedAbsoluteInterval::until_date) for more details.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OutOfRangeReferenceDate`](HalfBoundedAbsoluteIntervalCreationError::OutOfRangeReferenceDate) if
+    /// the week's first day is out of range.
+    ///
+    /// See [`until_date`](HalfBoundedAbsoluteInterval::until_date) for more errors that could occur,
+    /// as this method uses it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chrono::{Datelike, DateTime, Duration, FixedOffset, NaiveDate, Utc, Weekday};
+    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// # use periodical::intervals::meta::{BoundInclusivity, OpeningDirection};
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    ///
+    /// let interval = HalfBoundedAbsoluteInterval::until_iso_week(
+    ///     NaiveDate::from_ymd_opt(2026, 5, 1).unwrap().iso_week(),
+    ///     offset_tz,
+    /// ).unwrap();
+    ///
+    /// assert_eq!(interval.reference_time(), "2026-04-26 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(interval.reference_inclusivity(), BoundInclusivity::Exclusive);
+    /// assert_eq!(interval.opening_direction(), OpeningDirection::ToPast);
+    /// # Ok::<(), chrono::format::ParseError>(())
+    /// ```
+    pub fn until_iso_week<Tz>(iso_week: IsoWeek, tz: Tz) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::until_date(
+            NaiveDate::from_isoywd_opt(iso_week.year(), iso_week.week(), Weekday::Mon)
+                .ok_or(HalfBoundedAbsoluteIntervalCreationError::OutOfRangeReferenceDate)?,
+            tz,
+        )
+    }
+
+    /// Creates a new [`HalfBoundedAbsoluteInterval`] that spans since the current ISO week in the given timezone
+    ///
+    /// See [`since_iso_week`](HalfBoundedAbsoluteInterval::since_iso_week) for more details.
+    ///
+    /// # Errors
+    ///
+    /// See [`since_iso_week`](HalfBoundedAbsoluteInterval::since_iso_week) for more details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chrono::{Duration, FixedOffset, Weekday};
+    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    ///
+    /// let since_this_iso_week = HalfBoundedAbsoluteInterval::since_this_iso_week(offset_tz).unwrap();
+    /// ```
+    pub fn since_this_iso_week<Tz>(tz: Tz) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::since_iso_week(naive_date_today(&tz).iso_week(), tz)
+    }
+
+    /// Creates a new [`HalfBoundedAbsoluteInterval`] that spans until the current ISO week in the given timezone
+    ///
+    /// See [`until_iso_week`](HalfBoundedAbsoluteInterval::until_iso_week) for more details.
+    ///
+    /// # Errors
+    ///
+    /// See [`until_iso_week`](HalfBoundedAbsoluteInterval::until_iso_week) for more details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chrono::{Duration, FixedOffset, Weekday};
+    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    ///
+    /// let until_this_iso_week = HalfBoundedAbsoluteInterval::until_this_iso_week(offset_tz).unwrap();
+    /// ```
+    pub fn until_this_iso_week<Tz>(tz: Tz) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::until_iso_week(naive_date_today(&tz).iso_week(), tz)
+    }
+
+    /// Creates a new [`HalfBoundedAbsoluteInterval`] that spans since the given month in the given timezone
+    ///
+    /// See [`since_date`](HalfBoundedAbsoluteInterval::since_date) for more details.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OutOfRangeReferenceDate`](HalfBoundedAbsoluteIntervalCreationError::OutOfRangeReferenceDate) if
+    /// the month's first day is out of range.
+    ///
+    /// See [`since_date`](HalfBoundedAbsoluteInterval::since_date) for more errors that could occur,
+    /// as this method uses it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chrono::{DateTime, Duration, FixedOffset, Month, Utc};
+    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// # use periodical::intervals::meta::{BoundInclusivity, OpeningDirection};
+    /// # use periodical::time::NaiveMonth;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    ///
+    /// let since_month = HalfBoundedAbsoluteInterval::since_month(
+    ///     NaiveMonth::new(2026, Month::March),
+    ///     offset_tz,
+    /// ).unwrap();
+    ///
+    /// assert_eq!(since_month.reference_time(), "2026-02-28 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(since_month.reference_inclusivity(), BoundInclusivity::Inclusive);
+    /// assert_eq!(since_month.opening_direction(), OpeningDirection::ToFuture);
+    /// # Ok::<(), chrono::format::ParseError>(())
+    /// ```
+    pub fn since_month<Tz>(month: NaiveMonth, tz: Tz) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::since_date(
+            month
+                .checked_first_day()
+                .ok_or(HalfBoundedAbsoluteIntervalCreationError::OutOfRangeReferenceDate)?,
+            tz,
+        )
+    }
+
+    /// Creates a new [`HalfBoundedAbsoluteInterval`] that spans until the given month in the given timezone
+    ///
+    /// See [`until_date`](HalfBoundedAbsoluteInterval::until_date) for more details.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OutOfRangeReferenceDate`](HalfBoundedAbsoluteIntervalCreationError::OutOfRangeReferenceDate) if
+    /// the month's first day is out of range.
+    ///
+    /// See [`until_date`](HalfBoundedAbsoluteInterval::until_date) for more errors that could occur,
+    /// as this method uses it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chrono::{DateTime, Duration, FixedOffset, Month, Utc};
+    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// # use periodical::intervals::meta::{BoundInclusivity, OpeningDirection};
+    /// # use periodical::time::NaiveMonth;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    ///
+    /// let until_month = HalfBoundedAbsoluteInterval::until_month(
+    ///     NaiveMonth::new(2026, Month::March),
+    ///     offset_tz,
+    /// ).unwrap();
+    ///
+    /// assert_eq!(until_month.reference_time(), "2026-02-28 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(until_month.reference_inclusivity(), BoundInclusivity::Exclusive);
+    /// assert_eq!(until_month.opening_direction(), OpeningDirection::ToPast);
+    /// # Ok::<(), chrono::format::ParseError>(())
+    /// ```
+    pub fn until_month<Tz>(month: NaiveMonth, tz: Tz) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::until_date(
+            month
+                .checked_first_day()
+                .ok_or(HalfBoundedAbsoluteIntervalCreationError::OutOfRangeReferenceDate)?,
+            tz,
+        )
+    }
+
+    /// Creates a new [`HalfBoundedAbsoluteInterval`] that spans since the current month in the given timezone
+    ///
+    /// See [`since_month`](HalfBoundedAbsoluteInterval::since_month) for more details.
+    ///
+    /// # Errors
+    ///
+    /// See [`since_month`](HalfBoundedAbsoluteInterval::since_month) for more details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chrono::{Duration, FixedOffset, Weekday};
+    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    ///
+    /// let since_this_month = HalfBoundedAbsoluteInterval::since_this_month(offset_tz).unwrap();
+    /// ```
+    pub fn since_this_month<Tz>(tz: Tz) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::since_month(
+            NaiveMonth::try_from(naive_date_today(&tz))
+                .or(Err(HalfBoundedAbsoluteIntervalCreationError::DateOperationError))?,
+            tz,
+        )
+    }
+
+    /// Creates a new [`HalfBoundedAbsoluteInterval`] that spans until the current month in the given timezone
+    ///
+    /// See [`until_month`](HalfBoundedAbsoluteInterval::until_month) for more details.
+    ///
+    /// # Errors
+    ///
+    /// See [`until_month`](HalfBoundedAbsoluteInterval::until_month) for more details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chrono::{Duration, FixedOffset, Weekday};
+    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    ///
+    /// let until_this_month = HalfBoundedAbsoluteInterval::until_this_month(offset_tz).unwrap();
+    /// ```
+    pub fn until_this_month<Tz>(tz: Tz) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::until_month(
+            NaiveMonth::try_from(naive_date_today(&tz))
+                .or(Err(HalfBoundedAbsoluteIntervalCreationError::DateOperationError))?,
+            tz,
+        )
+    }
+
+    /// Creates a new [`HalfBoundedAbsoluteInterval`] that spans since the given year in the given timezone
+    ///
+    /// See [`since_date`](HalfBoundedAbsoluteInterval::since_date) for more details.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OutOfRangeReferenceDate`](HalfBoundedAbsoluteIntervalCreationError::OutOfRangeReferenceDate) if
+    /// the year's first day is out of range.
+    ///
+    /// See [`since_date`](HalfBoundedAbsoluteInterval::since_date) for more errors that could occur,
+    /// as this method uses it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chrono::{DateTime, Duration, FixedOffset, Month, Utc};
+    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// # use periodical::intervals::meta::{BoundInclusivity, OpeningDirection};
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    ///
+    /// let since_year = HalfBoundedAbsoluteInterval::since_year(2026, offset_tz).unwrap();
+    ///
+    /// assert_eq!(since_year.reference_time(), "2025-12-31 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(since_year.reference_inclusivity(), BoundInclusivity::Inclusive);
+    /// assert_eq!(since_year.opening_direction(), OpeningDirection::ToFuture);
+    /// # Ok::<(), chrono::format::ParseError>(())
+    /// ```
+    pub fn since_year<Tz>(year: i32, tz: Tz) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::since_date(
+            NaiveDate::from_yo_opt(year, 1).ok_or(HalfBoundedAbsoluteIntervalCreationError::OutOfRangeReferenceDate)?,
+            tz,
+        )
+    }
+
+    /// Creates a new [`HalfBoundedAbsoluteInterval`] that spans until the given year in the given timezone
+    ///
+    /// See [`until_date`](HalfBoundedAbsoluteInterval::until_date) for more details.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OutOfRangeReferenceDate`](HalfBoundedAbsoluteIntervalCreationError::OutOfRangeReferenceDate) if
+    /// the year's first day is out of range.
+    ///
+    /// See [`until_date`](HalfBoundedAbsoluteInterval::until_date) for more errors that could occur,
+    /// as this method uses it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chrono::{DateTime, Duration, FixedOffset, Month, Utc};
+    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// # use periodical::intervals::meta::{BoundInclusivity, OpeningDirection};
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    ///
+    /// let until_year = HalfBoundedAbsoluteInterval::until_year(2026, offset_tz).unwrap();
+    ///
+    /// assert_eq!(until_year.reference_time(), "2025-12-31 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(until_year.reference_inclusivity(), BoundInclusivity::Exclusive);
+    /// assert_eq!(until_year.opening_direction(), OpeningDirection::ToPast);
+    /// # Ok::<(), chrono::format::ParseError>(())
+    /// ```
+    pub fn until_year<Tz>(year: i32, tz: Tz) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::until_date(
+            NaiveDate::from_yo_opt(year, 1).ok_or(HalfBoundedAbsoluteIntervalCreationError::OutOfRangeReferenceDate)?,
+            tz,
+        )
+    }
+
+    /// Creates a new [`HalfBoundedAbsoluteInterval`] that spans since the current year in the given timezone
+    ///
+    /// See [`since_year`](HalfBoundedAbsoluteInterval::since_year) for more details.
+    ///
+    /// # Errors
+    ///
+    /// See [`since_year`](HalfBoundedAbsoluteInterval::since_year) for more details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chrono::{Duration, FixedOffset, Weekday};
+    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    ///
+    /// let since_this_year = HalfBoundedAbsoluteInterval::since_this_year(offset_tz).unwrap();
+    /// ```
+    pub fn since_this_year<Tz>(tz: Tz) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::since_year(naive_date_today(&tz).year(), tz)
+    }
+
+    /// Creates a new [`HalfBoundedAbsoluteInterval`] that spans until the current year in the given timezone
+    ///
+    /// See [`until_year`](HalfBoundedAbsoluteInterval::until_year) for more details.
+    ///
+    /// # Errors
+    ///
+    /// See [`until_year`](HalfBoundedAbsoluteInterval::until_year) for more details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chrono::{Duration, FixedOffset, Weekday};
+    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    ///
+    /// let since_this_year = HalfBoundedAbsoluteInterval::until_this_year(offset_tz).unwrap();
+    /// ```
+    pub fn until_this_year<Tz>(tz: Tz) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::until_year(naive_date_today(&tz).year(), tz)
+    }
+
     /// Returns the reference time
     ///
     /// # Examples
@@ -4540,6 +5385,36 @@ impl HalfBoundedAbsoluteInterval {
         self.opening_direction = new_opening_direction;
     }
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum HalfBoundedAbsoluteIntervalCreationError {
+    /// Reference date could not be created as it was out of range
+    OutOfRangeReferenceDate,
+    /// Reference time could not be created as positioned in a time gap
+    ///
+    /// Time gaps are often created by daylight savings time (DST), where a given duration can be skipped,
+    /// therefore creating either a fold or a gap in time.
+    ReferenceTimeInTimeGap,
+    /// Something went wrong when computing a date
+    ///
+    /// This does not mean that the resulting date was out of range, but rather that something failed
+    /// in the process of calculating a date.
+    DateOperationError,
+}
+
+impl Display for HalfBoundedAbsoluteIntervalCreationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::OutOfRangeReferenceDate => write!(f, "Reference date could not be created as it was out of range"),
+            Self::ReferenceTimeInTimeGap => {
+                write!(f, "Reference time could not be created as positioned in a time gap")
+            },
+            Self::DateOperationError => write!(f, "Something went wrong when computing a date"),
+        }
+    }
+}
+
+impl Error for HalfBoundedAbsoluteIntervalCreationError {}
 
 impl Interval for HalfBoundedAbsoluteInterval {}
 

--- a/src/intervals/absolute.rs
+++ b/src/intervals/absolute.rs
@@ -27,7 +27,7 @@ use crate::intervals::ops::bound_overlap_ambiguity::{
 };
 use crate::time::{
     NAIVE_TIME_MIDNIGHT, NaiveDuration, checked_add_naive_duration_to_naive_date,
-    checked_sub_naive_duration_to_naive_date,
+    checked_sub_naive_duration_to_naive_date, naive_date_today,
 };
 
 use super::meta::{
@@ -2041,7 +2041,7 @@ impl BoundedAbsoluteInterval {
         Tz: TimeZone,
     {
         Self::from_date(
-            checked_add_naive_duration_to_naive_date(Utc::now().with_timezone(&tz).date_naive(), naive_duration)
+            checked_add_naive_duration_to_naive_date(naive_date_today(&tz), naive_duration)
                 .ok_or(BoundedAbsoluteIntervalCreationError::DateOperationError)?,
             tz,
         )
@@ -2082,7 +2082,7 @@ impl BoundedAbsoluteInterval {
         Tz: TimeZone,
     {
         Self::from_date(
-            checked_sub_naive_duration_to_naive_date(Utc::now().with_timezone(&tz).date_naive(), naive_duration)
+            checked_sub_naive_duration_to_naive_date(naive_date_today(&tz), naive_duration)
                 .ok_or(BoundedAbsoluteIntervalCreationError::DateOperationError)?,
             tz,
         )
@@ -2120,14 +2120,15 @@ impl BoundedAbsoluteInterval {
     where
         Tz: TimeZone,
     {
-        Self::from_date(Utc::now().with_timezone(&tz).date_naive(), tz)
+        Self::from_date(naive_date_today(&tz), tz)
     }
 
     /// Creates a new [`BoundedAbsoluteInterval`] of tomorrow in the given timezone
     ///
     /// # Errors
     ///
-    /// See [`day_in_days_from_today`](BoundedAbsoluteInterval::day_in_days_from_today) for more details.
+    /// See [`day_after_naive_duration_from_today`](BoundedAbsoluteInterval::day_after_naive_duration_from_today)
+    /// for more details.
     ///
     /// # Examples
     ///
@@ -2151,7 +2152,8 @@ impl BoundedAbsoluteInterval {
     ///
     /// # Errors
     ///
-    /// See [`day_in_days_from_today`](BoundedAbsoluteInterval::day_in_days_from_today) for more details.
+    /// See [`day_before_naive_duration_from_today`](BoundedAbsoluteInterval::day_before_naive_duration_from_today)
+    /// for more details.
     ///
     /// # Examples
     ///
@@ -2242,11 +2244,108 @@ impl BoundedAbsoluteInterval {
         ))
     }
 
-    pub fn week_in_weeks_from_today<Tz>(weeks_offset: i64, tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
+    /// Creates a new [`BoundedAbsoluteInterval`] of the week after a given [naive duration](NaiveDuration)
+    /// relative to today in the given timezone
+    /// 
+    /// # Errors
+    /// 
+    /// Returns [`DateOperationError`](BoundedAbsoluteIntervalCreationError::DateOperationError) if
+    /// [`time::checked_add_naive_duration_to_naive_date`](`checked_add_naive_duration_to_naive_date)
+    /// returns [`None`].
+    /// 
+    /// Returns [`OutOfRangeStartDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate) if
+    /// the week's start is out of range.
+    /// 
+    /// Returns [`OutOfRangeEndDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate) if
+    /// the week's end is out of range.
+    /// 
+    /// See [`from_inclusive_date_range`](BoundedAbsoluteInterval::from_inclusive_date_range) for more errors
+    /// that could occur, as this method uses it.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// # use chrono::{Duration, FixedOffset, Weekday};
+    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::meta::BoundInclusivity;
+    /// # use periodical::time::NaiveDuration;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let week = BoundedAbsoluteInterval::week_after_naive_duration_from_today(
+    ///     NaiveDuration::months(2),
+    ///     Weekday::Mon,
+    ///     offset_tz,
+    /// );
+    /// ```
+    pub fn week_after_naive_duration_from_today<Tz>(
+        naive_duration: NaiveDuration,
+        week_start: Weekday,
+        tz: Tz,
+    ) -> Result<Self, BoundedAbsoluteIntervalCreationError>
     where
         Tz: TimeZone,
     {
-        todo!()
+        let week = checked_add_naive_duration_to_naive_date(naive_date_today(&tz), naive_duration)
+            .ok_or(BoundedAbsoluteIntervalCreationError::DateOperationError)?
+            .week(week_start);
+
+        Self::from_inclusive_date_range(
+            week.checked_first_day().ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate)?,
+            week.checked_last_day().ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate)?,
+            tz,
+        )
+    }
+
+    /// Creates a new [`BoundedAbsoluteInterval`] of the week before a given [naive duration](NaiveDuration)
+    /// relative to today in the given timezone
+    /// 
+    /// # Errors
+    /// 
+    /// Returns [`DateOperationError`](BoundedAbsoluteIntervalCreationError::DateOperationError) if
+    /// [`time::checked_add_naive_duration_to_naive_date`](`checked_add_naive_duration_to_naive_date)
+    /// returns [`None`].
+    /// 
+    /// Returns [`OutOfRangeStartDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate) if
+    /// the week's start is out of range.
+    /// 
+    /// Returns [`OutOfRangeEndDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate) if
+    /// the week's end is out of range.
+    /// 
+    /// See [`from_inclusive_date_range`](BoundedAbsoluteInterval::from_inclusive_date_range) for more errors
+    /// that could occur, as this method uses it.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// # use chrono::{Duration, FixedOffset, Weekday};
+    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::meta::BoundInclusivity;
+    /// # use periodical::time::NaiveDuration;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let week = BoundedAbsoluteInterval::week_before_naive_duration_from_today(
+    ///     NaiveDuration::months(2),
+    ///     Weekday::Mon,
+    ///     offset_tz,
+    /// );
+    /// ```
+    pub fn week_before_naive_duration_from_today<Tz>(
+        naive_duration: NaiveDuration,
+        week_start: Weekday,
+        tz: Tz,
+    ) -> Result<Self, BoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        let week = checked_sub_naive_duration_to_naive_date(naive_date_today(&tz), naive_duration)
+            .ok_or(BoundedAbsoluteIntervalCreationError::DateOperationError)?
+            .week(week_start);
+
+        Self::from_inclusive_date_range(
+            week.checked_first_day().ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate)?,
+            week.checked_last_day().ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate)?,
+            tz,
+        )
     }
 
     /// Creates a new [`BoundedAbsoluteInterval`] of the current week in the given timezone
@@ -2259,27 +2358,120 @@ impl BoundedAbsoluteInterval {
     ///
     /// # Errors
     ///
-    /// See [`from_inclusive_date_range`](BoundedAbsoluteInterval::from_inclusive_date_range) for more details.
+    /// Returns [`OutOfRangeStartDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate) if
+    /// the week's start is out of range.
+    /// 
+    /// Returns [`OutOfRangeEndDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate) if
+    /// the week's end is out of range.
+    /// 
+    /// See [`from_inclusive_date_range`](BoundedAbsoluteInterval::from_inclusive_date_range) for more errors
+    /// that could occur, as this method uses it.
     ///
     /// # Examples
     ///
     /// ```
+    /// # use chrono::{Duration, FixedOffset, Weekday};
+    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::meta::BoundInclusivity;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let this_week = BoundedAbsoluteInterval::week_before_naive_duration_from_today(
+    ///     Weekday::Mon,
+    ///     offset_tz,
+    /// );
     /// ```
     pub fn this_week<Tz>(week_start: Weekday, tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
     where
         Tz: TimeZone,
     {
-        let this_week = Utc::now().with_timezone(&tz).date_naive().week(week_start);
+        let this_week = naive_date_today(&tz).week(week_start);
 
-        let from_date = this_week
-            .checked_first_day()
-            .ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate)?;
-        let to_date = this_week
-            .checked_last_day()
-            .ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate)?;
-
-        Self::from_inclusive_date_range(from_date, to_date, tz)
+        Self::from_inclusive_date_range(
+            this_week.checked_first_day().ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate)?,
+            this_week.checked_last_day().ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate)?,
+            tz,
+        )
     }
+
+    /// Creates a new [`BoundedAbsoluteInterval`] of the next week in the given timezone
+    ///
+    /// Since the definition of a _week_ changes from place to place, this method requires the day of the week
+    /// to consider as the start of a week.
+    ///
+    /// If you want a stable _week_ definition, use [`next_iso_week`](BoundedAbsoluteInterval::next_iso_week),
+    /// which uses [ISO weeks](https://en.wikipedia.org/w/index.php?title=ISO_week_date&oldid=1334192696).
+    ///
+    /// # Errors
+    /// 
+    /// See [`week_after_naive_duration_from_today`](BoundedAbsoluteInterval::week_after_naive_duration_from_today)
+    /// for more details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chrono::{Duration, FixedOffset, Weekday};
+    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::meta::BoundInclusivity;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let next_week = BoundedAbsoluteInterval::next_week(
+    ///     Weekday::Mon,
+    ///     offset_tz,
+    /// );
+    /// ```
+    pub fn next_week<Tz>(week_start: Weekday, tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::week_after_naive_duration_from_today(
+            NaiveDuration::weeks(week_start, 1),
+            week_start,
+            tz,
+        )
+    }
+
+    /// Creates a new [`BoundedAbsoluteInterval`] of the previous week in the given timezone
+    ///
+    /// Since the definition of a _week_ changes from place to place, this method requires the day of the week
+    /// to consider as the start of a week.
+    ///
+    /// If you want a stable _week_ definition, use [`previous_iso_week`](BoundedAbsoluteInterval::previous_iso_week),
+    /// which uses [ISO weeks](https://en.wikipedia.org/w/index.php?title=ISO_week_date&oldid=1334192696).
+    ///
+    /// # Errors
+    /// 
+    /// See [`week_before_naive_duration_from_today`](BoundedAbsoluteInterval::week_before_naive_duration_from_today)
+    /// for more details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chrono::{Duration, FixedOffset, Weekday};
+    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::meta::BoundInclusivity;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let previous_week = BoundedAbsoluteInterval::previous_week(
+    ///     Weekday::Mon,
+    ///     offset_tz,
+    /// );
+    /// ```
+    pub fn previous_week<Tz>(week_start: Weekday, tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::week_before_naive_duration_from_today(
+            NaiveDuration::weeks(week_start, 1),
+            week_start,
+            tz,
+        )
+    }
+
+    // TODO: ISO Week convenience methods
+
+    // TODO: Months convenience methods
+
+    // TODO: Years convenience methods
 
     /// Returns the start time
     ///

--- a/src/intervals/absolute.rs
+++ b/src/intervals/absolute.rs
@@ -17,7 +17,7 @@ use std::ops::{Bound, Range, RangeBounds, RangeFrom, RangeFull, RangeInclusive, 
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
-use chrono::{DateTime, Days, Duration, NaiveDate, TimeZone, Utc};
+use chrono::{DateTime, Days, Duration, NaiveDate, TimeZone, Utc, Weekday};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -25,7 +25,10 @@ use crate::intervals::meta::{Epsilon, Interval};
 use crate::intervals::ops::bound_overlap_ambiguity::{
     BoundOverlapAmbiguity, BoundOverlapDisambiguationRuleSet, DisambiguatedBoundOverlap,
 };
-use crate::time::NAIVE_TIME_MIDNIGHT;
+use crate::time::{
+    NAIVE_TIME_MIDNIGHT, NaiveDuration, checked_add_naive_duration_to_naive_date,
+    checked_sub_naive_duration_to_naive_date,
+};
 
 use super::meta::{
     BoundInclusivity, Duration as IntervalDuration, Emptiable, HasBoundInclusivity, HasDuration, HasOpenness,
@@ -1944,22 +1947,22 @@ impl BoundedAbsoluteInterval {
     }
 
     /// Creates a new [`BoundedAbsoluteInterval`] of the given date in the given timezone
-    /// 
+    ///
     /// # Errors
-    /// 
+    ///
     /// Returns [`StartInTimeGap`](BoundedAbsoluteIntervalCreationError::StartInTimeGap) if the given date
     /// at midnight in the given timezone is positioned inside a time gap[^1].
-    /// 
+    ///
     /// Returns [`OutOfRangeEndDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate) if the day after
     /// the given date is out of range.
-    /// 
+    ///
     /// Returns [`EndInTimeGap`](BoundedAbsoluteIntervalCreationError::EndInTimeGap) if the day after the given date
     /// at midnight in the given timezone is positioned inside a time gap[^1].
-    /// 
+    ///
     /// [^1]: See [`MappedLocalTime::None`](https://docs.rs/chrono/latest/chrono/offset/enum.LocalResult.html#variant.None)
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// # use chrono::{DateTime, Duration, Utc, NaiveDate, FixedOffset};
     /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
@@ -1967,9 +1970,9 @@ impl BoundedAbsoluteInterval {
     /// // UTC+02:00
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
     /// let date = NaiveDate::from_ymd_opt(2026, 1, 5).unwrap();
-    /// 
+    ///
     /// let interval = BoundedAbsoluteInterval::from_date(date, offset_tz).unwrap();
-    /// 
+    ///
     /// assert_eq!(interval.from_time(), "2026-01-04 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(interval.from_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(interval.to_time(), "2026-01-05 22:00:00Z".parse::<DateTime<Utc>>()?);
@@ -2003,83 +2006,114 @@ impl BoundedAbsoluteInterval {
         ))
     }
 
-    /// Creates a new [`BoundedAbsoluteInterval`] of the day in a given amount of days relative to today
-    /// in the given timezone
-    /// 
-    /// Represents the day that is positioned N days compared to today.
-    /// Also accepts negative values to represent a day in the past.
-    /// 
+    /// Creates a new [`BoundedAbsoluteInterval`] of the day after a given [naive duration](NaiveDuration)
+    /// relative to today in the given timezone
+    ///
     /// # Errors
-    /// 
-    /// Returns [`OutOfRangeStartDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate)
-    /// or [`OutOfRangeEndDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate)
-    /// if the date is out of range after applying the `days_offset`.
-    /// 
+    ///
+    /// Returns [`DateOperationError`](BoundedAbsoluteIntervalCreationError::DateOperationError) if
+    /// [`time::checked_add_naive_duration_to_naive_date`](`checked_add_naive_duration_to_naive_date)
+    /// returns [`None`].
+    ///
     /// See [`from_date`](BoundedAbsoluteInterval::from_date) for more errors that could occur, as this method
     /// uses it.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// # use chrono::{DateTime, Duration, Utc, FixedOffset};
     /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
     /// # use periodical::intervals::meta::BoundInclusivity;
+    /// # use periodical::time::NaiveDuration;
     /// // UTC+02:00
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
-    /// 
-    /// let interval = BoundedAbsoluteInterval::day_in_days_from_today(5, offset_tz).unwrap();
+    ///
+    /// let interval = BoundedAbsoluteInterval::day_after_naive_duration_from_today(
+    ///     NaiveDuration::days(5),
+    ///     offset_tz
+    /// ).unwrap();
     /// ```
-    pub fn day_in_days_from_today<Tz>(days_offset: i64, tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
+    pub fn day_after_naive_duration_from_today<Tz>(
+        naive_duration: NaiveDuration,
+        tz: Tz,
+    ) -> Result<Self, BoundedAbsoluteIntervalCreationError>
     where
         Tz: TimeZone,
     {
-        if days_offset.is_positive() {
-            Self::from_date(
-                Utc::now()
-                    .with_timezone(&tz)
-                    .date_naive()
-                    .checked_add_days(Days::new(days_offset.unsigned_abs()))
-                    .ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate)?,
-                tz,
-            )
-        } else {
-            Self::from_date(
-                Utc::now()
-                    .with_timezone(&tz)
-                    .date_naive()
-                    .checked_sub_days(Days::new(days_offset.unsigned_abs()))
-                    .ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate)?,
-                tz,
-            )
-        }
+        Self::from_date(
+            checked_add_naive_duration_to_naive_date(Utc::now().with_timezone(&tz).date_naive(), naive_duration)
+                .ok_or(BoundedAbsoluteIntervalCreationError::DateOperationError)?,
+            tz,
+        )
+    }
+
+    /// Creates a new [`BoundedAbsoluteInterval`] of the day before a given [naive duration](NaiveDuration)
+    /// relative to today in the given timezone
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DateOperationError`](BoundedAbsoluteIntervalCreationError::DateOperationError) if
+    /// [`time::checked_sub_naive_duration_to_naive_date`](`checked_sub_naive_duration_to_naive_date)
+    /// returns [`None`].
+    ///
+    /// See [`from_date`](BoundedAbsoluteInterval::from_date) for more errors that could occur, as this method
+    /// uses it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chrono::{DateTime, Duration, Utc, FixedOffset};
+    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::meta::BoundInclusivity;
+    /// # use periodical::time::NaiveDuration;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    ///
+    /// let interval = BoundedAbsoluteInterval::day_before_naive_duration_from_today(
+    ///     NaiveDuration::days(5),
+    ///     offset_tz
+    /// ).unwrap();
+    /// ```
+    pub fn day_before_naive_duration_from_today<Tz>(
+        naive_duration: NaiveDuration,
+        tz: Tz,
+    ) -> Result<Self, BoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::from_date(
+            checked_sub_naive_duration_to_naive_date(Utc::now().with_timezone(&tz).date_naive(), naive_duration)
+                .ok_or(BoundedAbsoluteIntervalCreationError::DateOperationError)?,
+            tz,
+        )
     }
 
     /// Returns the current day in the given [`TimeZone`](chrono::TimeZone) as a [`BoundedAbsoluteInterval`]
-    /// 
+    ///
     /// Uses [`from_date`](BoundedAbsoluteInterval::from_date) with the current day.
-    /// 
+    ///
     /// # Errors
-    /// 
+    ///
     /// Returns [`StartInTimeGap`](BoundedAbsoluteIntervalCreationError::StartInTimeGap) if today at midnight
     /// in the given timezone is positioned inside a time gap[^1].
-    /// 
+    ///
     /// Returns [`OutOfRangeEndDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate) if tomorrow's date
     /// is out of range.
-    /// 
+    ///
     /// Returns [`EndInTimeGap`](BoundedAbsoluteIntervalCreationError::EndInTimeGap) if tomorrow at midnight
     /// in the given timezone is positioned inside a time gap[^1].
-    /// 
+    ///
     /// [^1]: See [`MappedLocalTime::None`](https://docs.rs/chrono/latest/chrono/offset/enum.LocalResult.html#variant.None)
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// # use chrono::{DateTime, Duration, Utc, NaiveDate, FixedOffset};
     /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
     /// # use periodical::intervals::meta::BoundInclusivity;
     /// // UTC+02:00
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
-    /// 
+    ///
     /// let today = BoundedAbsoluteInterval::today(offset_tz).unwrap();
     /// ```
     pub fn today<Tz>(tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
@@ -2090,51 +2124,161 @@ impl BoundedAbsoluteInterval {
     }
 
     /// Creates a new [`BoundedAbsoluteInterval`] of tomorrow in the given timezone
-    /// 
+    ///
     /// # Errors
-    /// 
+    ///
     /// See [`day_in_days_from_today`](BoundedAbsoluteInterval::day_in_days_from_today) for more details.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// # use chrono::{DateTime, Duration, Utc, FixedOffset};
     /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
     /// # use periodical::intervals::meta::BoundInclusivity;
     /// // UTC+02:00
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
-    /// 
+    ///
     /// let tomorrow = BoundedAbsoluteInterval::tomorrow(offset_tz).unwrap();
     /// ```
     pub fn tomorrow<Tz>(tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
     where
         Tz: TimeZone,
     {
-        Self::day_in_days_from_today(1, tz)
+        Self::day_after_naive_duration_from_today(NaiveDuration::days(1), tz)
     }
 
     /// Creates a new [`BoundedAbsoluteInterval`] of yesterday in the given timezone
-    /// 
+    ///
     /// # Errors
-    /// 
+    ///
     /// See [`day_in_days_from_today`](BoundedAbsoluteInterval::day_in_days_from_today) for more details.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// # use chrono::{DateTime, Duration, Utc, FixedOffset};
     /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
     /// # use periodical::intervals::meta::BoundInclusivity;
     /// // UTC+02:00
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
-    /// 
+    ///
     /// let yesterday = BoundedAbsoluteInterval::yesterday(offset_tz).unwrap();
     /// ```
     pub fn yesterday<Tz>(tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
     where
         Tz: TimeZone,
     {
-        Self::day_in_days_from_today(-1, tz)
+        Self::day_before_naive_duration_from_today(NaiveDuration::days(1), tz)
+    }
+
+    /// Creates a new [`BoundedAbsoluteInterval`] from the provided inclusive date range in the given timezone
+    ///
+    /// Dates given in reverse chronological order are treated the same way as if they were provided
+    /// in chronological order.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StartInTimeGap`](BoundedAbsoluteIntervalCreationError::StartInTimeGap) if the given from date
+    /// at midnight in the given timezone is positioned inside a time gap[^1].
+    ///
+    /// Returns [`OutOfRangeEndDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate) if the day after
+    /// the given to date is out of range.
+    ///
+    /// Returns [`EndInTimeGap`](BoundedAbsoluteIntervalCreationError::EndInTimeGap) if the day after
+    /// the given to date at midnight in the given timezone is positioned inside a time gap[^1].
+    ///
+    /// [^1]: See [`MappedLocalTime::None`](https://docs.rs/chrono/latest/chrono/offset/enum.LocalResult.html#variant.None)
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chrono::{DateTime, Duration, Utc, NaiveDate, FixedOffset};
+    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::meta::BoundInclusivity;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let from = NaiveDate::from_ymd_opt(2026, 1, 5).unwrap();
+    /// let to = NaiveDate::from_ymd_opt(2026, 1, 10).unwrap();
+    ///
+    /// let interval = BoundedAbsoluteInterval::from_inclusive_date_range(from, to, offset_tz).unwrap();
+    ///
+    /// assert_eq!(interval.from_time(), "2026-01-04 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(interval.from_inclusivity(), BoundInclusivity::Inclusive);
+    /// assert_eq!(interval.to_time(), "2026-01-10 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(interval.to_inclusivity(), BoundInclusivity::Exclusive);
+    /// # Ok::<(), chrono::format::ParseError>(())
+    /// ```
+    pub fn from_inclusive_date_range<Tz>(
+        mut from_date: NaiveDate,
+        mut to_date: NaiveDate,
+        tz: Tz,
+    ) -> Result<Self, BoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        if from_date > to_date {
+            std::mem::swap(&mut from_date, &mut to_date);
+        }
+
+        let from = from_date
+            .and_time(NAIVE_TIME_MIDNIGHT)
+            .and_local_timezone(tz.clone())
+            .earliest()
+            .ok_or(BoundedAbsoluteIntervalCreationError::StartInTimeGap)?;
+
+        let to = to_date
+            .checked_add_days(Days::new(1))
+            .ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate)?
+            .and_time(NAIVE_TIME_MIDNIGHT)
+            .and_local_timezone(tz)
+            .latest()
+            .ok_or(BoundedAbsoluteIntervalCreationError::EndInTimeGap)?;
+
+        Ok(Self::unchecked_new_with_inclusivity(
+            from.with_timezone(&Utc),
+            BoundInclusivity::Inclusive,
+            to.with_timezone(&Utc),
+            BoundInclusivity::Exclusive,
+        ))
+    }
+
+    pub fn week_in_weeks_from_today<Tz>(weeks_offset: i64, tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        todo!()
+    }
+
+    /// Creates a new [`BoundedAbsoluteInterval`] of the current week in the given timezone
+    ///
+    /// Since the definition of a _week_ changes from place to place, this method requires the day of the week
+    /// to consider as the start of a week.
+    ///
+    /// If you want a stable _week_ definition, use [`this_iso_week`](BoundedAbsoluteInterval::this_iso_week),
+    /// which uses [ISO weeks](https://en.wikipedia.org/w/index.php?title=ISO_week_date&oldid=1334192696).
+    ///
+    /// # Errors
+    ///
+    /// See [`from_inclusive_date_range`](BoundedAbsoluteInterval::from_inclusive_date_range) for more details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// ```
+    pub fn this_week<Tz>(week_start: Weekday, tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        let this_week = Utc::now().with_timezone(&tz).date_naive().week(week_start);
+
+        let from_date = this_week
+            .checked_first_day()
+            .ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate)?;
+        let to_date = this_week
+            .checked_last_day()
+            .ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate)?;
+
+        Self::from_inclusive_date_range(from_date, to_date, tz)
     }
 
     /// Returns the start time
@@ -2441,7 +2585,7 @@ impl BoundedAbsoluteInterval {
 }
 
 /// Errors that can occur when creating a new [`BoundedAbsoluteInterval`]
-/// 
+///
 /// Those errors are mostly created by convenience methods, such as [`BoundedAbsoluteInterval::today`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum BoundedAbsoluteIntervalCreationError {
@@ -2450,15 +2594,25 @@ pub enum BoundedAbsoluteIntervalCreationError {
     /// End date could not be created as it was out of range
     OutOfRangeEndDate,
     /// Start time could not be created as positioned in a time gap
-    /// 
+    ///
     /// Time gaps are often created by daylight savings time (DST), where a given duration can be skipped,
     /// therefore creating either a fold or a gap in time.
     StartInTimeGap,
     /// End time could not be created as positioned in a time gap
-    /// 
+    ///
     /// Time gaps are often created by daylight savings time (DST), where a given duration can be skipped,
     /// therefore creating either a fold or a gap in time.
     EndInTimeGap,
+    /// Something went wrong when computing a date
+    ///
+    /// This does not mean that the resulting date was out of range, but rather that something failed
+    /// in the process of calculating a date.
+    ///
+    /// An example would be subtracting a large value from a date's year (`chrono` stores years in [`i32`]):
+    /// Removing `i64::from(i32::MAX + 10)` from [`i32::MAX`] can be represented by an [`i32`],
+    /// but the computation may use `.checked_sub(i32::try_from(x))`, which would fail as `i64::from(i32::MAX + 10)`
+    /// cannot be stored in an [`i32`].
+    DateOperationError,
 }
 
 impl Display for BoundedAbsoluteIntervalCreationError {
@@ -2468,6 +2622,7 @@ impl Display for BoundedAbsoluteIntervalCreationError {
             Self::OutOfRangeEndDate => write!(f, "End date could not be created as it was out of range"),
             Self::StartInTimeGap => write!(f, "Start time could not be created as positioned in a time gap"),
             Self::EndInTimeGap => write!(f, "End time could not be created as positioned in a time gap"),
+            Self::DateOperationError => write!(f, "Something went wrong when computing a date"),
         }
     }
 }

--- a/src/intervals/absolute.rs
+++ b/src/intervals/absolute.rs
@@ -17,7 +17,7 @@ use std::ops::{Bound, Range, RangeBounds, RangeFrom, RangeFull, RangeInclusive, 
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
-use chrono::{DateTime, Datelike, Days, Duration, IsoWeek, NaiveDate, NaiveWeek, TimeZone, Utc, Weekday};
+use chrono::{DateTime, Datelike, Days, Duration, IsoWeek, Month, NaiveDate, NaiveWeek, TimeZone, Utc, Weekday};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -26,7 +26,7 @@ use crate::intervals::ops::bound_overlap_ambiguity::{
     BoundOverlapAmbiguity, BoundOverlapDisambiguationRuleSet, DisambiguatedBoundOverlap,
 };
 use crate::time::{
-    NAIVE_TIME_MIDNIGHT, NaiveDuration, checked_add_naive_duration_to_naive_date,
+    NAIVE_TIME_MIDNIGHT, NaiveDuration, NaiveMonth, checked_add_naive_duration_to_naive_date,
     checked_sub_naive_duration_to_naive_date, naive_date_today,
 };
 
@@ -2244,6 +2244,50 @@ impl BoundedAbsoluteInterval {
         ))
     }
 
+    /// Creates a new [`BoundedAbsoluteInterval`] from the provided week in the given timezone
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OutOfRangeStartDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate) if
+    /// the week's first date is out of range.
+    ///
+    /// Returns [`OutOfRangeEndDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate) if
+    /// the week's last date is out of range.
+    ///
+    /// See [`from_inclusive_date_range`](BoundedAbsoluteInterval::from_inclusive_date_range) for more errors
+    /// that could occur, as this method uses it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chrono::{DateTime, Duration, FixedOffset, NaiveDate, Utc, Weekday};
+    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::meta::BoundInclusivity;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let week = NaiveDate::from_ymd_opt(2026, 5, 1).unwrap().week(Weekday::Tue);
+    ///
+    /// let week_interval = BoundedAbsoluteInterval::from_week(week, offset_tz).unwrap();
+    ///
+    /// assert_eq!(week_interval.from_time(), "2026-04-27 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(week_interval.from_inclusivity(), BoundInclusivity::Inclusive);
+    /// assert_eq!(week_interval.to_time(), "2026-05-04 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(week_interval.to_inclusivity(), BoundInclusivity::Exclusive);
+    /// # Ok::<(), chrono::format::ParseError>(())
+    /// ```
+    pub fn from_week<Tz>(week: NaiveWeek, tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::from_inclusive_date_range(
+            week.checked_first_day()
+                .ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate)?,
+            week.checked_last_day()
+                .ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate)?,
+            tz,
+        )
+    }
+
     /// Creates a new [`BoundedAbsoluteInterval`] from the provided inclusive week range in the given timezone
     ///
     /// Weeks given in reverse chronological order are treated the same way as if they were provided
@@ -2524,6 +2568,46 @@ impl BoundedAbsoluteInterval {
         Tz: TimeZone,
     {
         Self::week_before_naive_duration_from_today(NaiveDuration::weeks(week_start, 1), week_start, tz)
+    }
+
+    /// Creates a new [`BoundedAbsoluteInterval`] from the provided ISO week in the given timezone
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OutOfRangeStartDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate) if
+    /// the week's first date is out of range.
+    ///
+    /// See [`from_week`](BoundedAbsoluteInterval::from_week) for more errors that could occur,
+    /// as this method uses it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chrono::{Datelike, DateTime, Duration, FixedOffset, NaiveDate, Utc, Weekday};
+    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::meta::BoundInclusivity;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let iso_week = NaiveDate::from_ymd_opt(2026, 5, 1).unwrap().iso_week();
+    ///
+    /// let iso_week_interval = BoundedAbsoluteInterval::from_iso_week(iso_week, offset_tz).unwrap();
+    ///
+    /// assert_eq!(iso_week_interval.from_time(), "2026-04-26 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(iso_week_interval.from_inclusivity(), BoundInclusivity::Inclusive);
+    /// assert_eq!(iso_week_interval.to_time(), "2026-05-03 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(iso_week_interval.to_inclusivity(), BoundInclusivity::Exclusive);
+    /// # Ok::<(), chrono::format::ParseError>(())
+    /// ```
+    pub fn from_iso_week<Tz>(iso_week: IsoWeek, tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::from_week(
+            NaiveDate::from_isoywd_opt(iso_week.year(), iso_week.week(), Weekday::Mon)
+                .ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate)?
+                .week(Weekday::Mon),
+            tz,
+        )
     }
 
     /// Creates a new [`BoundedAbsoluteInterval`] from the provided inclusive ISO week range in the given timezone

--- a/src/intervals/absolute.rs
+++ b/src/intervals/absolute.rs
@@ -25,7 +25,7 @@ use crate::intervals::meta::{Epsilon, Interval};
 use crate::intervals::ops::bound_overlap_ambiguity::{
     BoundOverlapAmbiguity, BoundOverlapDisambiguationRuleSet, DisambiguatedBoundOverlap,
 };
-use crate::time_constants::NAIVE_TIME_MIDNIGHT;
+use crate::time::NAIVE_TIME_MIDNIGHT;
 
 use super::meta::{
     BoundInclusivity, Duration as IntervalDuration, Emptiable, HasBoundInclusivity, HasDuration, HasOpenness,

--- a/src/intervals/absolute.rs
+++ b/src/intervals/absolute.rs
@@ -17,7 +17,7 @@ use std::ops::{Bound, Range, RangeBounds, RangeFrom, RangeFull, RangeInclusive, 
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
-use chrono::{DateTime, Days, Duration, Utc};
+use chrono::{DateTime, Days, Duration, NaiveDate, TimeZone, Utc};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -1943,7 +1943,69 @@ impl BoundedAbsoluteInterval {
         }
     }
 
+    /// Creates a new [`BoundedAbsoluteInterval`] of the given date in the given timezone
+    /// 
+    /// # Errors
+    /// 
+    /// Returns [`StartInTimeGap`](BoundedAbsoluteIntervalCreationError::StartInTimeGap) if the given date
+    /// at midnight in the given timezone is positioned inside a time gap[^1].
+    /// 
+    /// Returns [`OutOfRangeEndDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate) if the day after
+    /// the given date is out of range.
+    /// 
+    /// Returns [`EndInTimeGap`](BoundedAbsoluteIntervalCreationError::EndInTimeGap) if the day after the given date
+    /// at midnight in the given timezone is positioned inside a time gap[^1].
+    /// 
+    /// [^1]: See [`MappedLocalTime::None`](https://docs.rs/chrono/latest/chrono/offset/enum.LocalResult.html#variant.None)
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// # use chrono::{DateTime, Duration, Utc, NaiveDate, FixedOffset};
+    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::meta::BoundInclusivity;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let date = NaiveDate::from_ymd_opt(2026, 1, 5).unwrap();
+    /// 
+    /// let interval = BoundedAbsoluteInterval::from_date(date, offset_tz).unwrap();
+    /// 
+    /// assert_eq!(interval.from_time(), "2026-01-04 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(interval.from_inclusivity(), BoundInclusivity::Inclusive);
+    /// assert_eq!(interval.to_time(), "2026-01-05 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(interval.to_inclusivity(), BoundInclusivity::Exclusive);
+    /// # Ok::<(), chrono::format::ParseError>(())
+    /// ```
+    pub fn from_date<Tz>(naive_date: NaiveDate, tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        let from = naive_date
+            .and_time(NAIVE_TIME_MIDNIGHT)
+            .and_local_timezone(tz.clone())
+            .earliest()
+            .ok_or(BoundedAbsoluteIntervalCreationError::StartInTimeGap)?;
+
+        let next_day = naive_date
+            .checked_add_days(Days::new(1))
+            .ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate)?;
+        let to = next_day
+            .and_time(NAIVE_TIME_MIDNIGHT)
+            .and_local_timezone(tz)
+            .latest()
+            .ok_or(BoundedAbsoluteIntervalCreationError::EndInTimeGap)?;
+
+        Ok(Self::unchecked_new_with_inclusivity(
+            from.with_timezone(&Utc),
+            BoundInclusivity::Inclusive,
+            to.with_timezone(&Utc),
+            BoundInclusivity::Exclusive,
+        ))
+    }
+
     /// Returns the current day in the given [`TimeZone`](chrono::TimeZone) as a [`BoundedAbsoluteInterval`]
+    /// 
+    /// Uses [`from_date`](BoundedAbsoluteInterval::from_date) with the current day.
     /// 
     /// # Errors
     /// 
@@ -1957,32 +2019,23 @@ impl BoundedAbsoluteInterval {
     /// in the given timezone is positioned inside a time gap[^1].
     /// 
     /// [^1]: See [`MappedLocalTime::None`](https://docs.rs/chrono/latest/chrono/offset/enum.LocalResult.html#variant.None)
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// # use chrono::{DateTime, Duration, Utc, NaiveDate, FixedOffset};
+    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::meta::BoundInclusivity;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// 
+    /// let today = BoundedAbsoluteInterval::today(offset_tz).unwrap();
+    /// ```
     pub fn today<Tz>(tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
     where
-        Tz: chrono::TimeZone,
+        Tz: TimeZone,
     {
-        let today = Utc::now().with_timezone(&tz).date_naive();
-        let from = today
-            .and_time(NAIVE_TIME_MIDNIGHT)
-            .and_local_timezone(tz.clone())
-            .earliest()
-            .ok_or(BoundedAbsoluteIntervalCreationError::StartInTimeGap)?;
-
-        let tomorrow = today
-            .checked_add_days(Days::new(1))
-            .ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate)?;
-        let to = tomorrow
-            .and_time(NAIVE_TIME_MIDNIGHT)
-            .and_local_timezone(tz)
-            .latest()
-            .ok_or(BoundedAbsoluteIntervalCreationError::EndInTimeGap)?;
-
-        Ok(Self::unchecked_new_with_inclusivity(
-            from.with_timezone(&Utc),
-            BoundInclusivity::Inclusive,
-            to.with_timezone(&Utc),
-            BoundInclusivity::Exclusive,
-        ))
+        Self::from_date(Utc::now().with_timezone(&tz).date_naive(), tz)
     }
 
     /// Returns the start time

--- a/src/intervals/absolute.rs
+++ b/src/intervals/absolute.rs
@@ -4187,7 +4187,7 @@ impl BoundedAbsoluteInterval {
     /// #         ExampleError::BoundedAbsoluteIntervalCreationError(value)
     /// #     }
     /// # }
-    /// # 
+    /// #
     /// # impl From<chrono::format::ParseError> for ExampleError {
     /// #     fn from(value: chrono::format::ParseError) -> Self {
     /// #         ExampleError::ParseError(value)
@@ -4275,7 +4275,7 @@ impl BoundedAbsoluteInterval {
     /// #         ExampleError::BoundedAbsoluteIntervalCreationError(value)
     /// #     }
     /// # }
-    /// # 
+    /// #
     /// # impl From<chrono::format::ParseError> for ExampleError {
     /// #     fn from(value: chrono::format::ParseError) -> Self {
     /// #         ExampleError::ParseError(value)

--- a/src/intervals/absolute.rs
+++ b/src/intervals/absolute.rs
@@ -17,7 +17,7 @@ use std::ops::{Bound, Range, RangeBounds, RangeFrom, RangeFull, RangeInclusive, 
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
-use chrono::{DateTime, Datelike, Days, Duration, IsoWeek, Month, NaiveDate, NaiveWeek, TimeZone, Utc, Weekday};
+use chrono::{DateTime, Datelike, Days, Duration, IsoWeek, NaiveDate, NaiveWeek, TimeZone, Utc, Weekday};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -2875,7 +2875,270 @@ impl BoundedAbsoluteInterval {
         Self::iso_week_before_naive_duration_from_today(NaiveDuration::Weeks(Weekday::Mon, 1), tz)
     }
 
-    // TODO: Months convenience methods
+    /// Creates a new [`BoundedAbsoluteInterval`] of the given month in the given timezone
+    /// 
+    /// # Errors
+    /// 
+    /// Returns [`OutOfRangeStartDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate) if
+    /// the first day of the month is out of range.
+    /// 
+    /// Returns [`OutOfRangeEndDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate) if
+    /// the last day of the month is out of range.
+    /// 
+    /// See [`from_inclusive_date_range`](BoundedAbsoluteInterval::from_inclusive_date_range) for more errors
+    /// that could occur, as this method uses it.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// # use chrono::{DateTime, Duration, FixedOffset, Month, Utc};
+    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::meta::BoundInclusivity;
+    /// # use periodical::time::NaiveMonth;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// 
+    /// let month = BoundedAbsoluteInterval::from_month(
+    ///     NaiveMonth::new(2026, Month::May),
+    ///     offset_tz,
+    /// ).unwrap();
+    /// 
+    /// assert_eq!(month.from_time(), "2026-04-30 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(month.from_inclusivity(), BoundInclusivity::Inclusive);
+    /// assert_eq!(month.to_time(), "2026-05-31 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(month.to_inclusivity(), BoundInclusivity::Exclusive);
+    /// # Ok::<(), chrono::format::ParseError>(())
+    /// ```
+    pub fn from_month<Tz>(month: NaiveMonth, tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::from_inclusive_date_range(
+            month.checked_first_day().ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate)?,
+            month.checked_last_day().ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate)?,
+            tz,
+        )
+    }
+
+    /// Creates a new [`BoundedAbsoluteInterval`] from the provided inclusive month range in the given timezone
+    ///
+    /// Months given in reverse chronological order are treated the same way as if they were provided
+    /// in chronological order.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OutOfRangeStartDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate) if
+    /// the from month's first day is out of range.
+    ///
+    /// Returns [`OutOfRangeEndDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate) if
+    /// the to month's last day is out of range.
+    ///
+    /// See [`from_inclusive_date_range`](BoundedAbsoluteInterval::from_inclusive_date_range) for more errors
+    /// that could occur, as this method uses it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chrono::{DateTime, Duration, FixedOffset, Month, Utc};
+    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::meta::BoundInclusivity;
+    /// # use periodical::time::NaiveMonth;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    ///
+    /// let interval = BoundedAbsoluteInterval::from_inclusive_month_range(
+    ///     NaiveMonth::new(2026, Month::January),
+    ///     NaiveMonth::new(2026, Month::May),
+    ///     offset_tz,
+    /// ).unwrap();
+    ///
+    /// assert_eq!(interval.from_time(), "2025-12-31 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(interval.from_inclusivity(), BoundInclusivity::Inclusive);
+    /// assert_eq!(interval.to_time(), "2026-05-31 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(interval.to_inclusivity(), BoundInclusivity::Exclusive);
+    /// # Ok::<(), chrono::format::ParseError>(())
+    /// ```
+    pub fn from_inclusive_month_range<Tz>(
+        mut from: NaiveMonth,
+        mut to: NaiveMonth,
+        tz: Tz,
+    ) -> Result<Self, BoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        if from > to {
+            std::mem::swap(&mut from, &mut to);
+        }
+
+        Self::from_inclusive_date_range(
+            from.checked_first_day().ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate)?,
+            to.checked_last_day().ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate)?,
+            tz,
+        )
+    }
+
+    /// Creates a new [`BoundedAbsoluteInterval`] of the month after a given [naive duration](NaiveDuration)
+    /// relative to today in the given timezone
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DateOperationError`](BoundedAbsoluteIntervalCreationError::DateOperationError) if
+    /// [`time::checked_add_naive_duration_to_naive_date`](`checked_add_naive_duration_to_naive_date)
+    /// returns [`None`], or if conversion of today's [`NaiveDate`] to a [`NaiveMonth`] failed.
+    ///
+    /// See [`from_month`](BoundedAbsoluteInterval::from_month) for more errors that could occur,
+    /// as this method uses it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chrono::{Duration, FixedOffset};
+    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::time::NaiveDuration;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// 
+    /// let month = BoundedAbsoluteInterval::month_after_naive_duration_from_today(
+    ///     NaiveDuration::months(2),
+    ///     offset_tz,
+    /// );
+    /// ```
+    pub fn month_after_naive_duration_from_today<Tz>(
+        naive_duration: NaiveDuration,
+        tz: Tz,
+    ) -> Result<Self, BoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        let day = checked_add_naive_duration_to_naive_date(naive_date_today(&tz), naive_duration)
+            .ok_or(BoundedAbsoluteIntervalCreationError::DateOperationError)?;
+
+        Self::from_month(
+            NaiveMonth::try_from(day).or(Err(BoundedAbsoluteIntervalCreationError::DateOperationError))?,
+            tz,
+        )
+    }
+
+    /// Creates a new [`BoundedAbsoluteInterval`] of the month after a given [naive duration](NaiveDuration)
+    /// relative to today in the given timezone
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DateOperationError`](BoundedAbsoluteIntervalCreationError::DateOperationError) if
+    /// [`time::checked_sub_naive_duration_to_naive_date`](`checked_sub_naive_duration_to_naive_date)
+    /// returns [`None`], or if conversion of today's [`NaiveDate`] to a [`NaiveMonth`] failed.
+    ///
+    /// See [`from_month`](BoundedAbsoluteInterval::from_month) for more errors that could occur,
+    /// as this method uses it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chrono::{Duration, FixedOffset};
+    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::time::NaiveDuration;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// 
+    /// let month = BoundedAbsoluteInterval::month_before_naive_duration_from_today(
+    ///     NaiveDuration::months(2),
+    ///     offset_tz,
+    /// );
+    /// ```
+    pub fn month_before_naive_duration_from_today<Tz>(
+        naive_duration: NaiveDuration,
+        tz: Tz,
+    ) -> Result<Self, BoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        let day = checked_sub_naive_duration_to_naive_date(naive_date_today(&tz), naive_duration)
+            .ok_or(BoundedAbsoluteIntervalCreationError::DateOperationError)?;
+
+        Self::from_month(
+            NaiveMonth::try_from(day).or(Err(BoundedAbsoluteIntervalCreationError::DateOperationError))?,
+            tz,
+        )
+    }
+
+    /// Creates a new [`BoundedAbsoluteInterval`] of the current month in the given timezone
+    /// 
+    /// # Errors
+    /// 
+    /// Returns [`DateOperationError`](BoundedAbsoluteIntervalCreationError::DateOperationError) if
+    /// conversion of today's [`NaiveDate`] to a [`NaiveMonth`] failed.
+    /// 
+    /// See [`from_month`](BoundedAbsoluteInterval::from_month) for more errors that could occur,
+    /// as this method uses it.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// # use chrono::{Duration, FixedOffset};
+    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// 
+    /// let month = BoundedAbsoluteInterval::this_month(offset_tz);
+    /// ```
+    pub fn this_month<Tz>(tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::from_month(
+            NaiveMonth::try_from(naive_date_today(&tz))
+                .or(Err(BoundedAbsoluteIntervalCreationError::DateOperationError))?,
+            tz,
+        )
+    }
+
+    /// Creates a new [`BoundedAbsoluteInterval`] of the next month in the given timezone
+    /// 
+    /// # Errors
+    /// 
+    /// See [`month_after_naive_duration_from_today`](BoundedAbsoluteInterval::month_after_naive_duration_from_today)
+    /// for more details.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// # use chrono::{Duration, FixedOffset};
+    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// 
+    /// let month = BoundedAbsoluteInterval::next_month(offset_tz);
+    /// ```
+    pub fn next_month<Tz>(tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::month_after_naive_duration_from_today(NaiveDuration::months(1), tz)
+    }
+
+    /// Creates a new [`BoundedAbsoluteInterval`] of the previous month in the given timezone
+    /// 
+    /// # Errors
+    /// 
+    /// See [`month_before_naive_duration_from_today`](BoundedAbsoluteInterval::month_before_naive_duration_from_today)
+    /// for more details.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// # use chrono::{Duration, FixedOffset};
+    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// 
+    /// let month = BoundedAbsoluteInterval::previous_month(offset_tz);
+    /// ```
+    pub fn previous_month<Tz>(tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::month_before_naive_duration_from_today(NaiveDuration::months(1), tz)
+    }
 
     // TODO: Years convenience methods
 

--- a/src/intervals/absolute.rs
+++ b/src/intervals/absolute.rs
@@ -1959,7 +1959,7 @@ impl BoundedAbsoluteInterval {
     /// Returns [`EndInTimeGap`](BoundedAbsoluteIntervalCreationError::EndInTimeGap) if the day after the given date
     /// at midnight in the given timezone is positioned inside a time gap[^1].
     ///
-    /// [^1]: See [`MappedLocalTime::None`](https://docs.rs/chrono/latest/chrono/offset/enum.LocalResult.html#variant.None)
+    /// [^1]: See [`MappedLocalTime::None`](chrono::offset::LocalResult::None)
     ///
     /// # Examples
     ///
@@ -2030,7 +2030,7 @@ impl BoundedAbsoluteInterval {
     ///
     /// let interval = BoundedAbsoluteInterval::day_after_naive_duration_from_naive_date(
     ///     NaiveDate::from_ymd_opt(2026, 4, 29).unwrap(),
-    ///     NaiveDuration::days(5),
+    ///     NaiveDuration::Days(5),
     ///     offset_tz
     /// ).unwrap();
     ///
@@ -2079,7 +2079,7 @@ impl BoundedAbsoluteInterval {
     ///
     /// let interval = BoundedAbsoluteInterval::day_before_naive_duration_from_naive_date(
     ///     NaiveDate::from_ymd_opt(2026, 4, 29).unwrap(),
-    ///     NaiveDuration::days(5),
+    ///     NaiveDuration::Days(5),
     ///     offset_tz
     /// ).unwrap();
     ///
@@ -2123,7 +2123,7 @@ impl BoundedAbsoluteInterval {
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
     ///
     /// let interval = BoundedAbsoluteInterval::day_after_naive_duration_from_today(
-    ///     NaiveDuration::days(5),
+    ///     NaiveDuration::Days(5),
     ///     offset_tz
     /// ).unwrap();
     /// ```
@@ -2156,7 +2156,7 @@ impl BoundedAbsoluteInterval {
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
     ///
     /// let interval = BoundedAbsoluteInterval::day_before_naive_duration_from_today(
-    ///     NaiveDuration::days(5),
+    ///     NaiveDuration::Days(5),
     ///     offset_tz
     /// ).unwrap();
     /// ```
@@ -2185,7 +2185,7 @@ impl BoundedAbsoluteInterval {
     /// Returns [`EndInTimeGap`](BoundedAbsoluteIntervalCreationError::EndInTimeGap) if tomorrow at midnight
     /// in the given timezone is positioned inside a time gap[^1].
     ///
-    /// [^1]: See [`MappedLocalTime::None`](https://docs.rs/chrono/latest/chrono/offset/enum.LocalResult.html#variant.None)
+    /// [^1]: See [`MappedLocalTime::None`](chrono::offset::LocalResult::None)
     ///
     /// # Examples
     ///
@@ -2227,7 +2227,7 @@ impl BoundedAbsoluteInterval {
     where
         Tz: TimeZone,
     {
-        Self::day_after_naive_duration_from_today(NaiveDuration::days(1), tz)
+        Self::day_after_naive_duration_from_today(NaiveDuration::Days(1), tz)
     }
 
     /// Creates a new [`BoundedAbsoluteInterval`] of yesterday in the given timezone
@@ -2252,7 +2252,7 @@ impl BoundedAbsoluteInterval {
     where
         Tz: TimeZone,
     {
-        Self::day_before_naive_duration_from_today(NaiveDuration::days(1), tz)
+        Self::day_before_naive_duration_from_today(NaiveDuration::Days(1), tz)
     }
 
     /// Creates a new [`BoundedAbsoluteInterval`] from the provided inclusive date range in the given timezone
@@ -2271,7 +2271,7 @@ impl BoundedAbsoluteInterval {
     /// Returns [`EndInTimeGap`](BoundedAbsoluteIntervalCreationError::EndInTimeGap) if the day after
     /// the given to date at midnight in the given timezone is positioned inside a time gap[^1].
     ///
-    /// [^1]: See [`MappedLocalTime::None`](https://docs.rs/chrono/latest/chrono/offset/enum.LocalResult.html#variant.None)
+    /// [^1]: See [`MappedLocalTime::None`](chrono::offset::LocalResult::None)
     ///
     /// # Examples
     ///
@@ -2453,7 +2453,7 @@ impl BoundedAbsoluteInterval {
     ///
     /// let week = BoundedAbsoluteInterval::week_after_naive_duration_from_naive_date(
     ///     NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
-    ///     NaiveDuration::weeks(Weekday::Mon, 2),
+    ///     NaiveDuration::Weeks(Weekday::Mon, 2),
     ///     Weekday::Mon,
     ///     offset_tz,
     /// ).unwrap();
@@ -2504,7 +2504,7 @@ impl BoundedAbsoluteInterval {
     ///
     /// let week = BoundedAbsoluteInterval::week_before_naive_duration_from_naive_date(
     ///     NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
-    ///     NaiveDuration::weeks(Weekday::Mon, 2),
+    ///     NaiveDuration::Weeks(Weekday::Mon, 2),
     ///     Weekday::Mon,
     ///     offset_tz,
     /// ).unwrap();
@@ -2549,7 +2549,7 @@ impl BoundedAbsoluteInterval {
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
     ///
     /// let week = BoundedAbsoluteInterval::week_after_naive_duration_from_today(
-    ///     NaiveDuration::months(2),
+    ///     NaiveDuration::Months(2),
     ///     Weekday::Mon,
     ///     offset_tz,
     /// ).unwrap();
@@ -2583,7 +2583,7 @@ impl BoundedAbsoluteInterval {
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
     ///
     /// let week = BoundedAbsoluteInterval::week_before_naive_duration_from_today(
-    ///     NaiveDuration::months(2),
+    ///     NaiveDuration::Months(2),
     ///     Weekday::Mon,
     ///     offset_tz,
     /// ).unwrap();
@@ -2678,7 +2678,7 @@ impl BoundedAbsoluteInterval {
     where
         Tz: TimeZone,
     {
-        Self::week_after_naive_duration_from_today(NaiveDuration::weeks(week_start, 1), week_start, tz)
+        Self::week_after_naive_duration_from_today(NaiveDuration::Weeks(week_start, 1), week_start, tz)
     }
 
     /// Creates a new [`BoundedAbsoluteInterval`] of the previous week in the given timezone
@@ -2711,7 +2711,7 @@ impl BoundedAbsoluteInterval {
     where
         Tz: TimeZone,
     {
-        Self::week_before_naive_duration_from_today(NaiveDuration::weeks(week_start, 1), week_start, tz)
+        Self::week_before_naive_duration_from_today(NaiveDuration::Weeks(week_start, 1), week_start, tz)
     }
 
     /// Creates a new [`BoundedAbsoluteInterval`] from the provided ISO week in the given timezone
@@ -2892,7 +2892,7 @@ impl BoundedAbsoluteInterval {
     ///
     /// let week = BoundedAbsoluteInterval::iso_week_after_naive_duration_from_naive_date(
     ///     NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
-    ///     NaiveDuration::weeks(Weekday::Mon, 2),
+    ///     NaiveDuration::IsoWeeks(2),
     ///     offset_tz,
     /// ).unwrap();
     ///
@@ -2933,7 +2933,7 @@ impl BoundedAbsoluteInterval {
     ///
     /// let week = BoundedAbsoluteInterval::iso_week_before_naive_duration_from_naive_date(
     ///     NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
-    ///     NaiveDuration::weeks(Weekday::Mon, 2),
+    ///     NaiveDuration::IsoWeeks(2),
     ///     offset_tz,
     /// ).unwrap();
     ///
@@ -2972,7 +2972,7 @@ impl BoundedAbsoluteInterval {
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
     ///
     /// let iso_week = BoundedAbsoluteInterval::iso_week_after_naive_duration_from_today(
-    ///     NaiveDuration::months(2),
+    ///     NaiveDuration::Months(2),
     ///     offset_tz,
     /// );
     /// ```
@@ -3004,7 +3004,7 @@ impl BoundedAbsoluteInterval {
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
     ///
     /// let iso_week = BoundedAbsoluteInterval::iso_week_before_naive_duration_from_today(
-    ///     NaiveDuration::months(2),
+    ///     NaiveDuration::Months(2),
     ///     offset_tz,
     /// );
     /// ```
@@ -3072,7 +3072,7 @@ impl BoundedAbsoluteInterval {
     where
         Tz: TimeZone,
     {
-        Self::iso_week_after_naive_duration_from_today(NaiveDuration::weeks(Weekday::Mon, 1), tz)
+        Self::iso_week_after_naive_duration_from_today(NaiveDuration::IsoWeeks(1), tz)
     }
 
     /// Creates a new [`BoundedAbsoluteInterval`] of the previous ISO week in the given timezone
@@ -3096,7 +3096,7 @@ impl BoundedAbsoluteInterval {
     where
         Tz: TimeZone,
     {
-        Self::iso_week_before_naive_duration_from_today(NaiveDuration::weeks(Weekday::Mon, 1), tz)
+        Self::iso_week_before_naive_duration_from_today(NaiveDuration::IsoWeeks(1), tz)
     }
 
     /// Creates a new [`BoundedAbsoluteInterval`] of the given month in the given timezone
@@ -3231,7 +3231,7 @@ impl BoundedAbsoluteInterval {
     ///
     /// let month = BoundedAbsoluteInterval::month_after_naive_duration_from_naive_date(
     ///     NaiveDate::from_ymd_opt(2026, 5, 5).unwrap(),
-    ///     NaiveDuration::months(2),
+    ///     NaiveDuration::Months(2),
     ///     offset_tz,
     /// ).unwrap();
     ///
@@ -3282,7 +3282,7 @@ impl BoundedAbsoluteInterval {
     ///
     /// let month = BoundedAbsoluteInterval::month_before_naive_duration_from_naive_date(
     ///     NaiveDate::from_ymd_opt(2026, 5, 5).unwrap(),
-    ///     NaiveDuration::months(2),
+    ///     NaiveDuration::Months(2),
     ///     offset_tz,
     /// ).unwrap();
     ///
@@ -3327,7 +3327,7 @@ impl BoundedAbsoluteInterval {
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
     ///
     /// let month = BoundedAbsoluteInterval::month_after_naive_duration_from_today(
-    ///     NaiveDuration::months(2),
+    ///     NaiveDuration::Months(2),
     ///     offset_tz,
     /// ).unwrap();
     /// ```
@@ -3359,7 +3359,7 @@ impl BoundedAbsoluteInterval {
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
     ///
     /// let month = BoundedAbsoluteInterval::month_before_naive_duration_from_today(
-    ///     NaiveDuration::months(2),
+    ///     NaiveDuration::Months(2),
     ///     offset_tz,
     /// ).unwrap();
     /// ```
@@ -3425,7 +3425,7 @@ impl BoundedAbsoluteInterval {
     where
         Tz: TimeZone,
     {
-        Self::month_after_naive_duration_from_today(NaiveDuration::months(1), tz)
+        Self::month_after_naive_duration_from_today(NaiveDuration::Months(1), tz)
     }
 
     /// Creates a new [`BoundedAbsoluteInterval`] of the previous month in the given timezone
@@ -3449,7 +3449,7 @@ impl BoundedAbsoluteInterval {
     where
         Tz: TimeZone,
     {
-        Self::month_before_naive_duration_from_today(NaiveDuration::months(1), tz)
+        Self::month_before_naive_duration_from_today(NaiveDuration::Months(1), tz)
     }
 
     /// Creates a new [`BoundedAbsoluteInterval`] from the given year in the given timezone
@@ -3593,7 +3593,7 @@ impl BoundedAbsoluteInterval {
     ///
     /// let year = BoundedAbsoluteInterval::year_after_naive_duration_from_naive_date(
     ///     NaiveDate::from_ymd_opt(2026, 5, 5).unwrap(),
-    ///     NaiveDuration::months(15),
+    ///     NaiveDuration::Months(15),
     ///     offset_tz,
     /// ).unwrap();
     ///
@@ -3643,7 +3643,7 @@ impl BoundedAbsoluteInterval {
     ///
     /// let year = BoundedAbsoluteInterval::year_before_naive_duration_from_naive_date(
     ///     NaiveDate::from_ymd_opt(2026, 5, 5).unwrap(),
-    ///     NaiveDuration::months(15),
+    ///     NaiveDuration::Months(15),
     ///     offset_tz,
     /// ).unwrap();
     ///
@@ -3687,7 +3687,7 @@ impl BoundedAbsoluteInterval {
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
     ///
     /// let year = BoundedAbsoluteInterval::year_after_naive_duration_from_today(
-    ///     NaiveDuration::months(15),
+    ///     NaiveDuration::Months(15),
     ///     offset_tz,
     /// ).unwrap();
     /// ```
@@ -3719,7 +3719,7 @@ impl BoundedAbsoluteInterval {
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
     ///
     /// let year = BoundedAbsoluteInterval::year_before_naive_duration_from_today(
-    ///     NaiveDuration::months(15),
+    ///     NaiveDuration::Months(15),
     ///     offset_tz,
     /// ).unwrap();
     /// ```
@@ -3776,7 +3776,7 @@ impl BoundedAbsoluteInterval {
     where
         Tz: TimeZone,
     {
-        Self::year_after_naive_duration_from_today(NaiveDuration::years(1), tz)
+        Self::year_after_naive_duration_from_today(NaiveDuration::Years(1), tz)
     }
 
     /// Creates a new [`BoundedAbsoluteInterval`] of the previous year in the given timezone
@@ -3799,7 +3799,7 @@ impl BoundedAbsoluteInterval {
     where
         Tz: TimeZone,
     {
-        Self::year_before_naive_duration_from_today(NaiveDuration::years(1), tz)
+        Self::year_before_naive_duration_from_today(NaiveDuration::Years(1), tz)
     }
 
     /// Returns the start time
@@ -4439,7 +4439,7 @@ impl HalfBoundedAbsoluteInterval {
     /// Returns [`ReferenceTimeInTimeGap`](HalfBoundedAbsoluteIntervalCreationError::ReferenceTimeInTimeGap) if
     /// the given date's start (midnight) is positioned inside a time gap[^1].
     ///
-    /// [^1]: See [`MappedLocalTime::None`](https://docs.rs/chrono/latest/chrono/offset/enum.LocalResult.html#variant.None)
+    /// [^1]: See [`MappedLocalTime::None`](chrono::offset::LocalResult::None)
     ///
     /// # Examples
     ///
@@ -4483,7 +4483,7 @@ impl HalfBoundedAbsoluteInterval {
     /// Returns [`ReferenceTimeInTimeGap`](HalfBoundedAbsoluteIntervalCreationError::ReferenceTimeInTimeGap) if
     /// the given date's start (midnight) is positioned inside a time gap[^1].
     ///
-    /// [^1]: See [`MappedLocalTime::None`](https://docs.rs/chrono/latest/chrono/offset/enum.LocalResult.html#variant.None)
+    /// [^1]: See [`MappedLocalTime::None`](chrono::offset::LocalResult::None)
     ///
     /// # Examples
     ///

--- a/src/intervals/absolute.rs
+++ b/src/intervals/absolute.rs
@@ -1964,20 +1964,66 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{DateTime, Duration, Utc, NaiveDate, FixedOffset};
-    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError};
     /// # use periodical::intervals::meta::BoundInclusivity;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct NaiveDateFromYmdError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     NaiveDateFromYmdError(NaiveDateFromYmdError),
+    /// #     BoundedAbsoluteIntervalCreationError(BoundedAbsoluteIntervalCreationError),
+    /// #     ParseError(chrono::format::ParseError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<NaiveDateFromYmdError> for ExampleError {
+    /// #     fn from(value: NaiveDateFromYmdError) -> Self {
+    /// #         ExampleError::NaiveDateFromYmdError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<BoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: BoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::BoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<chrono::format::ParseError> for ExampleError {
+    /// #     fn from(value: chrono::format::ParseError) -> Self {
+    /// #         ExampleError::ParseError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
-    /// let date = NaiveDate::from_ymd_opt(2026, 1, 5).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
+    /// let date = NaiveDate::from_ymd_opt(2026, 1, 5).ok_or(NaiveDateFromYmdError)?;
     ///
-    /// let interval = BoundedAbsoluteInterval::from_date(date, offset_tz).unwrap();
+    /// let interval = BoundedAbsoluteInterval::from_date(date, offset_tz)?;
     ///
     /// assert_eq!(interval.from_time(), "2026-01-04 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(interval.from_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(interval.to_time(), "2026-01-05 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(interval.to_inclusivity(), BoundInclusivity::Exclusive);
-    /// # Ok::<(), chrono::format::ParseError>(())
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn from_date<Tz>(naive_date: NaiveDate, tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
     where
@@ -2021,24 +2067,70 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{DateTime, Duration, FixedOffset, NaiveDate, Utc};
-    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError};
     /// # use periodical::intervals::meta::BoundInclusivity;
     /// # use periodical::time::NaiveDuration;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct NaiveDateFromYmdError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     NaiveDateFromYmdError(NaiveDateFromYmdError),
+    /// #     BoundedAbsoluteIntervalCreationError(BoundedAbsoluteIntervalCreationError),
+    /// #     ParseError(chrono::format::ParseError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<NaiveDateFromYmdError> for ExampleError {
+    /// #     fn from(value: NaiveDateFromYmdError) -> Self {
+    /// #         ExampleError::NaiveDateFromYmdError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<BoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: BoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::BoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<chrono::format::ParseError> for ExampleError {
+    /// #     fn from(value: chrono::format::ParseError) -> Self {
+    /// #         ExampleError::ParseError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
     /// let interval = BoundedAbsoluteInterval::day_after_naive_duration_from_naive_date(
-    ///     NaiveDate::from_ymd_opt(2026, 4, 29).unwrap(),
+    ///     NaiveDate::from_ymd_opt(2026, 4, 29).ok_or(NaiveDateFromYmdError)?,
     ///     NaiveDuration::Days(5),
     ///     offset_tz
-    /// ).unwrap();
+    /// )?;
     ///
     /// assert_eq!(interval.from_time(), "2026-05-03 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(interval.from_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(interval.to_time(), "2026-05-04 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(interval.to_inclusivity(), BoundInclusivity::Exclusive);
-    /// # Ok::<(), chrono::format::ParseError>(())
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn day_after_naive_duration_from_naive_date<Tz>(
         naive_date: NaiveDate,
@@ -2070,24 +2162,70 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{DateTime, Duration, FixedOffset, NaiveDate, Utc};
-    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError};
     /// # use periodical::intervals::meta::BoundInclusivity;
     /// # use periodical::time::NaiveDuration;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct NaiveDateFromYmdError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     NaiveDateFromYmdError(NaiveDateFromYmdError),
+    /// #     BoundedAbsoluteIntervalCreationError(BoundedAbsoluteIntervalCreationError),
+    /// #     ParseError(chrono::format::ParseError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<NaiveDateFromYmdError> for ExampleError {
+    /// #     fn from(value: NaiveDateFromYmdError) -> Self {
+    /// #         ExampleError::NaiveDateFromYmdError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<BoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: BoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::BoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<chrono::format::ParseError> for ExampleError {
+    /// #     fn from(value: chrono::format::ParseError) -> Self {
+    /// #         ExampleError::ParseError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
     /// let interval = BoundedAbsoluteInterval::day_before_naive_duration_from_naive_date(
-    ///     NaiveDate::from_ymd_opt(2026, 4, 29).unwrap(),
+    ///     NaiveDate::from_ymd_opt(2026, 4, 29).ok_or(NaiveDateFromYmdError)?,
     ///     NaiveDuration::Days(5),
     ///     offset_tz
-    /// ).unwrap();
+    /// )?;
     ///
     /// assert_eq!(interval.from_time(), "2026-04-23 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(interval.from_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(interval.to_time(), "2026-04-24 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(interval.to_inclusivity(), BoundInclusivity::Exclusive);
-    /// # Ok::<(), chrono::format::ParseError>(())
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn day_before_naive_duration_from_naive_date<Tz>(
         naive_date: NaiveDate,
@@ -2115,17 +2253,47 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{DateTime, Duration, Utc, FixedOffset};
-    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError};
     /// # use periodical::intervals::meta::BoundInclusivity;
     /// # use periodical::time::NaiveDuration;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     BoundedAbsoluteIntervalCreationError(BoundedAbsoluteIntervalCreationError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<BoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: BoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::BoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
     /// let interval = BoundedAbsoluteInterval::day_after_naive_duration_from_today(
     ///     NaiveDuration::Days(5),
     ///     offset_tz
-    /// ).unwrap();
+    /// )?;
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn day_after_naive_duration_from_today<Tz>(
         naive_duration: NaiveDuration,
@@ -2148,17 +2316,47 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{DateTime, Duration, Utc, FixedOffset};
-    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError};
     /// # use periodical::intervals::meta::BoundInclusivity;
     /// # use periodical::time::NaiveDuration;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     BoundedAbsoluteIntervalCreationError(BoundedAbsoluteIntervalCreationError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<BoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: BoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::BoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
     /// let interval = BoundedAbsoluteInterval::day_before_naive_duration_from_today(
     ///     NaiveDuration::Days(5),
     ///     offset_tz
-    /// ).unwrap();
+    /// )?;
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn day_before_naive_duration_from_today<Tz>(
         naive_duration: NaiveDuration,
@@ -2190,13 +2388,43 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{DateTime, Duration, Utc, NaiveDate, FixedOffset};
-    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError};
     /// # use periodical::intervals::meta::BoundInclusivity;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     BoundedAbsoluteIntervalCreationError(BoundedAbsoluteIntervalCreationError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<BoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: BoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::BoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
-    /// let today = BoundedAbsoluteInterval::today(offset_tz).unwrap();
+    /// let today = BoundedAbsoluteInterval::today(offset_tz)?;
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn today<Tz>(tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
     where
@@ -2215,13 +2443,43 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{DateTime, Duration, Utc, FixedOffset};
-    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError};
     /// # use periodical::intervals::meta::BoundInclusivity;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     BoundedAbsoluteIntervalCreationError(BoundedAbsoluteIntervalCreationError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<BoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: BoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::BoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
-    /// let tomorrow = BoundedAbsoluteInterval::tomorrow(offset_tz).unwrap();
+    /// let tomorrow = BoundedAbsoluteInterval::tomorrow(offset_tz)?;
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn tomorrow<Tz>(tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
     where
@@ -2240,13 +2498,43 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{DateTime, Duration, Utc, FixedOffset};
-    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError};
     /// # use periodical::intervals::meta::BoundInclusivity;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     BoundedAbsoluteIntervalCreationError(BoundedAbsoluteIntervalCreationError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<BoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: BoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::BoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
-    /// let yesterday = BoundedAbsoluteInterval::yesterday(offset_tz).unwrap();
+    /// let yesterday = BoundedAbsoluteInterval::yesterday(offset_tz)?;
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn yesterday<Tz>(tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
     where
@@ -2276,21 +2564,67 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{DateTime, Duration, Utc, NaiveDate, FixedOffset};
-    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError};
     /// # use periodical::intervals::meta::BoundInclusivity;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct NaiveDateFromYmdError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     NaiveDateFromYmdError(NaiveDateFromYmdError),
+    /// #     BoundedAbsoluteIntervalCreationError(BoundedAbsoluteIntervalCreationError),
+    /// #     ParseError(chrono::format::ParseError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<NaiveDateFromYmdError> for ExampleError {
+    /// #     fn from(value: NaiveDateFromYmdError) -> Self {
+    /// #         ExampleError::NaiveDateFromYmdError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<BoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: BoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::BoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<chrono::format::ParseError> for ExampleError {
+    /// #     fn from(value: chrono::format::ParseError) -> Self {
+    /// #         ExampleError::ParseError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
-    /// let from = NaiveDate::from_ymd_opt(2026, 1, 5).unwrap();
-    /// let to = NaiveDate::from_ymd_opt(2026, 1, 10).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
+    /// let from = NaiveDate::from_ymd_opt(2026, 1, 5).ok_or(NaiveDateFromYmdError)?;
+    /// let to = NaiveDate::from_ymd_opt(2026, 1, 10).ok_or(NaiveDateFromYmdError)?;
     ///
-    /// let interval = BoundedAbsoluteInterval::from_inclusive_date_range(from, to, offset_tz).unwrap();
+    /// let interval = BoundedAbsoluteInterval::from_inclusive_date_range(from, to, offset_tz)?;
     ///
     /// assert_eq!(interval.from_time(), "2026-01-04 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(interval.from_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(interval.to_time(), "2026-01-10 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(interval.to_inclusivity(), BoundInclusivity::Exclusive);
-    /// # Ok::<(), chrono::format::ParseError>(())
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn from_inclusive_date_range<Tz>(
         mut from_date: NaiveDate,
@@ -2342,20 +2676,66 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{DateTime, Duration, FixedOffset, NaiveDate, Utc, Weekday};
-    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError};
     /// # use periodical::intervals::meta::BoundInclusivity;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct NaiveDateFromYmdError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     NaiveDateFromYmdError(NaiveDateFromYmdError),
+    /// #     BoundedAbsoluteIntervalCreationError(BoundedAbsoluteIntervalCreationError),
+    /// #     ParseError(chrono::format::ParseError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<NaiveDateFromYmdError> for ExampleError {
+    /// #     fn from(value: NaiveDateFromYmdError) -> Self {
+    /// #         ExampleError::NaiveDateFromYmdError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<BoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: BoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::BoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<chrono::format::ParseError> for ExampleError {
+    /// #     fn from(value: chrono::format::ParseError) -> Self {
+    /// #         ExampleError::ParseError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
-    /// let week = NaiveDate::from_ymd_opt(2026, 5, 1).unwrap().week(Weekday::Tue);
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
+    /// let week = NaiveDate::from_ymd_opt(2026, 5, 1).ok_or(NaiveDateFromYmdError)?.week(Weekday::Tue);
     ///
-    /// let week_interval = BoundedAbsoluteInterval::from_week(week, offset_tz).unwrap();
+    /// let week_interval = BoundedAbsoluteInterval::from_week(week, offset_tz)?;
     ///
     /// assert_eq!(week_interval.from_time(), "2026-04-27 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(week_interval.from_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(week_interval.to_time(), "2026-05-04 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(week_interval.to_inclusivity(), BoundInclusivity::Exclusive);
-    /// # Ok::<(), chrono::format::ParseError>(())
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn from_week<Tz>(week: NaiveWeek, tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
     where
@@ -2392,21 +2772,67 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{Datelike, DateTime, Duration, FixedOffset, NaiveDate, NaiveWeek, Utc, Weekday};
     /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError};
     /// # use periodical::intervals::meta::BoundInclusivity;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct NaiveDateFromYmdError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     NaiveDateFromYmdError(NaiveDateFromYmdError),
+    /// #     BoundedAbsoluteIntervalCreationError(BoundedAbsoluteIntervalCreationError),
+    /// #     ParseError(chrono::format::ParseError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<NaiveDateFromYmdError> for ExampleError {
+    /// #     fn from(value: NaiveDateFromYmdError) -> Self {
+    /// #         ExampleError::NaiveDateFromYmdError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<BoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: BoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::BoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<chrono::format::ParseError> for ExampleError {
+    /// #     fn from(value: chrono::format::ParseError) -> Self {
+    /// #         ExampleError::ParseError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
-    /// let from = NaiveDate::from_ymd_opt(2026, 1, 7).unwrap().week(Weekday::Mon);
-    /// let to = NaiveDate::from_ymd_opt(2026, 3, 17).unwrap().week(Weekday::Sat);
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
+    /// let from = NaiveDate::from_ymd_opt(2026, 1, 7).ok_or(NaiveDateFromYmdError)?.week(Weekday::Mon);
+    /// let to = NaiveDate::from_ymd_opt(2026, 3, 17).ok_or(NaiveDateFromYmdError)?.week(Weekday::Sat);
     ///
-    /// let interval = BoundedAbsoluteInterval::from_inclusive_week_range(from, to, offset_tz).unwrap();
+    /// let interval = BoundedAbsoluteInterval::from_inclusive_week_range(from, to, offset_tz)?;
     ///
     /// assert_eq!(interval.from_time(), "2026-01-04 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(interval.from_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(interval.to_time(), "2026-03-20 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(interval.to_inclusivity(), BoundInclusivity::Exclusive);
-    /// # Ok::<(), chrono::format::ParseError>(())
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn from_inclusive_week_range<Tz>(
         mut from: NaiveWeek,
@@ -2444,25 +2870,71 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{DateTime, Duration, FixedOffset, NaiveDate, Utc, Weekday};
-    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError};
     /// # use periodical::intervals::meta::BoundInclusivity;
     /// # use periodical::time::NaiveDuration;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct NaiveDateFromYmdError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     NaiveDateFromYmdError(NaiveDateFromYmdError),
+    /// #     BoundedAbsoluteIntervalCreationError(BoundedAbsoluteIntervalCreationError),
+    /// #     ParseError(chrono::format::ParseError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<NaiveDateFromYmdError> for ExampleError {
+    /// #     fn from(value: NaiveDateFromYmdError) -> Self {
+    /// #         ExampleError::NaiveDateFromYmdError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<BoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: BoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::BoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<chrono::format::ParseError> for ExampleError {
+    /// #     fn from(value: chrono::format::ParseError) -> Self {
+    /// #         ExampleError::ParseError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
     /// let week = BoundedAbsoluteInterval::week_after_naive_duration_from_naive_date(
-    ///     NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
+    ///     NaiveDate::from_ymd_opt(2026, 5, 1).ok_or(NaiveDateFromYmdError)?,
     ///     NaiveDuration::Weeks(Weekday::Mon, 2),
     ///     Weekday::Mon,
     ///     offset_tz,
-    /// ).unwrap();
+    /// )?;
     ///
     /// assert_eq!(week.from_time(), "2026-05-10 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(week.from_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(week.to_time(), "2026-05-17 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(week.to_inclusivity(), BoundInclusivity::Exclusive);
-    /// # Ok::<(), chrono::format::ParseError>(())
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn week_after_naive_duration_from_naive_date<Tz>(
         naive_date: NaiveDate,
@@ -2495,25 +2967,71 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{DateTime, Duration, FixedOffset, NaiveDate, Utc, Weekday};
-    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError};
     /// # use periodical::intervals::meta::BoundInclusivity;
     /// # use periodical::time::NaiveDuration;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct NaiveDateFromYmdError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     NaiveDateFromYmdError(NaiveDateFromYmdError),
+    /// #     BoundedAbsoluteIntervalCreationError(BoundedAbsoluteIntervalCreationError),
+    /// #     ParseError(chrono::format::ParseError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<NaiveDateFromYmdError> for ExampleError {
+    /// #     fn from(value: NaiveDateFromYmdError) -> Self {
+    /// #         ExampleError::NaiveDateFromYmdError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<BoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: BoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::BoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<chrono::format::ParseError> for ExampleError {
+    /// #     fn from(value: chrono::format::ParseError) -> Self {
+    /// #         ExampleError::ParseError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
     /// let week = BoundedAbsoluteInterval::week_before_naive_duration_from_naive_date(
-    ///     NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
+    ///     NaiveDate::from_ymd_opt(2026, 5, 1).ok_or(NaiveDateFromYmdError)?,
     ///     NaiveDuration::Weeks(Weekday::Mon, 2),
     ///     Weekday::Mon,
     ///     offset_tz,
-    /// ).unwrap();
+    /// )?;
     ///
     /// assert_eq!(week.from_time(), "2026-04-12 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(week.from_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(week.to_time(), "2026-04-19 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(week.to_inclusivity(), BoundInclusivity::Exclusive);
-    /// # Ok::<(), chrono::format::ParseError>(())
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn week_before_naive_duration_from_naive_date<Tz>(
         naive_date: NaiveDate,
@@ -2542,17 +3060,47 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{Duration, FixedOffset, Weekday};
-    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError};
     /// # use periodical::time::NaiveDuration;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     BoundedAbsoluteIntervalCreationError(BoundedAbsoluteIntervalCreationError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<BoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: BoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::BoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
     /// let week = BoundedAbsoluteInterval::week_after_naive_duration_from_today(
     ///     NaiveDuration::Months(2),
     ///     Weekday::Mon,
     ///     offset_tz,
-    /// ).unwrap();
+    /// )?;
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn week_after_naive_duration_from_today<Tz>(
         naive_duration: NaiveDuration,
@@ -2576,17 +3124,47 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{Duration, FixedOffset, Weekday};
-    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError};
     /// # use periodical::time::NaiveDuration;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     BoundedAbsoluteIntervalCreationError(BoundedAbsoluteIntervalCreationError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<BoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: BoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::BoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
     /// let week = BoundedAbsoluteInterval::week_before_naive_duration_from_today(
     ///     NaiveDuration::Months(2),
     ///     Weekday::Mon,
     ///     offset_tz,
-    /// ).unwrap();
+    /// )?;
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn week_before_naive_duration_from_today<Tz>(
         naive_duration: NaiveDuration,
@@ -2621,15 +3199,45 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{Duration, FixedOffset, Weekday};
-    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError};
     /// # use periodical::intervals::meta::BoundInclusivity;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     BoundedAbsoluteIntervalCreationError(BoundedAbsoluteIntervalCreationError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<BoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: BoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::BoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     /// let this_week = BoundedAbsoluteInterval::this_week(
     ///     Weekday::Mon,
     ///     offset_tz,
-    /// );
+    /// )?;
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn this_week<Tz>(week_start: Weekday, tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
     where
@@ -2664,15 +3272,45 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{Duration, FixedOffset, Weekday};
-    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError};
     /// # use periodical::intervals::meta::BoundInclusivity;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     BoundedAbsoluteIntervalCreationError(BoundedAbsoluteIntervalCreationError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<BoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: BoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::BoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     /// let next_week = BoundedAbsoluteInterval::next_week(
     ///     Weekday::Mon,
     ///     offset_tz,
-    /// );
+    /// )?;
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn next_week<Tz>(week_start: Weekday, tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
     where
@@ -2697,15 +3335,45 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{Duration, FixedOffset, Weekday};
-    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError};
     /// # use periodical::intervals::meta::BoundInclusivity;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     BoundedAbsoluteIntervalCreationError(BoundedAbsoluteIntervalCreationError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<BoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: BoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::BoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     /// let previous_week = BoundedAbsoluteInterval::previous_week(
     ///     Weekday::Mon,
     ///     offset_tz,
-    /// );
+    /// )?;
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn previous_week<Tz>(week_start: Weekday, tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
     where
@@ -2727,20 +3395,66 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{Datelike, DateTime, Duration, FixedOffset, NaiveDate, Utc, Weekday};
-    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError};
     /// # use periodical::intervals::meta::BoundInclusivity;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct NaiveDateFromYmdError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     NaiveDateFromYmdError(NaiveDateFromYmdError),
+    /// #     BoundedAbsoluteIntervalCreationError(BoundedAbsoluteIntervalCreationError),
+    /// #     ParseError(chrono::format::ParseError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<NaiveDateFromYmdError> for ExampleError {
+    /// #     fn from(value: NaiveDateFromYmdError) -> Self {
+    /// #         ExampleError::NaiveDateFromYmdError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<BoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: BoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::BoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<chrono::format::ParseError> for ExampleError {
+    /// #     fn from(value: chrono::format::ParseError) -> Self {
+    /// #         ExampleError::ParseError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
-    /// let iso_week = NaiveDate::from_ymd_opt(2026, 5, 1).unwrap().iso_week();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
+    /// let iso_week = NaiveDate::from_ymd_opt(2026, 5, 1).ok_or(NaiveDateFromYmdError)?.iso_week();
     ///
-    /// let iso_week_interval = BoundedAbsoluteInterval::from_iso_week(iso_week, offset_tz).unwrap();
+    /// let iso_week_interval = BoundedAbsoluteInterval::from_iso_week(iso_week, offset_tz)?;
     ///
     /// assert_eq!(iso_week_interval.from_time(), "2026-04-26 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(iso_week_interval.from_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(iso_week_interval.to_time(), "2026-05-03 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(iso_week_interval.to_inclusivity(), BoundInclusivity::Exclusive);
-    /// # Ok::<(), chrono::format::ParseError>(())
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn from_iso_week<Tz>(iso_week: IsoWeek, tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
     where
@@ -2773,23 +3487,69 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{Datelike, DateTime, Duration, FixedOffset, NaiveDate, Utc};
-    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError};
     /// # use periodical::intervals::meta::BoundInclusivity;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct NaiveDateFromYmdError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     NaiveDateFromYmdError(NaiveDateFromYmdError),
+    /// #     BoundedAbsoluteIntervalCreationError(BoundedAbsoluteIntervalCreationError),
+    /// #     ParseError(chrono::format::ParseError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<NaiveDateFromYmdError> for ExampleError {
+    /// #     fn from(value: NaiveDateFromYmdError) -> Self {
+    /// #         ExampleError::NaiveDateFromYmdError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<BoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: BoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::BoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<chrono::format::ParseError> for ExampleError {
+    /// #     fn from(value: chrono::format::ParseError) -> Self {
+    /// #         ExampleError::ParseError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
     /// // Currently chrono has no public constructor for IsoWeek yet
-    /// let from = NaiveDate::from_ymd_opt(2026, 1, 7).unwrap().iso_week();
-    /// let to = NaiveDate::from_ymd_opt(2026, 3, 17).unwrap().iso_week();
+    /// let from = NaiveDate::from_ymd_opt(2026, 1, 7).ok_or(NaiveDateFromYmdError)?.iso_week();
+    /// let to = NaiveDate::from_ymd_opt(2026, 3, 17).ok_or(NaiveDateFromYmdError)?.iso_week();
     ///
-    /// let interval = BoundedAbsoluteInterval::from_inclusive_iso_week_range(from, to, offset_tz).unwrap();
+    /// let interval = BoundedAbsoluteInterval::from_inclusive_iso_week_range(from, to, offset_tz)?;
     ///
     /// assert_eq!(interval.from_time(), "2026-01-04 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(interval.from_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(interval.to_time(), "2026-03-22 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(interval.to_inclusivity(), BoundInclusivity::Exclusive);
-    /// # Ok::<(), chrono::format::ParseError>(())
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn from_inclusive_iso_week_range<Tz>(
         mut from: IsoWeek,
@@ -2835,19 +3595,55 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{DateTime, Duration, FixedOffset, Utc, Weekday};
-    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError};
     /// # use periodical::intervals::meta::BoundInclusivity;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     BoundedAbsoluteIntervalCreationError(BoundedAbsoluteIntervalCreationError),
+    /// #     ParseError(chrono::format::ParseError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<BoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: BoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::BoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<chrono::format::ParseError> for ExampleError {
+    /// #     fn from(value: chrono::format::ParseError) -> Self {
+    /// #         ExampleError::ParseError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
-    /// let iso_week = BoundedAbsoluteInterval::week_from_iso_year_week(2026, 5, offset_tz).unwrap();
+    /// let iso_week = BoundedAbsoluteInterval::week_from_iso_year_week(2026, 5, offset_tz)?;
     ///
     /// assert_eq!(iso_week.from_time(), "2026-01-25 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(iso_week.from_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(iso_week.to_time(), "2026-02-01 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(iso_week.to_inclusivity(), BoundInclusivity::Exclusive);
-    /// # Ok::<(), chrono::format::ParseError>(())
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn week_from_iso_year_week<Tz>(
         year: i32,
@@ -2883,24 +3679,70 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{DateTime, Duration, FixedOffset, NaiveDate, Utc, Weekday};
-    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError};
     /// # use periodical::intervals::meta::BoundInclusivity;
     /// # use periodical::time::NaiveDuration;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct NaiveDateFromYmdError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     NaiveDateFromYmdError(NaiveDateFromYmdError),
+    /// #     BoundedAbsoluteIntervalCreationError(BoundedAbsoluteIntervalCreationError),
+    /// #     ParseError(chrono::format::ParseError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<NaiveDateFromYmdError> for ExampleError {
+    /// #     fn from(value: NaiveDateFromYmdError) -> Self {
+    /// #         ExampleError::NaiveDateFromYmdError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<BoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: BoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::BoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<chrono::format::ParseError> for ExampleError {
+    /// #     fn from(value: chrono::format::ParseError) -> Self {
+    /// #         ExampleError::ParseError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
     /// let week = BoundedAbsoluteInterval::iso_week_after_naive_duration_from_naive_date(
-    ///     NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
+    ///     NaiveDate::from_ymd_opt(2026, 5, 1).ok_or(NaiveDateFromYmdError)?,
     ///     NaiveDuration::IsoWeeks(2),
     ///     offset_tz,
-    /// ).unwrap();
+    /// )?;
     ///
     /// assert_eq!(week.from_time(), "2026-05-10 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(week.from_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(week.to_time(), "2026-05-17 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(week.to_inclusivity(), BoundInclusivity::Exclusive);
-    /// # Ok::<(), chrono::format::ParseError>(())
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn iso_week_after_naive_duration_from_naive_date<Tz>(
         naive_date: NaiveDate,
@@ -2924,24 +3766,70 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{DateTime, Duration, FixedOffset, NaiveDate, Utc, Weekday};
-    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError};
     /// # use periodical::intervals::meta::BoundInclusivity;
     /// # use periodical::time::NaiveDuration;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct NaiveDateFromYmdError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     NaiveDateFromYmdError(NaiveDateFromYmdError),
+    /// #     BoundedAbsoluteIntervalCreationError(BoundedAbsoluteIntervalCreationError),
+    /// #     ParseError(chrono::format::ParseError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<NaiveDateFromYmdError> for ExampleError {
+    /// #     fn from(value: NaiveDateFromYmdError) -> Self {
+    /// #         ExampleError::NaiveDateFromYmdError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<BoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: BoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::BoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<chrono::format::ParseError> for ExampleError {
+    /// #     fn from(value: chrono::format::ParseError) -> Self {
+    /// #         ExampleError::ParseError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
     /// let week = BoundedAbsoluteInterval::iso_week_before_naive_duration_from_naive_date(
-    ///     NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
+    ///     NaiveDate::from_ymd_opt(2026, 5, 1).ok_or(NaiveDateFromYmdError)?,
     ///     NaiveDuration::IsoWeeks(2),
     ///     offset_tz,
-    /// ).unwrap();
+    /// )?;
     ///
     /// assert_eq!(week.from_time(), "2026-04-12 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(week.from_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(week.to_time(), "2026-04-19 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(week.to_inclusivity(), BoundInclusivity::Exclusive);
-    /// # Ok::<(), chrono::format::ParseError>(())
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn iso_week_before_naive_duration_from_naive_date<Tz>(
         naive_date: NaiveDate,
@@ -2965,16 +3853,46 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{Duration, FixedOffset, Weekday};
-    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError};
     /// # use periodical::time::NaiveDuration;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     BoundedAbsoluteIntervalCreationError(BoundedAbsoluteIntervalCreationError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<BoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: BoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::BoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
     /// let iso_week = BoundedAbsoluteInterval::iso_week_after_naive_duration_from_today(
     ///     NaiveDuration::Months(2),
     ///     offset_tz,
-    /// );
+    /// )?;
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn iso_week_after_naive_duration_from_today<Tz>(
         naive_duration: NaiveDuration,
@@ -2997,16 +3915,46 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{Duration, FixedOffset, Weekday};
-    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError};
     /// # use periodical::time::NaiveDuration;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     BoundedAbsoluteIntervalCreationError(BoundedAbsoluteIntervalCreationError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<BoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: BoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::BoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
     /// let iso_week = BoundedAbsoluteInterval::iso_week_before_naive_duration_from_today(
     ///     NaiveDuration::Months(2),
     ///     offset_tz,
-    /// );
+    /// )?;
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn iso_week_before_naive_duration_from_today<Tz>(
         naive_duration: NaiveDuration,
@@ -3031,12 +3979,42 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{Duration, FixedOffset};
-    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError};
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     BoundedAbsoluteIntervalCreationError(BoundedAbsoluteIntervalCreationError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<BoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: BoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::BoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
-    /// let iso_week = BoundedAbsoluteInterval::this_iso_week(offset_tz).unwrap();
+    /// let iso_week = BoundedAbsoluteInterval::this_iso_week(offset_tz)?;
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn this_iso_week<Tz>(tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
     where
@@ -3061,12 +4039,42 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{Duration, FixedOffset};
-    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError};
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     BoundedAbsoluteIntervalCreationError(BoundedAbsoluteIntervalCreationError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<BoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: BoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::BoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
-    /// let iso_week = BoundedAbsoluteInterval::next_iso_week(offset_tz).unwrap();
+    /// let iso_week = BoundedAbsoluteInterval::next_iso_week(offset_tz)?;
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn next_iso_week<Tz>(tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
     where
@@ -3085,12 +4093,42 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{Duration, FixedOffset};
-    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError};
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     BoundedAbsoluteIntervalCreationError(BoundedAbsoluteIntervalCreationError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<BoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: BoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::BoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
-    /// let iso_week = BoundedAbsoluteInterval::previous_iso_week(offset_tz).unwrap();
+    /// let iso_week = BoundedAbsoluteInterval::previous_iso_week(offset_tz)?;
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn previous_iso_week<Tz>(tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
     where
@@ -3115,23 +4153,59 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{DateTime, Duration, FixedOffset, Month, Utc};
-    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError};
     /// # use periodical::intervals::meta::BoundInclusivity;
     /// # use periodical::time::NaiveMonth;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     BoundedAbsoluteIntervalCreationError(BoundedAbsoluteIntervalCreationError),
+    /// #     ParseError(chrono::format::ParseError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<BoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: BoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::BoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
+    /// # 
+    /// # impl From<chrono::format::ParseError> for ExampleError {
+    /// #     fn from(value: chrono::format::ParseError) -> Self {
+    /// #         ExampleError::ParseError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
     /// let month = BoundedAbsoluteInterval::from_month(
     ///     NaiveMonth::new(2026, Month::May),
     ///     offset_tz,
-    /// ).unwrap();
+    /// )?;
     ///
     /// assert_eq!(month.from_time(), "2026-04-30 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(month.from_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(month.to_time(), "2026-05-31 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(month.to_inclusivity(), BoundInclusivity::Exclusive);
-    /// # Ok::<(), chrono::format::ParseError>(())
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn from_month<Tz>(month: NaiveMonth, tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
     where
@@ -3167,24 +4241,60 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{DateTime, Duration, FixedOffset, Month, Utc};
-    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError};
     /// # use periodical::intervals::meta::BoundInclusivity;
     /// # use periodical::time::NaiveMonth;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     BoundedAbsoluteIntervalCreationError(BoundedAbsoluteIntervalCreationError),
+    /// #     ParseError(chrono::format::ParseError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<BoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: BoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::BoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
+    /// # 
+    /// # impl From<chrono::format::ParseError> for ExampleError {
+    /// #     fn from(value: chrono::format::ParseError) -> Self {
+    /// #         ExampleError::ParseError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
     /// let interval = BoundedAbsoluteInterval::from_inclusive_month_range(
     ///     NaiveMonth::new(2026, Month::January),
     ///     NaiveMonth::new(2026, Month::May),
     ///     offset_tz,
-    /// ).unwrap();
+    /// )?;
     ///
     /// assert_eq!(interval.from_time(), "2025-12-31 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(interval.from_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(interval.to_time(), "2026-05-31 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(interval.to_inclusivity(), BoundInclusivity::Exclusive);
-    /// # Ok::<(), chrono::format::ParseError>(())
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn from_inclusive_month_range<Tz>(
         mut from: NaiveMonth,
@@ -3222,24 +4332,70 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{DateTime, Duration, FixedOffset, NaiveDate, Utc};
-    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError};
     /// # use periodical::intervals::meta::BoundInclusivity;
     /// # use periodical::time::NaiveDuration;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct NaiveDateFromYmdError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     NaiveDateFromYmdError(NaiveDateFromYmdError),
+    /// #     BoundedAbsoluteIntervalCreationError(BoundedAbsoluteIntervalCreationError),
+    /// #     ParseError(chrono::format::ParseError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<NaiveDateFromYmdError> for ExampleError {
+    /// #     fn from(value: NaiveDateFromYmdError) -> Self {
+    /// #         ExampleError::NaiveDateFromYmdError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<BoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: BoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::BoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<chrono::format::ParseError> for ExampleError {
+    /// #     fn from(value: chrono::format::ParseError) -> Self {
+    /// #         ExampleError::ParseError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
     /// let month = BoundedAbsoluteInterval::month_after_naive_duration_from_naive_date(
-    ///     NaiveDate::from_ymd_opt(2026, 5, 5).unwrap(),
+    ///     NaiveDate::from_ymd_opt(2026, 5, 5).ok_or(NaiveDateFromYmdError)?,
     ///     NaiveDuration::Months(2),
     ///     offset_tz,
-    /// ).unwrap();
+    /// )?;
     ///
     /// assert_eq!(month.from_time(), "2026-06-30 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(month.from_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(month.to_time(), "2026-07-31 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(month.to_inclusivity(), BoundInclusivity::Exclusive);
-    /// # Ok::<(), chrono::format::ParseError>(())
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn month_after_naive_duration_from_naive_date<Tz>(
         naive_date: NaiveDate,
@@ -3273,24 +4429,70 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{DateTime, Duration, FixedOffset, NaiveDate, Utc};
-    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError};
     /// # use periodical::intervals::meta::BoundInclusivity;
     /// # use periodical::time::NaiveDuration;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct NaiveDateFromYmdError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     NaiveDateFromYmdError(NaiveDateFromYmdError),
+    /// #     BoundedAbsoluteIntervalCreationError(BoundedAbsoluteIntervalCreationError),
+    /// #     ParseError(chrono::format::ParseError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<NaiveDateFromYmdError> for ExampleError {
+    /// #     fn from(value: NaiveDateFromYmdError) -> Self {
+    /// #         ExampleError::NaiveDateFromYmdError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<BoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: BoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::BoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<chrono::format::ParseError> for ExampleError {
+    /// #     fn from(value: chrono::format::ParseError) -> Self {
+    /// #         ExampleError::ParseError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
     /// let month = BoundedAbsoluteInterval::month_before_naive_duration_from_naive_date(
-    ///     NaiveDate::from_ymd_opt(2026, 5, 5).unwrap(),
+    ///     NaiveDate::from_ymd_opt(2026, 5, 5).ok_or(NaiveDateFromYmdError)?,
     ///     NaiveDuration::Months(2),
     ///     offset_tz,
-    /// ).unwrap();
+    /// )?;
     ///
     /// assert_eq!(month.from_time(), "2026-02-28 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(month.from_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(month.to_time(), "2026-03-31 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(month.to_inclusivity(), BoundInclusivity::Exclusive);
-    /// # Ok::<(), chrono::format::ParseError>(())
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn month_before_naive_duration_from_naive_date<Tz>(
         naive_date: NaiveDate,
@@ -3320,16 +4522,46 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{Duration, FixedOffset};
-    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError};
     /// # use periodical::time::NaiveDuration;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     BoundedAbsoluteIntervalCreationError(BoundedAbsoluteIntervalCreationError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<BoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: BoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::BoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
     /// let month = BoundedAbsoluteInterval::month_after_naive_duration_from_today(
     ///     NaiveDuration::Months(2),
     ///     offset_tz,
-    /// ).unwrap();
+    /// )?;
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn month_after_naive_duration_from_today<Tz>(
         naive_duration: NaiveDuration,
@@ -3352,16 +4584,46 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{Duration, FixedOffset};
-    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError};
     /// # use periodical::time::NaiveDuration;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     BoundedAbsoluteIntervalCreationError(BoundedAbsoluteIntervalCreationError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<BoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: BoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::BoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
     /// let month = BoundedAbsoluteInterval::month_before_naive_duration_from_today(
     ///     NaiveDuration::Months(2),
     ///     offset_tz,
-    /// ).unwrap();
+    /// )?;
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn month_before_naive_duration_from_today<Tz>(
         naive_duration: NaiveDuration,
@@ -3386,12 +4648,42 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{Duration, FixedOffset};
-    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError};
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     BoundedAbsoluteIntervalCreationError(BoundedAbsoluteIntervalCreationError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<BoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: BoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::BoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
-    /// let month = BoundedAbsoluteInterval::this_month(offset_tz);
+    /// let month = BoundedAbsoluteInterval::this_month(offset_tz)?;
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn this_month<Tz>(tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
     where
@@ -3414,12 +4706,42 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{Duration, FixedOffset};
-    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError};
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     BoundedAbsoluteIntervalCreationError(BoundedAbsoluteIntervalCreationError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<BoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: BoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::BoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
-    /// let month = BoundedAbsoluteInterval::next_month(offset_tz);
+    /// let month = BoundedAbsoluteInterval::next_month(offset_tz)?;
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn next_month<Tz>(tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
     where
@@ -3438,12 +4760,42 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{Duration, FixedOffset};
-    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError};
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     BoundedAbsoluteIntervalCreationError(BoundedAbsoluteIntervalCreationError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<BoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: BoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::BoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
-    /// let month = BoundedAbsoluteInterval::previous_month(offset_tz);
+    /// let month = BoundedAbsoluteInterval::previous_month(offset_tz)?;
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn previous_month<Tz>(tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
     where
@@ -3468,19 +4820,55 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{DateTime, Duration, FixedOffset, Utc};
-    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError};
     /// # use periodical::intervals::meta::BoundInclusivity;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     BoundedAbsoluteIntervalCreationError(BoundedAbsoluteIntervalCreationError),
+    /// #     ParseError(chrono::format::ParseError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<BoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: BoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::BoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<chrono::format::ParseError> for ExampleError {
+    /// #     fn from(value: chrono::format::ParseError) -> Self {
+    /// #         ExampleError::ParseError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
-    /// let year = BoundedAbsoluteInterval::from_year(2026, offset_tz).unwrap();
+    /// let year = BoundedAbsoluteInterval::from_year(2026, offset_tz)?;
     ///
     /// assert_eq!(year.from_time(), "2025-12-31 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(year.from_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(year.to_time(), "2026-12-31 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(year.to_inclusivity(), BoundInclusivity::Exclusive);
-    /// # Ok::<(), chrono::format::ParseError>(())
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn from_year<Tz>(year: i32, tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
     where
@@ -3524,19 +4912,55 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{DateTime, Duration, FixedOffset, Utc};
-    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError};
     /// # use periodical::intervals::meta::BoundInclusivity;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     BoundedAbsoluteIntervalCreationError(BoundedAbsoluteIntervalCreationError),
+    /// #     ParseError(chrono::format::ParseError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<BoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: BoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::BoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<chrono::format::ParseError> for ExampleError {
+    /// #     fn from(value: chrono::format::ParseError) -> Self {
+    /// #         ExampleError::ParseError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
-    /// let years = BoundedAbsoluteInterval::from_inclusive_year_range(2025, 2030, offset_tz).unwrap();
+    /// let years = BoundedAbsoluteInterval::from_inclusive_year_range(2025, 2030, offset_tz)?;
     ///
     /// assert_eq!(years.from_time(), "2024-12-31 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(years.from_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(years.to_time(), "2030-12-31 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(years.to_inclusivity(), BoundInclusivity::Exclusive);
-    /// # Ok::<(), chrono::format::ParseError>(())
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn from_inclusive_year_range<Tz>(
         mut from_year: i32,
@@ -3584,24 +5008,70 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{DateTime, Duration, FixedOffset, NaiveDate, Utc};
-    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError};
     /// # use periodical::intervals::meta::BoundInclusivity;
     /// # use periodical::time::NaiveDuration;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct NaiveDateFromYmdError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     NaiveDateFromYmdError(NaiveDateFromYmdError),
+    /// #     BoundedAbsoluteIntervalCreationError(BoundedAbsoluteIntervalCreationError),
+    /// #     ParseError(chrono::format::ParseError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<NaiveDateFromYmdError> for ExampleError {
+    /// #     fn from(value: NaiveDateFromYmdError) -> Self {
+    /// #         ExampleError::NaiveDateFromYmdError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<BoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: BoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::BoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<chrono::format::ParseError> for ExampleError {
+    /// #     fn from(value: chrono::format::ParseError) -> Self {
+    /// #         ExampleError::ParseError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
     /// let year = BoundedAbsoluteInterval::year_after_naive_duration_from_naive_date(
-    ///     NaiveDate::from_ymd_opt(2026, 5, 5).unwrap(),
+    ///     NaiveDate::from_ymd_opt(2026, 5, 5).ok_or(NaiveDateFromYmdError)?,
     ///     NaiveDuration::Months(15),
     ///     offset_tz,
-    /// ).unwrap();
+    /// )?;
     ///
     /// assert_eq!(year.from_time(), "2026-12-31 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(year.from_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(year.to_time(), "2027-12-31 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(year.to_inclusivity(), BoundInclusivity::Exclusive);
-    /// # Ok::<(), chrono::format::ParseError>(())
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn year_after_naive_duration_from_naive_date<Tz>(
         naive_date: NaiveDate,
@@ -3634,24 +5104,70 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{DateTime, Duration, FixedOffset, NaiveDate, Utc};
-    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError};
     /// # use periodical::intervals::meta::BoundInclusivity;
     /// # use periodical::time::NaiveDuration;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct NaiveDateFromYmdError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     NaiveDateFromYmdError(NaiveDateFromYmdError),
+    /// #     BoundedAbsoluteIntervalCreationError(BoundedAbsoluteIntervalCreationError),
+    /// #     ParseError(chrono::format::ParseError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<NaiveDateFromYmdError> for ExampleError {
+    /// #     fn from(value: NaiveDateFromYmdError) -> Self {
+    /// #         ExampleError::NaiveDateFromYmdError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<BoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: BoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::BoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<chrono::format::ParseError> for ExampleError {
+    /// #     fn from(value: chrono::format::ParseError) -> Self {
+    /// #         ExampleError::ParseError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
     /// let year = BoundedAbsoluteInterval::year_before_naive_duration_from_naive_date(
-    ///     NaiveDate::from_ymd_opt(2026, 5, 5).unwrap(),
+    ///     NaiveDate::from_ymd_opt(2026, 5, 5).ok_or(NaiveDateFromYmdError)?,
     ///     NaiveDuration::Months(15),
     ///     offset_tz,
-    /// ).unwrap();
+    /// )?;
     ///
     /// assert_eq!(year.from_time(), "2024-12-31 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(year.from_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(year.to_time(), "2025-12-31 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(year.to_inclusivity(), BoundInclusivity::Exclusive);
-    /// # Ok::<(), chrono::format::ParseError>(())
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn year_before_naive_duration_from_naive_date<Tz>(
         naive_date: NaiveDate,
@@ -3680,16 +5196,46 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{Duration, FixedOffset};
-    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError};
     /// # use periodical::time::NaiveDuration;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     BoundedAbsoluteIntervalCreationError(BoundedAbsoluteIntervalCreationError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<BoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: BoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::BoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
     /// let year = BoundedAbsoluteInterval::year_after_naive_duration_from_today(
     ///     NaiveDuration::Months(15),
     ///     offset_tz,
-    /// ).unwrap();
+    /// )?;
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn year_after_naive_duration_from_today<Tz>(
         naive_duration: NaiveDuration,
@@ -3712,16 +5258,46 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{Duration, FixedOffset};
-    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError};
     /// # use periodical::time::NaiveDuration;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     BoundedAbsoluteIntervalCreationError(BoundedAbsoluteIntervalCreationError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<BoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: BoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::BoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
     /// let year = BoundedAbsoluteInterval::year_before_naive_duration_from_today(
     ///     NaiveDuration::Months(15),
     ///     offset_tz,
-    /// ).unwrap();
+    /// )?;
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn year_before_naive_duration_from_today<Tz>(
         naive_duration: NaiveDuration,
@@ -3742,12 +5318,42 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{Duration, FixedOffset};
-    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError};
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     BoundedAbsoluteIntervalCreationError(BoundedAbsoluteIntervalCreationError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<BoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: BoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::BoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
-    /// let year = BoundedAbsoluteInterval::this_year(offset_tz);
+    /// let year = BoundedAbsoluteInterval::this_year(offset_tz)?;
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn this_year<Tz>(tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
     where
@@ -3765,12 +5371,42 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{Duration, FixedOffset};
-    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError};
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     BoundedAbsoluteIntervalCreationError(BoundedAbsoluteIntervalCreationError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<BoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: BoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::BoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
-    /// let year = BoundedAbsoluteInterval::next_year(offset_tz);
+    /// let year = BoundedAbsoluteInterval::next_year(offset_tz)?;
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn next_year<Tz>(tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
     where
@@ -3788,12 +5424,42 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{Duration, FixedOffset};
-    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError};
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     BoundedAbsoluteIntervalCreationError(BoundedAbsoluteIntervalCreationError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<BoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: BoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::BoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
-    /// let year = BoundedAbsoluteInterval::previous_year(offset_tz);
+    /// let year = BoundedAbsoluteInterval::previous_year(offset_tz)?;
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn previous_year<Tz>(tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
     where
@@ -4444,21 +6110,67 @@ impl HalfBoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{DateTime, Duration, FixedOffset, NaiveDate, Utc};
-    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{HalfBoundedAbsoluteInterval, HalfBoundedAbsoluteIntervalCreationError};
     /// # use periodical::intervals::meta::{BoundInclusivity, OpeningDirection};
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct NaiveDateFromYmdError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     NaiveDateFromYmdError(NaiveDateFromYmdError),
+    /// #     HalfBoundedAbsoluteIntervalCreationError(HalfBoundedAbsoluteIntervalCreationError),
+    /// #     ParseError(chrono::format::ParseError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<NaiveDateFromYmdError> for ExampleError {
+    /// #     fn from(value: NaiveDateFromYmdError) -> Self {
+    /// #         ExampleError::NaiveDateFromYmdError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<HalfBoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: HalfBoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::HalfBoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<chrono::format::ParseError> for ExampleError {
+    /// #     fn from(value: chrono::format::ParseError) -> Self {
+    /// #         ExampleError::ParseError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
     /// let from_first_of_may = HalfBoundedAbsoluteInterval::since_date(
-    ///     NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
+    ///     NaiveDate::from_ymd_opt(2026, 5, 1).ok_or(NaiveDateFromYmdError)?,
     ///     offset_tz,
-    /// ).unwrap();
+    /// )?;
     ///
     /// assert_eq!(from_first_of_may.reference_time(), "2026-04-30 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(from_first_of_may.reference_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(from_first_of_may.opening_direction(), OpeningDirection::ToFuture);
-    /// # Ok::<(), chrono::format::ParseError>(())
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn since_date<Tz>(naive_date: NaiveDate, tz: Tz) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError>
     where
@@ -4488,21 +6200,67 @@ impl HalfBoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{DateTime, Duration, FixedOffset, NaiveDate, Utc};
-    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{HalfBoundedAbsoluteInterval, HalfBoundedAbsoluteIntervalCreationError};
     /// # use periodical::intervals::meta::{BoundInclusivity, OpeningDirection};
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct NaiveDateFromYmdError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     NaiveDateFromYmdError(NaiveDateFromYmdError),
+    /// #     HalfBoundedAbsoluteIntervalCreationError(HalfBoundedAbsoluteIntervalCreationError),
+    /// #     ParseError(chrono::format::ParseError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<NaiveDateFromYmdError> for ExampleError {
+    /// #     fn from(value: NaiveDateFromYmdError) -> Self {
+    /// #         ExampleError::NaiveDateFromYmdError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<HalfBoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: HalfBoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::HalfBoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<chrono::format::ParseError> for ExampleError {
+    /// #     fn from(value: chrono::format::ParseError) -> Self {
+    /// #         ExampleError::ParseError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
     /// let until_first_of_may = HalfBoundedAbsoluteInterval::until_date(
-    ///     NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
+    ///     NaiveDate::from_ymd_opt(2026, 5, 1).ok_or(NaiveDateFromYmdError)?,
     ///     offset_tz,
-    /// ).unwrap();
+    /// )?;
     ///
     /// assert_eq!(until_first_of_may.reference_time(), "2026-04-30 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(until_first_of_may.reference_inclusivity(), BoundInclusivity::Exclusive);
     /// assert_eq!(until_first_of_may.opening_direction(), OpeningDirection::ToPast);
-    /// # Ok::<(), chrono::format::ParseError>(())
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn until_date<Tz>(naive_date: NaiveDate, tz: Tz) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError>
     where
@@ -4533,12 +6291,42 @@ impl HalfBoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{Duration, FixedOffset};
-    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{HalfBoundedAbsoluteInterval, HalfBoundedAbsoluteIntervalCreationError};
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     HalfBoundedAbsoluteIntervalCreationError(HalfBoundedAbsoluteIntervalCreationError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<HalfBoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: HalfBoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::HalfBoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
-    /// let since_today = HalfBoundedAbsoluteInterval::since_today(offset_tz).unwrap();
+    /// let since_today = HalfBoundedAbsoluteInterval::since_today(offset_tz)?;
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn since_today<Tz>(tz: Tz) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError>
     where
@@ -4558,12 +6346,42 @@ impl HalfBoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{Duration, FixedOffset};
-    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{HalfBoundedAbsoluteInterval, HalfBoundedAbsoluteIntervalCreationError};
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     HalfBoundedAbsoluteIntervalCreationError(HalfBoundedAbsoluteIntervalCreationError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<HalfBoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: HalfBoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::HalfBoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
-    /// let until_today = HalfBoundedAbsoluteInterval::until_today(offset_tz).unwrap();
+    /// let until_today = HalfBoundedAbsoluteInterval::until_today(offset_tz)?;
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn until_today<Tz>(tz: Tz) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError>
     where
@@ -4587,12 +6405,42 @@ impl HalfBoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{Duration, FixedOffset};
-    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{HalfBoundedAbsoluteInterval, HalfBoundedAbsoluteIntervalCreationError};
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     HalfBoundedAbsoluteIntervalCreationError(HalfBoundedAbsoluteIntervalCreationError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<HalfBoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: HalfBoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::HalfBoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
-    /// let since_tomorrow = HalfBoundedAbsoluteInterval::since_tomorrow(offset_tz).unwrap();
+    /// let since_tomorrow = HalfBoundedAbsoluteInterval::since_tomorrow(offset_tz)?;
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn since_tomorrow<Tz>(tz: Tz) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError>
     where
@@ -4620,12 +6468,42 @@ impl HalfBoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{Duration, FixedOffset};
-    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{HalfBoundedAbsoluteInterval, HalfBoundedAbsoluteIntervalCreationError};
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     HalfBoundedAbsoluteIntervalCreationError(HalfBoundedAbsoluteIntervalCreationError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<HalfBoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: HalfBoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::HalfBoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
-    /// let until_tomorrow = HalfBoundedAbsoluteInterval::until_tomorrow(offset_tz).unwrap();
+    /// let until_tomorrow = HalfBoundedAbsoluteInterval::until_tomorrow(offset_tz)?;
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn until_tomorrow<Tz>(tz: Tz) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError>
     where
@@ -4653,12 +6531,42 @@ impl HalfBoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{Duration, FixedOffset};
-    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{HalfBoundedAbsoluteInterval, HalfBoundedAbsoluteIntervalCreationError};
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     HalfBoundedAbsoluteIntervalCreationError(HalfBoundedAbsoluteIntervalCreationError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<HalfBoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: HalfBoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::HalfBoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
-    /// let since_yesterday = HalfBoundedAbsoluteInterval::since_yesterday(offset_tz).unwrap();
+    /// let since_yesterday = HalfBoundedAbsoluteInterval::since_yesterday(offset_tz)?;
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn since_yesterday<Tz>(tz: Tz) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError>
     where
@@ -4686,12 +6594,42 @@ impl HalfBoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{Duration, FixedOffset};
-    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{HalfBoundedAbsoluteInterval, HalfBoundedAbsoluteIntervalCreationError};
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     HalfBoundedAbsoluteIntervalCreationError(HalfBoundedAbsoluteIntervalCreationError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<HalfBoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: HalfBoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::HalfBoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
-    /// let until_yesterday = HalfBoundedAbsoluteInterval::until_yesterday(offset_tz).unwrap();
+    /// let until_yesterday = HalfBoundedAbsoluteInterval::until_yesterday(offset_tz)?;
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn until_yesterday<Tz>(tz: Tz) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError>
     where
@@ -4719,21 +6657,67 @@ impl HalfBoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{DateTime, Duration, FixedOffset, NaiveDate, Utc, Weekday};
-    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{HalfBoundedAbsoluteInterval, HalfBoundedAbsoluteIntervalCreationError};
     /// # use periodical::intervals::meta::{BoundInclusivity, OpeningDirection};
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct NaiveDateFromYmdError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     NaiveDateFromYmdError(NaiveDateFromYmdError),
+    /// #     HalfBoundedAbsoluteIntervalCreationError(HalfBoundedAbsoluteIntervalCreationError),
+    /// #     ParseError(chrono::format::ParseError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<NaiveDateFromYmdError> for ExampleError {
+    /// #     fn from(value: NaiveDateFromYmdError) -> Self {
+    /// #         ExampleError::NaiveDateFromYmdError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<HalfBoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: HalfBoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::HalfBoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<chrono::format::ParseError> for ExampleError {
+    /// #     fn from(value: chrono::format::ParseError) -> Self {
+    /// #         ExampleError::ParseError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
     /// let interval = HalfBoundedAbsoluteInterval::since_week(
-    ///     NaiveDate::from_ymd_opt(2026, 5, 1).unwrap().week(Weekday::Mon),
+    ///     NaiveDate::from_ymd_opt(2026, 5, 1).ok_or(NaiveDateFromYmdError)?.week(Weekday::Mon),
     ///     offset_tz,
-    /// ).unwrap();
+    /// )?;
     ///
     /// assert_eq!(interval.reference_time(), "2026-04-26 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(interval.reference_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(interval.opening_direction(), OpeningDirection::ToFuture);
-    /// # Ok::<(), chrono::format::ParseError>(())
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn since_week<Tz>(week: NaiveWeek, tz: Tz) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError>
     where
@@ -4761,21 +6745,67 @@ impl HalfBoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{DateTime, Duration, FixedOffset, NaiveDate, Utc, Weekday};
-    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{HalfBoundedAbsoluteInterval, HalfBoundedAbsoluteIntervalCreationError};
     /// # use periodical::intervals::meta::{BoundInclusivity, OpeningDirection};
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct NaiveDateFromYmdError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     NaiveDateFromYmdError(NaiveDateFromYmdError),
+    /// #     HalfBoundedAbsoluteIntervalCreationError(HalfBoundedAbsoluteIntervalCreationError),
+    /// #     ParseError(chrono::format::ParseError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<NaiveDateFromYmdError> for ExampleError {
+    /// #     fn from(value: NaiveDateFromYmdError) -> Self {
+    /// #         ExampleError::NaiveDateFromYmdError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<HalfBoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: HalfBoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::HalfBoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<chrono::format::ParseError> for ExampleError {
+    /// #     fn from(value: chrono::format::ParseError) -> Self {
+    /// #         ExampleError::ParseError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
     /// let interval = HalfBoundedAbsoluteInterval::until_week(
-    ///     NaiveDate::from_ymd_opt(2026, 5, 1).unwrap().week(Weekday::Mon),
+    ///     NaiveDate::from_ymd_opt(2026, 5, 1).ok_or(NaiveDateFromYmdError)?.week(Weekday::Mon),
     ///     offset_tz,
-    /// ).unwrap();
+    /// )?;
     ///
     /// assert_eq!(interval.reference_time(), "2026-04-26 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(interval.reference_inclusivity(), BoundInclusivity::Exclusive);
     /// assert_eq!(interval.opening_direction(), OpeningDirection::ToPast);
-    /// # Ok::<(), chrono::format::ParseError>(())
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn until_week<Tz>(week: NaiveWeek, tz: Tz) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError>
     where
@@ -4799,12 +6829,42 @@ impl HalfBoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{Duration, FixedOffset, Weekday};
-    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{HalfBoundedAbsoluteInterval, HalfBoundedAbsoluteIntervalCreationError};
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     HalfBoundedAbsoluteIntervalCreationError(HalfBoundedAbsoluteIntervalCreationError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<HalfBoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: HalfBoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::HalfBoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
-    /// let since_this_week = HalfBoundedAbsoluteInterval::since_this_week(Weekday::Mon, offset_tz).unwrap();
+    /// let since_this_week = HalfBoundedAbsoluteInterval::since_this_week(Weekday::Mon, offset_tz)?;
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn since_this_week<Tz>(week_start: Weekday, tz: Tz) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError>
     where
@@ -4824,12 +6884,42 @@ impl HalfBoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{Duration, FixedOffset, Weekday};
-    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{HalfBoundedAbsoluteInterval, HalfBoundedAbsoluteIntervalCreationError};
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     HalfBoundedAbsoluteIntervalCreationError(HalfBoundedAbsoluteIntervalCreationError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<HalfBoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: HalfBoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::HalfBoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
-    /// let until_this_week = HalfBoundedAbsoluteInterval::until_this_week(Weekday::Mon, offset_tz).unwrap();
+    /// let until_this_week = HalfBoundedAbsoluteInterval::until_this_week(Weekday::Mon, offset_tz)?;
+    /// # Ok::<(), ExampleError>(())
     pub fn until_this_week<Tz>(week_start: Weekday, tz: Tz) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError>
     where
         Tz: TimeZone,
@@ -4852,21 +6942,67 @@ impl HalfBoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{Datelike, DateTime, Duration, FixedOffset, NaiveDate, Utc, Weekday};
-    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{HalfBoundedAbsoluteInterval, HalfBoundedAbsoluteIntervalCreationError};
     /// # use periodical::intervals::meta::{BoundInclusivity, OpeningDirection};
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct NaiveDateFromYmdError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     NaiveDateFromYmdError(NaiveDateFromYmdError),
+    /// #     HalfBoundedAbsoluteIntervalCreationError(HalfBoundedAbsoluteIntervalCreationError),
+    /// #     ParseError(chrono::format::ParseError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<NaiveDateFromYmdError> for ExampleError {
+    /// #     fn from(value: NaiveDateFromYmdError) -> Self {
+    /// #         ExampleError::NaiveDateFromYmdError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<HalfBoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: HalfBoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::HalfBoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<chrono::format::ParseError> for ExampleError {
+    /// #     fn from(value: chrono::format::ParseError) -> Self {
+    /// #         ExampleError::ParseError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
     /// let interval = HalfBoundedAbsoluteInterval::since_iso_week(
-    ///     NaiveDate::from_ymd_opt(2026, 5, 1).unwrap().iso_week(),
+    ///     NaiveDate::from_ymd_opt(2026, 5, 1).ok_or(NaiveDateFromYmdError)?.iso_week(),
     ///     offset_tz,
-    /// ).unwrap();
+    /// )?;
     ///
     /// assert_eq!(interval.reference_time(), "2026-04-26 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(interval.reference_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(interval.opening_direction(), OpeningDirection::ToFuture);
-    /// # Ok::<(), chrono::format::ParseError>(())
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn since_iso_week<Tz>(iso_week: IsoWeek, tz: Tz) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError>
     where
@@ -4894,21 +7030,67 @@ impl HalfBoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{Datelike, DateTime, Duration, FixedOffset, NaiveDate, Utc, Weekday};
-    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{HalfBoundedAbsoluteInterval, HalfBoundedAbsoluteIntervalCreationError};
     /// # use periodical::intervals::meta::{BoundInclusivity, OpeningDirection};
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct NaiveDateFromYmdError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     NaiveDateFromYmdError(NaiveDateFromYmdError),
+    /// #     HalfBoundedAbsoluteIntervalCreationError(HalfBoundedAbsoluteIntervalCreationError),
+    /// #     ParseError(chrono::format::ParseError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<NaiveDateFromYmdError> for ExampleError {
+    /// #     fn from(value: NaiveDateFromYmdError) -> Self {
+    /// #         ExampleError::NaiveDateFromYmdError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<HalfBoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: HalfBoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::HalfBoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<chrono::format::ParseError> for ExampleError {
+    /// #     fn from(value: chrono::format::ParseError) -> Self {
+    /// #         ExampleError::ParseError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
     /// let interval = HalfBoundedAbsoluteInterval::until_iso_week(
-    ///     NaiveDate::from_ymd_opt(2026, 5, 1).unwrap().iso_week(),
+    ///     NaiveDate::from_ymd_opt(2026, 5, 1).ok_or(NaiveDateFromYmdError)?.iso_week(),
     ///     offset_tz,
-    /// ).unwrap();
+    /// )?;
     ///
     /// assert_eq!(interval.reference_time(), "2026-04-26 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(interval.reference_inclusivity(), BoundInclusivity::Exclusive);
     /// assert_eq!(interval.opening_direction(), OpeningDirection::ToPast);
-    /// # Ok::<(), chrono::format::ParseError>(())
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn until_iso_week<Tz>(iso_week: IsoWeek, tz: Tz) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError>
     where
@@ -4932,12 +7114,42 @@ impl HalfBoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{Duration, FixedOffset, Weekday};
-    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{HalfBoundedAbsoluteInterval, HalfBoundedAbsoluteIntervalCreationError};
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     HalfBoundedAbsoluteIntervalCreationError(HalfBoundedAbsoluteIntervalCreationError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<HalfBoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: HalfBoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::HalfBoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
-    /// let since_this_iso_week = HalfBoundedAbsoluteInterval::since_this_iso_week(offset_tz).unwrap();
+    /// let since_this_iso_week = HalfBoundedAbsoluteInterval::since_this_iso_week(offset_tz)?;
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn since_this_iso_week<Tz>(tz: Tz) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError>
     where
@@ -4957,12 +7169,42 @@ impl HalfBoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{Duration, FixedOffset, Weekday};
-    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{HalfBoundedAbsoluteInterval, HalfBoundedAbsoluteIntervalCreationError};
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     HalfBoundedAbsoluteIntervalCreationError(HalfBoundedAbsoluteIntervalCreationError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<HalfBoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: HalfBoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::HalfBoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
-    /// let until_this_iso_week = HalfBoundedAbsoluteInterval::until_this_iso_week(offset_tz).unwrap();
+    /// let until_this_iso_week = HalfBoundedAbsoluteInterval::until_this_iso_week(offset_tz)?;
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn until_this_iso_week<Tz>(tz: Tz) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError>
     where
@@ -4986,22 +7228,58 @@ impl HalfBoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{DateTime, Duration, FixedOffset, Month, Utc};
-    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{HalfBoundedAbsoluteInterval, HalfBoundedAbsoluteIntervalCreationError};
     /// # use periodical::intervals::meta::{BoundInclusivity, OpeningDirection};
     /// # use periodical::time::NaiveMonth;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     HalfBoundedAbsoluteIntervalCreationError(HalfBoundedAbsoluteIntervalCreationError),
+    /// #     ParseError(chrono::format::ParseError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<HalfBoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: HalfBoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::HalfBoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<chrono::format::ParseError> for ExampleError {
+    /// #     fn from(value: chrono::format::ParseError) -> Self {
+    /// #         ExampleError::ParseError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
     /// let since_month = HalfBoundedAbsoluteInterval::since_month(
     ///     NaiveMonth::new(2026, Month::March),
     ///     offset_tz,
-    /// ).unwrap();
+    /// )?;
     ///
     /// assert_eq!(since_month.reference_time(), "2026-02-28 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(since_month.reference_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(since_month.opening_direction(), OpeningDirection::ToFuture);
-    /// # Ok::<(), chrono::format::ParseError>(())
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn since_month<Tz>(month: NaiveMonth, tz: Tz) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError>
     where
@@ -5030,22 +7308,58 @@ impl HalfBoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{DateTime, Duration, FixedOffset, Month, Utc};
-    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{HalfBoundedAbsoluteInterval, HalfBoundedAbsoluteIntervalCreationError};
     /// # use periodical::intervals::meta::{BoundInclusivity, OpeningDirection};
     /// # use periodical::time::NaiveMonth;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     HalfBoundedAbsoluteIntervalCreationError(HalfBoundedAbsoluteIntervalCreationError),
+    /// #     ParseError(chrono::format::ParseError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<HalfBoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: HalfBoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::HalfBoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<chrono::format::ParseError> for ExampleError {
+    /// #     fn from(value: chrono::format::ParseError) -> Self {
+    /// #         ExampleError::ParseError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
     /// let until_month = HalfBoundedAbsoluteInterval::until_month(
     ///     NaiveMonth::new(2026, Month::March),
     ///     offset_tz,
-    /// ).unwrap();
+    /// )?;
     ///
     /// assert_eq!(until_month.reference_time(), "2026-02-28 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(until_month.reference_inclusivity(), BoundInclusivity::Exclusive);
     /// assert_eq!(until_month.opening_direction(), OpeningDirection::ToPast);
-    /// # Ok::<(), chrono::format::ParseError>(())
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn until_month<Tz>(month: NaiveMonth, tz: Tz) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError>
     where
@@ -5070,12 +7384,42 @@ impl HalfBoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{Duration, FixedOffset, Weekday};
-    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{HalfBoundedAbsoluteInterval, HalfBoundedAbsoluteIntervalCreationError};
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     HalfBoundedAbsoluteIntervalCreationError(HalfBoundedAbsoluteIntervalCreationError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<HalfBoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: HalfBoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::HalfBoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
-    /// let since_this_month = HalfBoundedAbsoluteInterval::since_this_month(offset_tz).unwrap();
+    /// let since_this_month = HalfBoundedAbsoluteInterval::since_this_month(offset_tz)?;
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn since_this_month<Tz>(tz: Tz) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError>
     where
@@ -5099,12 +7443,42 @@ impl HalfBoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{Duration, FixedOffset, Weekday};
-    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{HalfBoundedAbsoluteInterval, HalfBoundedAbsoluteIntervalCreationError};
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     HalfBoundedAbsoluteIntervalCreationError(HalfBoundedAbsoluteIntervalCreationError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<HalfBoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: HalfBoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::HalfBoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
-    /// let until_this_month = HalfBoundedAbsoluteInterval::until_this_month(offset_tz).unwrap();
+    /// let until_this_month = HalfBoundedAbsoluteInterval::until_this_month(offset_tz)?;
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn until_this_month<Tz>(tz: Tz) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError>
     where
@@ -5132,18 +7506,54 @@ impl HalfBoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{DateTime, Duration, FixedOffset, Month, Utc};
-    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{HalfBoundedAbsoluteInterval, HalfBoundedAbsoluteIntervalCreationError};
     /// # use periodical::intervals::meta::{BoundInclusivity, OpeningDirection};
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     HalfBoundedAbsoluteIntervalCreationError(HalfBoundedAbsoluteIntervalCreationError),
+    /// #     ParseError(chrono::format::ParseError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<HalfBoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: HalfBoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::HalfBoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<chrono::format::ParseError> for ExampleError {
+    /// #     fn from(value: chrono::format::ParseError) -> Self {
+    /// #         ExampleError::ParseError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
-    /// let since_year = HalfBoundedAbsoluteInterval::since_year(2026, offset_tz).unwrap();
+    /// let since_year = HalfBoundedAbsoluteInterval::since_year(2026, offset_tz)?;
     ///
     /// assert_eq!(since_year.reference_time(), "2025-12-31 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(since_year.reference_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(since_year.opening_direction(), OpeningDirection::ToFuture);
-    /// # Ok::<(), chrono::format::ParseError>(())
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn since_year<Tz>(year: i32, tz: Tz) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError>
     where
@@ -5170,18 +7580,54 @@ impl HalfBoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{DateTime, Duration, FixedOffset, Month, Utc};
-    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{HalfBoundedAbsoluteInterval, HalfBoundedAbsoluteIntervalCreationError};
     /// # use periodical::intervals::meta::{BoundInclusivity, OpeningDirection};
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     HalfBoundedAbsoluteIntervalCreationError(HalfBoundedAbsoluteIntervalCreationError),
+    /// #     ParseError(chrono::format::ParseError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<HalfBoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: HalfBoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::HalfBoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<chrono::format::ParseError> for ExampleError {
+    /// #     fn from(value: chrono::format::ParseError) -> Self {
+    /// #         ExampleError::ParseError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
-    /// let until_year = HalfBoundedAbsoluteInterval::until_year(2026, offset_tz).unwrap();
+    /// let until_year = HalfBoundedAbsoluteInterval::until_year(2026, offset_tz)?;
     ///
     /// assert_eq!(until_year.reference_time(), "2025-12-31 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(until_year.reference_inclusivity(), BoundInclusivity::Exclusive);
     /// assert_eq!(until_year.opening_direction(), OpeningDirection::ToPast);
-    /// # Ok::<(), chrono::format::ParseError>(())
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn until_year<Tz>(year: i32, tz: Tz) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError>
     where
@@ -5204,12 +7650,42 @@ impl HalfBoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{Duration, FixedOffset, Weekday};
-    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{HalfBoundedAbsoluteInterval, HalfBoundedAbsoluteIntervalCreationError};
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     HalfBoundedAbsoluteIntervalCreationError(HalfBoundedAbsoluteIntervalCreationError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<HalfBoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: HalfBoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::HalfBoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
-    /// let since_this_year = HalfBoundedAbsoluteInterval::since_this_year(offset_tz).unwrap();
+    /// let since_this_year = HalfBoundedAbsoluteInterval::since_this_year(offset_tz)?;
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn since_this_year<Tz>(tz: Tz) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError>
     where
@@ -5229,12 +7705,42 @@ impl HalfBoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use std::num::TryFromIntError;
     /// # use chrono::{Duration, FixedOffset, Weekday};
-    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// # use periodical::intervals::absolute::{HalfBoundedAbsoluteInterval, HalfBoundedAbsoluteIntervalCreationError};
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct FixedOffsetError;
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     TryFromIntError(TryFromIntError),
+    /// #     FixedOffsetError(FixedOffsetError),
+    /// #     HalfBoundedAbsoluteIntervalCreationError(HalfBoundedAbsoluteIntervalCreationError),
+    /// # }
+    /// #
+    /// # impl From<TryFromIntError> for ExampleError {
+    /// #     fn from(value: TryFromIntError) -> Self {
+    /// #         ExampleError::TryFromIntError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<FixedOffsetError> for ExampleError {
+    /// #     fn from(value: FixedOffsetError) -> Self {
+    /// #         ExampleError::FixedOffsetError(value)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl From<HalfBoundedAbsoluteIntervalCreationError> for ExampleError {
+    /// #     fn from(value: HalfBoundedAbsoluteIntervalCreationError) -> Self {
+    /// #         ExampleError::HalfBoundedAbsoluteIntervalCreationError(value)
+    /// #     }
+    /// # }
     /// // UTC+02:00
-    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
     ///
-    /// let since_this_year = HalfBoundedAbsoluteInterval::until_this_year(offset_tz).unwrap();
+    /// let since_this_year = HalfBoundedAbsoluteInterval::until_this_year(offset_tz)?;
+    /// # Ok::<(), ExampleError>(())
     /// ```
     pub fn until_this_year<Tz>(tz: Tz) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError>
     where

--- a/src/intervals/absolute.rs
+++ b/src/intervals/absolute.rs
@@ -17,7 +17,7 @@ use std::ops::{Bound, Range, RangeBounds, RangeFrom, RangeFull, RangeInclusive, 
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
-use chrono::{DateTime, Duration, Utc};
+use chrono::{DateTime, Days, Duration, Utc};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -25,6 +25,7 @@ use crate::intervals::meta::{Epsilon, Interval};
 use crate::intervals::ops::bound_overlap_ambiguity::{
     BoundOverlapAmbiguity, BoundOverlapDisambiguationRuleSet, DisambiguatedBoundOverlap,
 };
+use crate::time_constants::NAIVE_TIME_MIDNIGHT;
 
 use super::meta::{
     BoundInclusivity, Duration as IntervalDuration, Emptiable, HasBoundInclusivity, HasDuration, HasOpenness,
@@ -1942,6 +1943,48 @@ impl BoundedAbsoluteInterval {
         }
     }
 
+    /// Returns the current day in the given [`TimeZone`](chrono::TimeZone) as a [`BoundedAbsoluteInterval`]
+    /// 
+    /// # Errors
+    /// 
+    /// Returns [`StartInTimeGap`](BoundedAbsoluteIntervalCreationError::StartInTimeGap) if today at midnight
+    /// in the given timezone is positioned inside a time gap[^1].
+    /// 
+    /// Returns [`OutOfRangeEndDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate) if tomorrow's date
+    /// is out of range.
+    /// 
+    /// Returns [`EndInTimeGap`](BoundedAbsoluteIntervalCreationError::EndInTimeGap) if tomorrow at midnight
+    /// in the given timezone is positioned inside a time gap[^1].
+    /// 
+    /// [^1]: See [`MappedLocalTime::None`](https://docs.rs/chrono/latest/chrono/offset/enum.LocalResult.html#variant.None)
+    pub fn today<Tz>(tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
+    where
+        Tz: chrono::TimeZone,
+    {
+        let today = Utc::now().with_timezone(&tz).date_naive();
+        let from = today
+            .and_time(NAIVE_TIME_MIDNIGHT)
+            .and_local_timezone(tz.clone())
+            .earliest()
+            .ok_or(BoundedAbsoluteIntervalCreationError::StartInTimeGap)?;
+
+        let tomorrow = today
+            .checked_add_days(Days::new(1))
+            .ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate)?;
+        let to = tomorrow
+            .and_time(NAIVE_TIME_MIDNIGHT)
+            .and_local_timezone(tz)
+            .latest()
+            .ok_or(BoundedAbsoluteIntervalCreationError::EndInTimeGap)?;
+
+        Ok(Self::unchecked_new_with_inclusivity(
+            from.with_timezone(&Utc),
+            BoundInclusivity::Inclusive,
+            to.with_timezone(&Utc),
+            BoundInclusivity::Exclusive,
+        ))
+    }
+
     /// Returns the start time
     ///
     /// # Examples
@@ -2244,6 +2287,40 @@ impl BoundedAbsoluteInterval {
         true
     }
 }
+
+/// Errors that can occur when creating a new [`BoundedAbsoluteInterval`]
+/// 
+/// Those errors are mostly created by convenience methods, such as [`BoundedAbsoluteInterval::today`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum BoundedAbsoluteIntervalCreationError {
+    /// Start date could not be created as it was out of range
+    OutOfRangeStartDate,
+    /// End date could not be created as it was out of range
+    OutOfRangeEndDate,
+    /// Start time could not be created as positioned in a time gap
+    /// 
+    /// Time gaps are often created by daylight savings time (DST), where a given duration can be skipped,
+    /// therefore creating either a fold or a gap in time.
+    StartInTimeGap,
+    /// End time could not be created as positioned in a time gap
+    /// 
+    /// Time gaps are often created by daylight savings time (DST), where a given duration can be skipped,
+    /// therefore creating either a fold or a gap in time.
+    EndInTimeGap,
+}
+
+impl Display for BoundedAbsoluteIntervalCreationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::OutOfRangeStartDate => write!(f, "Start date could not be created as it was out of range"),
+            Self::OutOfRangeEndDate => write!(f, "End date could not be created as it was out of range"),
+            Self::StartInTimeGap => write!(f, "Start time could not be created as positioned in a time gap"),
+            Self::EndInTimeGap => write!(f, "End time could not be created as positioned in a time gap"),
+        }
+    }
+}
+
+impl Error for BoundedAbsoluteIntervalCreationError {}
 
 impl Interval for BoundedAbsoluteInterval {}
 

--- a/src/intervals/absolute.rs
+++ b/src/intervals/absolute.rs
@@ -17,7 +17,7 @@ use std::ops::{Bound, Range, RangeBounds, RangeFrom, RangeFull, RangeInclusive, 
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
-use chrono::{DateTime, Days, Duration, NaiveDate, TimeZone, Utc, Weekday};
+use chrono::{DateTime, Datelike, Days, Duration, IsoWeek, NaiveDate, NaiveWeek, TimeZone, Utc, Weekday};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -2244,6 +2244,63 @@ impl BoundedAbsoluteInterval {
         ))
     }
 
+    /// Creates a new [`BoundedAbsoluteInterval`] from the provided inclusive week range in the given timezone
+    /// 
+    /// Weeks given in reverse chronological order are treated the same way as if they were provided
+    /// in chronological order.
+    /// 
+    /// Note that the given from/to weeks can have different start days, so the resulting interval may not
+    /// always be a multiple of 7 days.
+    /// 
+    /// # Errors
+    /// 
+    /// Returns [`OutOfRangeStartDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate) if
+    /// the from week's first day is out of range.
+    /// 
+    /// Returns [`OutOfRangeEndDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate) if
+    /// the to week's last day is out of range.
+    /// 
+    /// See [`from_inclusive_date_range`](BoundedAbsoluteInterval::from_inclusive_date_range) for more errors
+    /// that could occur, as this method uses it.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// # use chrono::{Datelike, DateTime, Duration, FixedOffset, NaiveDate, NaiveWeek, Utc, Weekday};
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError};
+    /// # use periodical::intervals::meta::BoundInclusivity;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// let from = NaiveDate::from_ymd_opt(2026, 1, 7).unwrap().week(Weekday::Mon);
+    /// let to = NaiveDate::from_ymd_opt(2026, 3, 17).unwrap().week(Weekday::Sat);
+    /// 
+    /// let interval = BoundedAbsoluteInterval::from_inclusive_week_range(from, to, offset_tz).unwrap();
+    /// 
+    /// assert_eq!(interval.from_time(), "2026-01-04 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(interval.from_inclusivity(), BoundInclusivity::Inclusive);
+    /// assert_eq!(interval.to_time(), "2026-03-20 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(interval.to_inclusivity(), BoundInclusivity::Exclusive);
+    /// # Ok::<(), chrono::format::ParseError>(())
+    /// ```
+    pub fn from_inclusive_week_range<Tz>(
+        mut from: NaiveWeek,
+        mut to: NaiveWeek,
+        tz: Tz,
+    ) -> Result<Self, BoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        if from.checked_first_day() > to.checked_first_day() {
+            std::mem::swap(&mut from, &mut to);
+        }
+
+        Self::from_inclusive_date_range(
+            from.checked_first_day().ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate)?,
+            to.checked_last_day().ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate)?,
+            tz,
+        )
+    }
+
     /// Creates a new [`BoundedAbsoluteInterval`] of the week after a given [naive duration](NaiveDuration)
     /// relative to today in the given timezone
     /// 
@@ -2375,7 +2432,7 @@ impl BoundedAbsoluteInterval {
     /// # use periodical::intervals::meta::BoundInclusivity;
     /// // UTC+02:00
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
-    /// let this_week = BoundedAbsoluteInterval::week_before_naive_duration_from_today(
+    /// let this_week = BoundedAbsoluteInterval::this_week(
     ///     Weekday::Mon,
     ///     offset_tz,
     /// );
@@ -2467,7 +2524,266 @@ impl BoundedAbsoluteInterval {
         )
     }
 
-    // TODO: ISO Week convenience methods
+    /// Creates a new [`BoundedAbsoluteInterval`] from the provided inclusive ISO week range in the given timezone
+    /// 
+    /// Weeks given in reverse chronological order are treated the same way as if they were provided
+    /// in chronological order.
+    /// 
+    /// # Errors
+    /// 
+    /// Returns [`OutOfRangeStartDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate) if
+    /// the from week's first day is out of range.
+    /// 
+    /// Returns [`OutOfRangeEndDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate) if
+    /// the to week's last day is out of range.
+    /// 
+    /// See [`from_inclusive_date_range`](BoundedAbsoluteInterval::from_inclusive_date_range) for more errors
+    /// that could occur, as this method uses it.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// # use chrono::{Datelike, DateTime, Duration, FixedOffset, NaiveDate, Utc};
+    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::meta::BoundInclusivity;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// 
+    /// // Currently chrono has no public constructor for IsoWeek yet
+    /// let from = NaiveDate::from_ymd_opt(2026, 1, 7).unwrap().iso_week();
+    /// let to = NaiveDate::from_ymd_opt(2026, 3, 17).unwrap().iso_week();
+    /// 
+    /// let interval = BoundedAbsoluteInterval::from_inclusive_iso_week_range(from, to, offset_tz).unwrap();
+    /// 
+    /// assert_eq!(interval.from_time(), "2026-01-04 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(interval.from_inclusivity(), BoundInclusivity::Inclusive);
+    /// assert_eq!(interval.to_time(), "2026-03-22 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(interval.to_inclusivity(), BoundInclusivity::Exclusive);
+    /// # Ok::<(), chrono::format::ParseError>(())
+    /// ```
+    pub fn from_inclusive_iso_week_range<Tz>(
+        mut from: IsoWeek,
+        mut to: IsoWeek,
+        tz: Tz,
+    ) -> Result<Self, BoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        if from.year() > to.year() || (from.year() == to.year() && from.week() > to.week()) {
+            std::mem::swap(&mut from, &mut to);
+        }
+
+        Self::from_inclusive_date_range(
+            NaiveDate::from_isoywd_opt(from.year(), from.week(), Weekday::Mon)
+                .ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate)?,
+            NaiveDate::from_isoywd_opt(to.year(), to.week(), Weekday::Sun)
+                .ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate)?,
+            tz,
+        )
+    }
+
+    /// Creates a new [`BoundedAbsoluteInterval`] of the given week from the ISO year and week numbers
+    /// in the given timezone
+    /// 
+    /// Weeks given in reverse chronological order are treated the same way as if they were provided
+    /// in chronological order.
+    /// 
+    /// # Errors
+    /// 
+    /// Returns [`DateOperationError`](BoundedAbsoluteIntervalCreationError::DateOperationError) if
+    /// the provided ISO year and week numbers are invalid.
+    /// 
+    /// Returns [`OutOfRangeStartDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate) if
+    /// the week's first day is out of range.
+    /// 
+    /// Returns [`OutOfRangeEndDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate) if
+    /// the week's last day is out of range.
+    /// 
+    /// See [`from_inclusive_date_range`](BoundedAbsoluteInterval::from_inclusive_date_range) for more errors
+    /// that could occur, as this method uses it.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// # use chrono::{DateTime, Duration, FixedOffset, Utc, Weekday};
+    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::meta::BoundInclusivity;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// 
+    /// let iso_week = BoundedAbsoluteInterval::week_from_iso_year_week(2026, 5, offset_tz).unwrap();
+    /// 
+    /// assert_eq!(iso_week.from_time(), "2026-01-25 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(iso_week.from_inclusivity(), BoundInclusivity::Inclusive);
+    /// assert_eq!(iso_week.to_time(), "2026-02-01 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(iso_week.to_inclusivity(), BoundInclusivity::Exclusive);
+    /// # Ok::<(), chrono::format::ParseError>(())
+    /// ```
+    pub fn week_from_iso_year_week<Tz>(
+        year: i32,
+        week: u8,
+        tz: Tz,
+    ) -> Result<Self, BoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        let iso_week = NaiveDate::from_isoywd_opt(year, u32::from(week), Weekday::Mon)
+            .ok_or(BoundedAbsoluteIntervalCreationError::DateOperationError)?
+            .week(Weekday::Mon);
+
+        Self::from_inclusive_date_range(
+            iso_week.checked_first_day().ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate)?,
+            iso_week.checked_last_day().ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate)?,
+            tz,
+        )
+    }
+
+    /// Creates a new [`BoundedAbsoluteInterval`] of the ISO week after a given [naive duration](NaiveDuration)
+    /// relative to today in the given timezone
+    /// 
+    /// # Errors
+    /// 
+    /// See [`week_after_naive_duration_from_today`](BoundedAbsoluteInterval::week_after_naive_duration_from_today)
+    /// for more details.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// # use chrono::{Duration, FixedOffset, Weekday};
+    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::meta::BoundInclusivity;
+    /// # use periodical::time::NaiveDuration;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// 
+    /// let iso_week = BoundedAbsoluteInterval::iso_week_after_naive_duration_from_today(
+    ///     NaiveDuration::months(2),
+    ///     offset_tz,
+    /// );
+    /// ```
+    pub fn iso_week_after_naive_duration_from_today<Tz>(
+        naive_duration: NaiveDuration,
+        tz: Tz,
+    ) -> Result<Self, BoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::week_after_naive_duration_from_today(naive_duration, Weekday::Mon, tz)
+    }
+
+    /// Creates a new [`BoundedAbsoluteInterval`] of the ISO week before a given [naive duration](NaiveDuration)
+    /// relative to today in the given timezone
+    /// 
+    /// # Errors
+    /// 
+    /// See [`week_before_naive_duration_from_today`](BoundedAbsoluteInterval::week_before_naive_duration_from_today)
+    /// for more details.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// # use chrono::{Duration, FixedOffset, Weekday};
+    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::meta::BoundInclusivity;
+    /// # use periodical::time::NaiveDuration;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// 
+    /// let iso_week = BoundedAbsoluteInterval::iso_week_before_naive_duration_from_today(
+    ///     NaiveDuration::months(2),
+    ///     offset_tz,
+    /// );
+    /// ```
+    pub fn iso_week_before_naive_duration_from_today<Tz>(
+        naive_duration: NaiveDuration,
+        tz: Tz,
+    ) -> Result<Self, BoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::week_before_naive_duration_from_today(naive_duration, Weekday::Mon, tz)
+    }
+
+    /// Creates a new [`BoundedAbsoluteInterval`] of the current ISO week in the given timezone
+    /// 
+    /// # Errors
+    /// 
+    /// Returns [`DateOperationError`](BoundedAbsoluteIntervalCreationError::DateOperationError) if
+    /// the current ISO week has a week number that doesn't fit in an [`u8`], which is not normally possible.
+    /// 
+    /// See [`week_from_iso_year_week`](BoundedAbsoluteInterval::week_from_iso_year_week) for more errors
+    /// that could occur, as this method uses it.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// # use chrono::{Duration, FixedOffset};
+    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// 
+    /// let iso_week = BoundedAbsoluteInterval::this_iso_week(offset_tz).unwrap();
+    /// ```
+    pub fn this_iso_week<Tz>(tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        let this_iso_week = naive_date_today(&tz).iso_week();
+
+        Self::week_from_iso_year_week(
+            this_iso_week.year(),
+            u8::try_from(this_iso_week.week()).or(Err(BoundedAbsoluteIntervalCreationError::DateOperationError))?,
+            tz,
+        )
+    }
+
+    /// Creates a new [`BoundedAbsoluteInterval`] of the next ISO week in the given timezone
+    /// 
+    /// # Errors
+    /// 
+    /// See [`iso_week_after_naive_duration_from_today`](BoundedAbsoluteInterval::iso_week_after_naive_duration_from_today)
+    /// for more details.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// # use chrono::{Duration, FixedOffset};
+    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// 
+    /// let iso_week = BoundedAbsoluteInterval::next_iso_week(offset_tz).unwrap();
+    /// ```
+    pub fn next_iso_week<Tz>(tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::iso_week_after_naive_duration_from_today(NaiveDuration::Weeks(Weekday::Mon, 1), tz)
+    }
+
+    /// Creates a new [`BoundedAbsoluteInterval`] of the previous ISO week in the given timezone
+    /// 
+    /// # Errors
+    /// 
+    /// See [`iso_week_before_naive_duration_from_today`](BoundedAbsoluteInterval::iso_week_before_naive_duration_from_today)
+    /// for more details.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// # use chrono::{Duration, FixedOffset};
+    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// 
+    /// let iso_week = BoundedAbsoluteInterval::previous_iso_week(offset_tz).unwrap();
+    /// ```
+    pub fn previous_iso_week<Tz>(tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::iso_week_before_naive_duration_from_today(NaiveDuration::Weeks(Weekday::Mon, 1), tz)
+    }
 
     // TODO: Months convenience methods
 

--- a/src/intervals/absolute.rs
+++ b/src/intervals/absolute.rs
@@ -2003,6 +2003,57 @@ impl BoundedAbsoluteInterval {
         ))
     }
 
+    /// Creates a new [`BoundedAbsoluteInterval`] of the day in a given amount of days relative to today
+    /// in the given timezone
+    /// 
+    /// Represents the day that is positioned N days compared to today.
+    /// Also accepts negative values to represent a day in the past.
+    /// 
+    /// # Errors
+    /// 
+    /// Returns [`OutOfRangeStartDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate)
+    /// or [`OutOfRangeEndDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate)
+    /// if the date is out of range after applying the `days_offset`.
+    /// 
+    /// See [`from_date`](BoundedAbsoluteInterval::from_date) for more errors that could occur, as this method
+    /// uses it.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// # use chrono::{DateTime, Duration, Utc, FixedOffset};
+    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::meta::BoundInclusivity;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// 
+    /// let interval = BoundedAbsoluteInterval::day_in_days_from_today(5, offset_tz).unwrap();
+    /// ```
+    pub fn day_in_days_from_today<Tz>(days_offset: i64, tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        if days_offset.is_positive() {
+            Self::from_date(
+                Utc::now()
+                    .with_timezone(&tz)
+                    .date_naive()
+                    .checked_add_days(Days::new(days_offset.unsigned_abs()))
+                    .ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate)?,
+                tz,
+            )
+        } else {
+            Self::from_date(
+                Utc::now()
+                    .with_timezone(&tz)
+                    .date_naive()
+                    .checked_sub_days(Days::new(days_offset.unsigned_abs()))
+                    .ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate)?,
+                tz,
+            )
+        }
+    }
+
     /// Returns the current day in the given [`TimeZone`](chrono::TimeZone) as a [`BoundedAbsoluteInterval`]
     /// 
     /// Uses [`from_date`](BoundedAbsoluteInterval::from_date) with the current day.
@@ -2036,6 +2087,54 @@ impl BoundedAbsoluteInterval {
         Tz: TimeZone,
     {
         Self::from_date(Utc::now().with_timezone(&tz).date_naive(), tz)
+    }
+
+    /// Creates a new [`BoundedAbsoluteInterval`] of tomorrow in the given timezone
+    /// 
+    /// # Errors
+    /// 
+    /// See [`day_in_days_from_today`](BoundedAbsoluteInterval::day_in_days_from_today) for more details.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// # use chrono::{DateTime, Duration, Utc, FixedOffset};
+    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::meta::BoundInclusivity;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// 
+    /// let tomorrow = BoundedAbsoluteInterval::tomorrow(offset_tz).unwrap();
+    /// ```
+    pub fn tomorrow<Tz>(tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::day_in_days_from_today(1, tz)
+    }
+
+    /// Creates a new [`BoundedAbsoluteInterval`] of yesterday in the given timezone
+    /// 
+    /// # Errors
+    /// 
+    /// See [`day_in_days_from_today`](BoundedAbsoluteInterval::day_in_days_from_today) for more details.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// # use chrono::{DateTime, Duration, Utc, FixedOffset};
+    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::meta::BoundInclusivity;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// 
+    /// let yesterday = BoundedAbsoluteInterval::yesterday(offset_tz).unwrap();
+    /// ```
+    pub fn yesterday<Tz>(tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::day_in_days_from_today(-1, tz)
     }
 
     /// Returns the start time

--- a/src/intervals/absolute.rs
+++ b/src/intervals/absolute.rs
@@ -2245,26 +2245,26 @@ impl BoundedAbsoluteInterval {
     }
 
     /// Creates a new [`BoundedAbsoluteInterval`] from the provided inclusive week range in the given timezone
-    /// 
+    ///
     /// Weeks given in reverse chronological order are treated the same way as if they were provided
     /// in chronological order.
-    /// 
+    ///
     /// Note that the given from/to weeks can have different start days, so the resulting interval may not
     /// always be a multiple of 7 days.
-    /// 
+    ///
     /// # Errors
-    /// 
+    ///
     /// Returns [`OutOfRangeStartDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate) if
     /// the from week's first day is out of range.
-    /// 
+    ///
     /// Returns [`OutOfRangeEndDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate) if
     /// the to week's last day is out of range.
-    /// 
+    ///
     /// See [`from_inclusive_date_range`](BoundedAbsoluteInterval::from_inclusive_date_range) for more errors
     /// that could occur, as this method uses it.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// # use chrono::{Datelike, DateTime, Duration, FixedOffset, NaiveDate, NaiveWeek, Utc, Weekday};
     /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError};
@@ -2273,9 +2273,9 @@ impl BoundedAbsoluteInterval {
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
     /// let from = NaiveDate::from_ymd_opt(2026, 1, 7).unwrap().week(Weekday::Mon);
     /// let to = NaiveDate::from_ymd_opt(2026, 3, 17).unwrap().week(Weekday::Sat);
-    /// 
+    ///
     /// let interval = BoundedAbsoluteInterval::from_inclusive_week_range(from, to, offset_tz).unwrap();
-    /// 
+    ///
     /// assert_eq!(interval.from_time(), "2026-01-04 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(interval.from_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(interval.to_time(), "2026-03-20 22:00:00Z".parse::<DateTime<Utc>>()?);
@@ -2295,32 +2295,34 @@ impl BoundedAbsoluteInterval {
         }
 
         Self::from_inclusive_date_range(
-            from.checked_first_day().ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate)?,
-            to.checked_last_day().ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate)?,
+            from.checked_first_day()
+                .ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate)?,
+            to.checked_last_day()
+                .ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate)?,
             tz,
         )
     }
 
     /// Creates a new [`BoundedAbsoluteInterval`] of the week after a given [naive duration](NaiveDuration)
     /// relative to today in the given timezone
-    /// 
+    ///
     /// # Errors
-    /// 
+    ///
     /// Returns [`DateOperationError`](BoundedAbsoluteIntervalCreationError::DateOperationError) if
     /// [`time::checked_add_naive_duration_to_naive_date`](`checked_add_naive_duration_to_naive_date)
     /// returns [`None`].
-    /// 
+    ///
     /// Returns [`OutOfRangeStartDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate) if
     /// the week's start is out of range.
-    /// 
+    ///
     /// Returns [`OutOfRangeEndDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate) if
     /// the week's end is out of range.
-    /// 
+    ///
     /// See [`from_inclusive_date_range`](BoundedAbsoluteInterval::from_inclusive_date_range) for more errors
     /// that could occur, as this method uses it.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// # use chrono::{Duration, FixedOffset, Weekday};
     /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
@@ -2347,32 +2349,34 @@ impl BoundedAbsoluteInterval {
             .week(week_start);
 
         Self::from_inclusive_date_range(
-            week.checked_first_day().ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate)?,
-            week.checked_last_day().ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate)?,
+            week.checked_first_day()
+                .ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate)?,
+            week.checked_last_day()
+                .ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate)?,
             tz,
         )
     }
 
     /// Creates a new [`BoundedAbsoluteInterval`] of the week before a given [naive duration](NaiveDuration)
     /// relative to today in the given timezone
-    /// 
+    ///
     /// # Errors
-    /// 
+    ///
     /// Returns [`DateOperationError`](BoundedAbsoluteIntervalCreationError::DateOperationError) if
     /// [`time::checked_add_naive_duration_to_naive_date`](`checked_add_naive_duration_to_naive_date)
     /// returns [`None`].
-    /// 
+    ///
     /// Returns [`OutOfRangeStartDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate) if
     /// the week's start is out of range.
-    /// 
+    ///
     /// Returns [`OutOfRangeEndDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate) if
     /// the week's end is out of range.
-    /// 
+    ///
     /// See [`from_inclusive_date_range`](BoundedAbsoluteInterval::from_inclusive_date_range) for more errors
     /// that could occur, as this method uses it.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// # use chrono::{Duration, FixedOffset, Weekday};
     /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
@@ -2399,8 +2403,10 @@ impl BoundedAbsoluteInterval {
             .week(week_start);
 
         Self::from_inclusive_date_range(
-            week.checked_first_day().ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate)?,
-            week.checked_last_day().ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate)?,
+            week.checked_first_day()
+                .ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate)?,
+            week.checked_last_day()
+                .ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate)?,
             tz,
         )
     }
@@ -2417,10 +2423,10 @@ impl BoundedAbsoluteInterval {
     ///
     /// Returns [`OutOfRangeStartDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate) if
     /// the week's start is out of range.
-    /// 
+    ///
     /// Returns [`OutOfRangeEndDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate) if
     /// the week's end is out of range.
-    /// 
+    ///
     /// See [`from_inclusive_date_range`](BoundedAbsoluteInterval::from_inclusive_date_range) for more errors
     /// that could occur, as this method uses it.
     ///
@@ -2444,8 +2450,12 @@ impl BoundedAbsoluteInterval {
         let this_week = naive_date_today(&tz).week(week_start);
 
         Self::from_inclusive_date_range(
-            this_week.checked_first_day().ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate)?,
-            this_week.checked_last_day().ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate)?,
+            this_week
+                .checked_first_day()
+                .ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate)?,
+            this_week
+                .checked_last_day()
+                .ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate)?,
             tz,
         )
     }
@@ -2459,7 +2469,7 @@ impl BoundedAbsoluteInterval {
     /// which uses [ISO weeks](https://en.wikipedia.org/w/index.php?title=ISO_week_date&oldid=1334192696).
     ///
     /// # Errors
-    /// 
+    ///
     /// See [`week_after_naive_duration_from_today`](BoundedAbsoluteInterval::week_after_naive_duration_from_today)
     /// for more details.
     ///
@@ -2480,11 +2490,7 @@ impl BoundedAbsoluteInterval {
     where
         Tz: TimeZone,
     {
-        Self::week_after_naive_duration_from_today(
-            NaiveDuration::weeks(week_start, 1),
-            week_start,
-            tz,
-        )
+        Self::week_after_naive_duration_from_today(NaiveDuration::weeks(week_start, 1), week_start, tz)
     }
 
     /// Creates a new [`BoundedAbsoluteInterval`] of the previous week in the given timezone
@@ -2496,7 +2502,7 @@ impl BoundedAbsoluteInterval {
     /// which uses [ISO weeks](https://en.wikipedia.org/w/index.php?title=ISO_week_date&oldid=1334192696).
     ///
     /// # Errors
-    /// 
+    ///
     /// See [`week_before_naive_duration_from_today`](BoundedAbsoluteInterval::week_before_naive_duration_from_today)
     /// for more details.
     ///
@@ -2517,44 +2523,40 @@ impl BoundedAbsoluteInterval {
     where
         Tz: TimeZone,
     {
-        Self::week_before_naive_duration_from_today(
-            NaiveDuration::weeks(week_start, 1),
-            week_start,
-            tz,
-        )
+        Self::week_before_naive_duration_from_today(NaiveDuration::weeks(week_start, 1), week_start, tz)
     }
 
     /// Creates a new [`BoundedAbsoluteInterval`] from the provided inclusive ISO week range in the given timezone
-    /// 
+    ///
     /// Weeks given in reverse chronological order are treated the same way as if they were provided
     /// in chronological order.
-    /// 
+    ///
     /// # Errors
-    /// 
+    ///
     /// Returns [`OutOfRangeStartDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate) if
     /// the from week's first day is out of range.
-    /// 
+    ///
     /// Returns [`OutOfRangeEndDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate) if
     /// the to week's last day is out of range.
-    /// 
+    ///
     /// See [`from_inclusive_date_range`](BoundedAbsoluteInterval::from_inclusive_date_range) for more errors
     /// that could occur, as this method uses it.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// # use chrono::{Datelike, DateTime, Duration, FixedOffset, NaiveDate, Utc};
     /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
     /// # use periodical::intervals::meta::BoundInclusivity;
     /// // UTC+02:00
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
-    /// 
+    ///
     /// // Currently chrono has no public constructor for IsoWeek yet
     /// let from = NaiveDate::from_ymd_opt(2026, 1, 7).unwrap().iso_week();
     /// let to = NaiveDate::from_ymd_opt(2026, 3, 17).unwrap().iso_week();
-    /// 
+    ///
     /// let interval = BoundedAbsoluteInterval::from_inclusive_iso_week_range(from, to, offset_tz).unwrap();
-    /// 
+    ///
     /// assert_eq!(interval.from_time(), "2026-01-04 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(interval.from_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(interval.to_time(), "2026-03-22 22:00:00Z".parse::<DateTime<Utc>>()?);
@@ -2584,35 +2586,35 @@ impl BoundedAbsoluteInterval {
 
     /// Creates a new [`BoundedAbsoluteInterval`] of the given week from the ISO year and week numbers
     /// in the given timezone
-    /// 
+    ///
     /// Weeks given in reverse chronological order are treated the same way as if they were provided
     /// in chronological order.
-    /// 
+    ///
     /// # Errors
-    /// 
+    ///
     /// Returns [`DateOperationError`](BoundedAbsoluteIntervalCreationError::DateOperationError) if
     /// the provided ISO year and week numbers are invalid.
-    /// 
+    ///
     /// Returns [`OutOfRangeStartDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate) if
     /// the week's first day is out of range.
-    /// 
+    ///
     /// Returns [`OutOfRangeEndDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate) if
     /// the week's last day is out of range.
-    /// 
+    ///
     /// See [`from_inclusive_date_range`](BoundedAbsoluteInterval::from_inclusive_date_range) for more errors
     /// that could occur, as this method uses it.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// # use chrono::{DateTime, Duration, FixedOffset, Utc, Weekday};
     /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
     /// # use periodical::intervals::meta::BoundInclusivity;
     /// // UTC+02:00
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
-    /// 
+    ///
     /// let iso_week = BoundedAbsoluteInterval::week_from_iso_year_week(2026, 5, offset_tz).unwrap();
-    /// 
+    ///
     /// assert_eq!(iso_week.from_time(), "2026-01-25 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(iso_week.from_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(iso_week.to_time(), "2026-02-01 22:00:00Z".parse::<DateTime<Utc>>()?);
@@ -2632,22 +2634,26 @@ impl BoundedAbsoluteInterval {
             .week(Weekday::Mon);
 
         Self::from_inclusive_date_range(
-            iso_week.checked_first_day().ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate)?,
-            iso_week.checked_last_day().ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate)?,
+            iso_week
+                .checked_first_day()
+                .ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate)?,
+            iso_week
+                .checked_last_day()
+                .ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate)?,
             tz,
         )
     }
 
     /// Creates a new [`BoundedAbsoluteInterval`] of the ISO week after a given [naive duration](NaiveDuration)
     /// relative to today in the given timezone
-    /// 
+    ///
     /// # Errors
-    /// 
+    ///
     /// See [`week_after_naive_duration_from_today`](BoundedAbsoluteInterval::week_after_naive_duration_from_today)
     /// for more details.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// # use chrono::{Duration, FixedOffset, Weekday};
     /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
@@ -2655,7 +2661,7 @@ impl BoundedAbsoluteInterval {
     /// # use periodical::time::NaiveDuration;
     /// // UTC+02:00
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
-    /// 
+    ///
     /// let iso_week = BoundedAbsoluteInterval::iso_week_after_naive_duration_from_today(
     ///     NaiveDuration::months(2),
     ///     offset_tz,
@@ -2673,14 +2679,14 @@ impl BoundedAbsoluteInterval {
 
     /// Creates a new [`BoundedAbsoluteInterval`] of the ISO week before a given [naive duration](NaiveDuration)
     /// relative to today in the given timezone
-    /// 
+    ///
     /// # Errors
-    /// 
+    ///
     /// See [`week_before_naive_duration_from_today`](BoundedAbsoluteInterval::week_before_naive_duration_from_today)
     /// for more details.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// # use chrono::{Duration, FixedOffset, Weekday};
     /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
@@ -2688,7 +2694,7 @@ impl BoundedAbsoluteInterval {
     /// # use periodical::time::NaiveDuration;
     /// // UTC+02:00
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
-    /// 
+    ///
     /// let iso_week = BoundedAbsoluteInterval::iso_week_before_naive_duration_from_today(
     ///     NaiveDuration::months(2),
     ///     offset_tz,
@@ -2705,23 +2711,23 @@ impl BoundedAbsoluteInterval {
     }
 
     /// Creates a new [`BoundedAbsoluteInterval`] of the current ISO week in the given timezone
-    /// 
+    ///
     /// # Errors
-    /// 
+    ///
     /// Returns [`DateOperationError`](BoundedAbsoluteIntervalCreationError::DateOperationError) if
     /// the current ISO week has a week number that doesn't fit in an [`u8`], which is not normally possible.
-    /// 
+    ///
     /// See [`week_from_iso_year_week`](BoundedAbsoluteInterval::week_from_iso_year_week) for more errors
     /// that could occur, as this method uses it.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// # use chrono::{Duration, FixedOffset};
     /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
     /// // UTC+02:00
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
-    /// 
+    ///
     /// let iso_week = BoundedAbsoluteInterval::this_iso_week(offset_tz).unwrap();
     /// ```
     pub fn this_iso_week<Tz>(tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
@@ -2738,20 +2744,20 @@ impl BoundedAbsoluteInterval {
     }
 
     /// Creates a new [`BoundedAbsoluteInterval`] of the next ISO week in the given timezone
-    /// 
+    ///
     /// # Errors
-    /// 
+    ///
     /// See [`iso_week_after_naive_duration_from_today`](BoundedAbsoluteInterval::iso_week_after_naive_duration_from_today)
     /// for more details.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// # use chrono::{Duration, FixedOffset};
     /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
     /// // UTC+02:00
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
-    /// 
+    ///
     /// let iso_week = BoundedAbsoluteInterval::next_iso_week(offset_tz).unwrap();
     /// ```
     pub fn next_iso_week<Tz>(tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
@@ -2762,20 +2768,20 @@ impl BoundedAbsoluteInterval {
     }
 
     /// Creates a new [`BoundedAbsoluteInterval`] of the previous ISO week in the given timezone
-    /// 
+    ///
     /// # Errors
-    /// 
+    ///
     /// See [`iso_week_before_naive_duration_from_today`](BoundedAbsoluteInterval::iso_week_before_naive_duration_from_today)
     /// for more details.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// # use chrono::{Duration, FixedOffset};
     /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
     /// // UTC+02:00
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
-    /// 
+    ///
     /// let iso_week = BoundedAbsoluteInterval::previous_iso_week(offset_tz).unwrap();
     /// ```
     pub fn previous_iso_week<Tz>(tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>

--- a/src/intervals/absolute.rs
+++ b/src/intervals/absolute.rs
@@ -2006,7 +2006,7 @@ impl BoundedAbsoluteInterval {
     }
 
     /// Creates a new [`BoundedAbsoluteInterval`] of the day after a given [naive duration](NaiveDuration)
-    /// relative to today in the given timezone
+    /// relative to the given day in the given timezone
     ///
     /// # Errors
     ///
@@ -2016,6 +2016,100 @@ impl BoundedAbsoluteInterval {
     ///
     /// See [`from_date`](BoundedAbsoluteInterval::from_date) for more errors that could occur, as this method
     /// uses it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chrono::{DateTime, Duration, FixedOffset, NaiveDate, Utc};
+    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::meta::BoundInclusivity;
+    /// # use periodical::time::NaiveDuration;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    ///
+    /// let interval = BoundedAbsoluteInterval::day_after_naive_duration_from_naive_date(
+    ///     NaiveDate::from_ymd_opt(2026, 4, 29).unwrap(),
+    ///     NaiveDuration::days(5),
+    ///     offset_tz
+    /// ).unwrap();
+    /// 
+    /// assert_eq!(interval.from_time(), "2026-05-03 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(interval.from_inclusivity(), BoundInclusivity::Inclusive);
+    /// assert_eq!(interval.to_time(), "2026-05-04 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(interval.to_inclusivity(), BoundInclusivity::Exclusive);
+    /// # Ok::<(), chrono::format::ParseError>(())
+    /// ```
+    pub fn day_after_naive_duration_from_naive_date<Tz>(
+        naive_date: NaiveDate,
+        naive_duration: NaiveDuration,
+        tz: Tz,
+    ) -> Result<Self, BoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::from_date(
+            checked_add_naive_duration_to_naive_date(naive_date, naive_duration)
+                .ok_or(BoundedAbsoluteIntervalCreationError::DateOperationError)?,
+            tz,
+        )
+    }
+
+    /// Creates a new [`BoundedAbsoluteInterval`] of the day after a given [naive duration](NaiveDuration)
+    /// relative to the given day in the given timezone
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DateOperationError`](BoundedAbsoluteIntervalCreationError::DateOperationError) if
+    /// [`time::checked_sub_naive_duration_to_naive_date`](`checked_sub_naive_duration_to_naive_date)
+    /// returns [`None`].
+    ///
+    /// See [`from_date`](BoundedAbsoluteInterval::from_date) for more errors that could occur, as this method
+    /// uses it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chrono::{DateTime, Duration, FixedOffset, NaiveDate, Utc};
+    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::meta::BoundInclusivity;
+    /// # use periodical::time::NaiveDuration;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    ///
+    /// let interval = BoundedAbsoluteInterval::day_before_naive_duration_from_naive_date(
+    ///     NaiveDate::from_ymd_opt(2026, 4, 29).unwrap(),
+    ///     NaiveDuration::days(5),
+    ///     offset_tz
+    /// ).unwrap();
+    /// 
+    /// assert_eq!(interval.from_time(), "2026-04-23 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(interval.from_inclusivity(), BoundInclusivity::Inclusive);
+    /// assert_eq!(interval.to_time(), "2026-04-24 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(interval.to_inclusivity(), BoundInclusivity::Exclusive);
+    /// # Ok::<(), chrono::format::ParseError>(())
+    /// ```
+    pub fn day_before_naive_duration_from_naive_date<Tz>(
+        naive_date: NaiveDate,
+        naive_duration: NaiveDuration,
+        tz: Tz,
+    ) -> Result<Self, BoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::from_date(
+            checked_sub_naive_duration_to_naive_date(naive_date, naive_duration)
+                .ok_or(BoundedAbsoluteIntervalCreationError::DateOperationError)?,
+            tz,
+        )
+    }
+
+    /// Creates a new [`BoundedAbsoluteInterval`] of the day after a given [naive duration](NaiveDuration)
+    /// relative to today in the given timezone
+    ///
+    /// # Errors
+    ///
+    /// See [`day_after_naive_duration_from_naive_date`](BoundedAbsoluteInterval::day_after_naive_duration_from_naive_date)
+    /// for more details.
     ///
     /// # Examples
     ///
@@ -2039,11 +2133,7 @@ impl BoundedAbsoluteInterval {
     where
         Tz: TimeZone,
     {
-        Self::from_date(
-            checked_add_naive_duration_to_naive_date(naive_date_today(&tz), naive_duration)
-                .ok_or(BoundedAbsoluteIntervalCreationError::DateOperationError)?,
-            tz,
-        )
+        Self::day_after_naive_duration_from_naive_date(naive_date_today(&tz), naive_duration, tz)
     }
 
     /// Creates a new [`BoundedAbsoluteInterval`] of the day before a given [naive duration](NaiveDuration)
@@ -2051,12 +2141,8 @@ impl BoundedAbsoluteInterval {
     ///
     /// # Errors
     ///
-    /// Returns [`DateOperationError`](BoundedAbsoluteIntervalCreationError::DateOperationError) if
-    /// [`time::checked_sub_naive_duration_to_naive_date`](`checked_sub_naive_duration_to_naive_date)
-    /// returns [`None`].
-    ///
-    /// See [`from_date`](BoundedAbsoluteInterval::from_date) for more errors that could occur, as this method
-    /// uses it.
+    /// See [`day_before_naive_duration_from_naive_date`](BoundedAbsoluteInterval::day_before_naive_duration_from_naive_date)
+    /// for more details.
     ///
     /// # Examples
     ///
@@ -2080,11 +2166,7 @@ impl BoundedAbsoluteInterval {
     where
         Tz: TimeZone,
     {
-        Self::from_date(
-            checked_sub_naive_duration_to_naive_date(naive_date_today(&tz), naive_duration)
-                .ok_or(BoundedAbsoluteIntervalCreationError::DateOperationError)?,
-            tz,
-        )
+        Self::day_before_naive_duration_from_naive_date(naive_date_today(&tz), naive_duration, tz)
     }
 
     /// Returns the current day in the given [`TimeZone`](chrono::TimeZone) as a [`BoundedAbsoluteInterval`]
@@ -2347,7 +2429,7 @@ impl BoundedAbsoluteInterval {
     }
 
     /// Creates a new [`BoundedAbsoluteInterval`] of the week after a given [naive duration](NaiveDuration)
-    /// relative to today in the given timezone
+    /// relative to the given date in the given timezone
     ///
     /// # Errors
     ///
@@ -2355,29 +2437,121 @@ impl BoundedAbsoluteInterval {
     /// [`time::checked_add_naive_duration_to_naive_date`](`checked_add_naive_duration_to_naive_date)
     /// returns [`None`].
     ///
-    /// Returns [`OutOfRangeStartDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate) if
-    /// the week's start is out of range.
+    /// See [`from_week`](BoundedAbsoluteInterval::from_week) for more errors that could occur,
+    /// as this method uses it.
     ///
-    /// Returns [`OutOfRangeEndDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate) if
-    /// the week's end is out of range.
+    /// # Examples
     ///
-    /// See [`from_inclusive_date_range`](BoundedAbsoluteInterval::from_inclusive_date_range) for more errors
-    /// that could occur, as this method uses it.
+    /// ```
+    /// # use chrono::{DateTime, Duration, FixedOffset, NaiveDate, Utc, Weekday};
+    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::meta::BoundInclusivity;
+    /// # use periodical::time::NaiveDuration;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// 
+    /// let week = BoundedAbsoluteInterval::week_after_naive_duration_from_naive_date(
+    ///     NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
+    ///     NaiveDuration::weeks(Weekday::Mon, 2),
+    ///     Weekday::Mon,
+    ///     offset_tz,
+    /// ).unwrap();
+    /// 
+    /// assert_eq!(week.from_time(), "2026-05-10 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(week.from_inclusivity(), BoundInclusivity::Inclusive);
+    /// assert_eq!(week.to_time(), "2026-05-17 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(week.to_inclusivity(), BoundInclusivity::Exclusive);
+    /// # Ok::<(), chrono::format::ParseError>(())
+    /// ```
+    pub fn week_after_naive_duration_from_naive_date<Tz>(
+        naive_date: NaiveDate,
+        naive_duration: NaiveDuration,
+        week_start: Weekday,
+        tz: Tz,
+    ) -> Result<Self, BoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        let week = checked_add_naive_duration_to_naive_date(naive_date, naive_duration)
+            .ok_or(BoundedAbsoluteIntervalCreationError::DateOperationError)?
+            .week(week_start);
+
+        Self::from_week(week, tz)
+    }
+
+    /// Creates a new [`BoundedAbsoluteInterval`] of the week before a given [naive duration](NaiveDuration)
+    /// relative to the given date in the given timezone
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DateOperationError`](BoundedAbsoluteIntervalCreationError::DateOperationError) if
+    /// [`time::checked_sub_naive_duration_to_naive_date`](`checked_sub_naive_duration_to_naive_date)
+    /// returns [`None`].
+    ///
+    /// See [`from_week`](BoundedAbsoluteInterval::from_week) for more errors that could occur,
+    /// as this method uses it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chrono::{DateTime, Duration, FixedOffset, NaiveDate, Utc, Weekday};
+    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::meta::BoundInclusivity;
+    /// # use periodical::time::NaiveDuration;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// 
+    /// let week = BoundedAbsoluteInterval::week_before_naive_duration_from_naive_date(
+    ///     NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
+    ///     NaiveDuration::weeks(Weekday::Mon, 2),
+    ///     Weekday::Mon,
+    ///     offset_tz,
+    /// ).unwrap();
+    /// 
+    /// assert_eq!(week.from_time(), "2026-04-12 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(week.from_inclusivity(), BoundInclusivity::Inclusive);
+    /// assert_eq!(week.to_time(), "2026-04-19 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(week.to_inclusivity(), BoundInclusivity::Exclusive);
+    /// # Ok::<(), chrono::format::ParseError>(())
+    /// ```
+    pub fn week_before_naive_duration_from_naive_date<Tz>(
+        naive_date: NaiveDate,
+        naive_duration: NaiveDuration,
+        week_start: Weekday,
+        tz: Tz,
+    ) -> Result<Self, BoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        let week = checked_sub_naive_duration_to_naive_date(naive_date, naive_duration)
+            .ok_or(BoundedAbsoluteIntervalCreationError::DateOperationError)?
+            .week(week_start);
+
+        Self::from_week(week, tz)
+    }
+
+    /// Creates a new [`BoundedAbsoluteInterval`] of the week after a given [naive duration](NaiveDuration)
+    /// relative to today in the given timezone
+    ///
+    /// # Errors
+    ///
+    /// See [`week_after_naive_duration_from_naive_date`](BoundedAbsoluteInterval::week_after_naive_duration_from_naive_date)
+    /// for more details.
     ///
     /// # Examples
     ///
     /// ```
     /// # use chrono::{Duration, FixedOffset, Weekday};
     /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
-    /// # use periodical::intervals::meta::BoundInclusivity;
     /// # use periodical::time::NaiveDuration;
     /// // UTC+02:00
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// 
     /// let week = BoundedAbsoluteInterval::week_after_naive_duration_from_today(
     ///     NaiveDuration::months(2),
     ///     Weekday::Mon,
     ///     offset_tz,
-    /// );
+    /// ).unwrap();
     /// ```
     pub fn week_after_naive_duration_from_today<Tz>(
         naive_duration: NaiveDuration,
@@ -2387,17 +2561,7 @@ impl BoundedAbsoluteInterval {
     where
         Tz: TimeZone,
     {
-        let week = checked_add_naive_duration_to_naive_date(naive_date_today(&tz), naive_duration)
-            .ok_or(BoundedAbsoluteIntervalCreationError::DateOperationError)?
-            .week(week_start);
-
-        Self::from_inclusive_date_range(
-            week.checked_first_day()
-                .ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate)?,
-            week.checked_last_day()
-                .ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate)?,
-            tz,
-        )
+        Self::week_after_naive_duration_from_naive_date(naive_date_today(&tz), naive_duration, week_start, tz)
     }
 
     /// Creates a new [`BoundedAbsoluteInterval`] of the week before a given [naive duration](NaiveDuration)
@@ -2405,33 +2569,23 @@ impl BoundedAbsoluteInterval {
     ///
     /// # Errors
     ///
-    /// Returns [`DateOperationError`](BoundedAbsoluteIntervalCreationError::DateOperationError) if
-    /// [`time::checked_add_naive_duration_to_naive_date`](`checked_add_naive_duration_to_naive_date)
-    /// returns [`None`].
-    ///
-    /// Returns [`OutOfRangeStartDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate) if
-    /// the week's start is out of range.
-    ///
-    /// Returns [`OutOfRangeEndDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate) if
-    /// the week's end is out of range.
-    ///
-    /// See [`from_inclusive_date_range`](BoundedAbsoluteInterval::from_inclusive_date_range) for more errors
-    /// that could occur, as this method uses it.
+    /// See [`week_before_naive_duration_from_naive_date`](BoundedAbsoluteInterval::week_before_naive_duration_from_naive_date)
+    /// for more details.
     ///
     /// # Examples
     ///
     /// ```
     /// # use chrono::{Duration, FixedOffset, Weekday};
     /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
-    /// # use periodical::intervals::meta::BoundInclusivity;
     /// # use periodical::time::NaiveDuration;
     /// // UTC+02:00
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// 
     /// let week = BoundedAbsoluteInterval::week_before_naive_duration_from_today(
     ///     NaiveDuration::months(2),
     ///     Weekday::Mon,
     ///     offset_tz,
-    /// );
+    /// ).unwrap();
     /// ```
     pub fn week_before_naive_duration_from_today<Tz>(
         naive_duration: NaiveDuration,
@@ -2441,17 +2595,7 @@ impl BoundedAbsoluteInterval {
     where
         Tz: TimeZone,
     {
-        let week = checked_sub_naive_duration_to_naive_date(naive_date_today(&tz), naive_duration)
-            .ok_or(BoundedAbsoluteIntervalCreationError::DateOperationError)?
-            .week(week_start);
-
-        Self::from_inclusive_date_range(
-            week.checked_first_day()
-                .ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate)?,
-            week.checked_last_day()
-                .ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate)?,
-            tz,
-        )
+        Self::week_before_naive_duration_from_naive_date(naive_date_today(&tz), naive_duration, week_start, tz)
     }
 
     /// Creates a new [`BoundedAbsoluteInterval`] of the current week in the given timezone
@@ -2728,11 +2872,93 @@ impl BoundedAbsoluteInterval {
     }
 
     /// Creates a new [`BoundedAbsoluteInterval`] of the ISO week after a given [naive duration](NaiveDuration)
+    /// relative to the given date in the given timezone
+    ///
+    /// # Errors
+    ///
+    /// See [`week_after_naive_duration_from_naive_date`](BoundedAbsoluteInterval::week_after_naive_duration_from_naive_date)
+    /// for more details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chrono::{DateTime, Duration, FixedOffset, NaiveDate, Utc, Weekday};
+    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::meta::BoundInclusivity;
+    /// # use periodical::time::NaiveDuration;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// 
+    /// let week = BoundedAbsoluteInterval::iso_week_after_naive_duration_from_naive_date(
+    ///     NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
+    ///     NaiveDuration::weeks(Weekday::Mon, 2),
+    ///     offset_tz,
+    /// ).unwrap();
+    /// 
+    /// assert_eq!(week.from_time(), "2026-05-10 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(week.from_inclusivity(), BoundInclusivity::Inclusive);
+    /// assert_eq!(week.to_time(), "2026-05-17 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(week.to_inclusivity(), BoundInclusivity::Exclusive);
+    /// # Ok::<(), chrono::format::ParseError>(())
+    /// ```
+    pub fn iso_week_after_naive_duration_from_naive_date<Tz>(
+        naive_date: NaiveDate,
+        naive_duration: NaiveDuration,
+        tz: Tz,
+    ) -> Result<Self, BoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::week_after_naive_duration_from_naive_date(naive_date, naive_duration, Weekday::Mon, tz)
+    }
+
+    /// Creates a new [`BoundedAbsoluteInterval`] of the ISO week before a given [naive duration](NaiveDuration)
+    /// relative to the given date in the given timezone
+    ///
+    /// # Errors
+    ///
+    /// See [`week_before_naive_duration_from_naive_date`](BoundedAbsoluteInterval::week_before_naive_duration_from_naive_date)
+    /// for more details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chrono::{DateTime, Duration, FixedOffset, NaiveDate, Utc, Weekday};
+    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::meta::BoundInclusivity;
+    /// # use periodical::time::NaiveDuration;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// 
+    /// let week = BoundedAbsoluteInterval::iso_week_before_naive_duration_from_naive_date(
+    ///     NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
+    ///     NaiveDuration::weeks(Weekday::Mon, 2),
+    ///     offset_tz,
+    /// ).unwrap();
+    /// 
+    /// assert_eq!(week.from_time(), "2026-04-12 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(week.from_inclusivity(), BoundInclusivity::Inclusive);
+    /// assert_eq!(week.to_time(), "2026-04-19 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(week.to_inclusivity(), BoundInclusivity::Exclusive);
+    /// # Ok::<(), chrono::format::ParseError>(())
+    /// ```
+    pub fn iso_week_before_naive_duration_from_naive_date<Tz>(
+        naive_date: NaiveDate,
+        naive_duration: NaiveDuration,
+        tz: Tz,
+    ) -> Result<Self, BoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::week_before_naive_duration_from_naive_date(naive_date, naive_duration, Weekday::Mon, tz)
+    }
+
+    /// Creates a new [`BoundedAbsoluteInterval`] of the ISO week after a given [naive duration](NaiveDuration)
     /// relative to today in the given timezone
     ///
     /// # Errors
     ///
-    /// See [`week_after_naive_duration_from_today`](BoundedAbsoluteInterval::week_after_naive_duration_from_today)
+    /// See [`iso_week_after_naive_duration_from_naive_date`](BoundedAbsoluteInterval::iso_week_after_naive_duration_from_naive_date)
     /// for more details.
     ///
     /// # Examples
@@ -2740,7 +2966,6 @@ impl BoundedAbsoluteInterval {
     /// ```
     /// # use chrono::{Duration, FixedOffset, Weekday};
     /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
-    /// # use periodical::intervals::meta::BoundInclusivity;
     /// # use periodical::time::NaiveDuration;
     /// // UTC+02:00
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
@@ -2757,7 +2982,7 @@ impl BoundedAbsoluteInterval {
     where
         Tz: TimeZone,
     {
-        Self::week_after_naive_duration_from_today(naive_duration, Weekday::Mon, tz)
+        Self::iso_week_after_naive_duration_from_naive_date(naive_date_today(&tz), naive_duration, tz)
     }
 
     /// Creates a new [`BoundedAbsoluteInterval`] of the ISO week before a given [naive duration](NaiveDuration)
@@ -2765,7 +2990,7 @@ impl BoundedAbsoluteInterval {
     ///
     /// # Errors
     ///
-    /// See [`week_before_naive_duration_from_today`](BoundedAbsoluteInterval::week_before_naive_duration_from_today)
+    /// See [`iso_week_before_naive_duration_from_naive_date`](BoundedAbsoluteInterval::iso_week_before_naive_duration_from_naive_date)
     /// for more details.
     ///
     /// # Examples
@@ -2773,7 +2998,6 @@ impl BoundedAbsoluteInterval {
     /// ```
     /// # use chrono::{Duration, FixedOffset, Weekday};
     /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
-    /// # use periodical::intervals::meta::BoundInclusivity;
     /// # use periodical::time::NaiveDuration;
     /// // UTC+02:00
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
@@ -2790,7 +3014,7 @@ impl BoundedAbsoluteInterval {
     where
         Tz: TimeZone,
     {
-        Self::week_before_naive_duration_from_today(naive_duration, Weekday::Mon, tz)
+        Self::iso_week_before_naive_duration_from_naive_date(naive_date_today(&tz), naive_duration, tz)
     }
 
     /// Creates a new [`BoundedAbsoluteInterval`] of the current ISO week in the given timezone
@@ -2977,7 +3201,7 @@ impl BoundedAbsoluteInterval {
     }
 
     /// Creates a new [`BoundedAbsoluteInterval`] of the month after a given [naive duration](NaiveDuration)
-    /// relative to today in the given timezone
+    /// relative to the given date in the given timezone
     ///
     /// # Errors
     ///
@@ -2991,25 +3215,34 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
-    /// # use chrono::{Duration, FixedOffset};
+    /// # use chrono::{DateTime, Duration, FixedOffset, NaiveDate, Utc};
     /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::meta::BoundInclusivity;
     /// # use periodical::time::NaiveDuration;
     /// // UTC+02:00
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
     /// 
-    /// let month = BoundedAbsoluteInterval::month_after_naive_duration_from_today(
+    /// let month = BoundedAbsoluteInterval::month_after_naive_duration_from_naive_date(
+    ///     NaiveDate::from_ymd_opt(2026, 5, 5).unwrap(),
     ///     NaiveDuration::months(2),
     ///     offset_tz,
-    /// );
+    /// ).unwrap();
+    /// 
+    /// assert_eq!(month.from_time(), "2026-06-30 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(month.from_inclusivity(), BoundInclusivity::Inclusive);
+    /// assert_eq!(month.to_time(), "2026-07-31 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(month.to_inclusivity(), BoundInclusivity::Exclusive);
+    /// # Ok::<(), chrono::format::ParseError>(())
     /// ```
-    pub fn month_after_naive_duration_from_today<Tz>(
+    pub fn month_after_naive_duration_from_naive_date<Tz>(
+        naive_date: NaiveDate,
         naive_duration: NaiveDuration,
         tz: Tz,
     ) -> Result<Self, BoundedAbsoluteIntervalCreationError>
     where
         Tz: TimeZone,
     {
-        let day = checked_add_naive_duration_to_naive_date(naive_date_today(&tz), naive_duration)
+        let day = checked_add_naive_duration_to_naive_date(naive_date, naive_duration)
             .ok_or(BoundedAbsoluteIntervalCreationError::DateOperationError)?;
 
         Self::from_month(
@@ -3018,8 +3251,8 @@ impl BoundedAbsoluteInterval {
         )
     }
 
-    /// Creates a new [`BoundedAbsoluteInterval`] of the month after a given [naive duration](NaiveDuration)
-    /// relative to today in the given timezone
+    /// Creates a new [`BoundedAbsoluteInterval`] of the month before a given [naive duration](NaiveDuration)
+    /// relative to the given date in the given timezone
     ///
     /// # Errors
     ///
@@ -3033,6 +3266,85 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use chrono::{DateTime, Duration, FixedOffset, NaiveDate, Utc};
+    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::meta::BoundInclusivity;
+    /// # use periodical::time::NaiveDuration;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// 
+    /// let month = BoundedAbsoluteInterval::month_before_naive_duration_from_naive_date(
+    ///     NaiveDate::from_ymd_opt(2026, 5, 5).unwrap(),
+    ///     NaiveDuration::months(2),
+    ///     offset_tz,
+    /// ).unwrap();
+    /// 
+    /// assert_eq!(month.from_time(), "2026-02-28 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(month.from_inclusivity(), BoundInclusivity::Inclusive);
+    /// assert_eq!(month.to_time(), "2026-03-31 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(month.to_inclusivity(), BoundInclusivity::Exclusive);
+    /// # Ok::<(), chrono::format::ParseError>(())
+    /// ```
+    pub fn month_before_naive_duration_from_naive_date<Tz>(
+        naive_date: NaiveDate,
+        naive_duration: NaiveDuration,
+        tz: Tz,
+    ) -> Result<Self, BoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        let day = checked_sub_naive_duration_to_naive_date(naive_date, naive_duration)
+            .ok_or(BoundedAbsoluteIntervalCreationError::DateOperationError)?;
+
+        Self::from_month(
+            NaiveMonth::try_from(day).or(Err(BoundedAbsoluteIntervalCreationError::DateOperationError))?,
+            tz,
+        )
+    }
+
+    /// Creates a new [`BoundedAbsoluteInterval`] of the month after a given [naive duration](NaiveDuration)
+    /// relative to today in the given timezone
+    ///
+    /// # Errors
+    ///
+    /// See [`month_after_naive_duration_from_naive_date`](BoundedAbsoluteInterval::month_after_naive_duration_from_naive_date)
+    /// for more details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chrono::{Duration, FixedOffset};
+    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::time::NaiveDuration;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// 
+    /// let month = BoundedAbsoluteInterval::month_after_naive_duration_from_today(
+    ///     NaiveDuration::months(2),
+    ///     offset_tz,
+    /// ).unwrap();
+    /// ```
+    pub fn month_after_naive_duration_from_today<Tz>(
+        naive_duration: NaiveDuration,
+        tz: Tz,
+    ) -> Result<Self, BoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::month_after_naive_duration_from_naive_date(naive_date_today(&tz), naive_duration, tz)
+    }
+
+    /// Creates a new [`BoundedAbsoluteInterval`] of the month after a given [naive duration](NaiveDuration)
+    /// relative to today in the given timezone
+    ///
+    /// # Errors
+    ///
+    /// See [`month_before_naive_duration_from_naive_date`](BoundedAbsoluteInterval::month_before_naive_duration_from_naive_date)
+    /// for more details.
+    ///
+    /// # Examples
+    ///
+    /// ```
     /// # use chrono::{Duration, FixedOffset};
     /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
     /// # use periodical::time::NaiveDuration;
@@ -3042,7 +3354,7 @@ impl BoundedAbsoluteInterval {
     /// let month = BoundedAbsoluteInterval::month_before_naive_duration_from_today(
     ///     NaiveDuration::months(2),
     ///     offset_tz,
-    /// );
+    /// ).unwrap();
     /// ```
     pub fn month_before_naive_duration_from_today<Tz>(
         naive_duration: NaiveDuration,
@@ -3051,13 +3363,7 @@ impl BoundedAbsoluteInterval {
     where
         Tz: TimeZone,
     {
-        let day = checked_sub_naive_duration_to_naive_date(naive_date_today(&tz), naive_duration)
-            .ok_or(BoundedAbsoluteIntervalCreationError::DateOperationError)?;
-
-        Self::from_month(
-            NaiveMonth::try_from(day).or(Err(BoundedAbsoluteIntervalCreationError::DateOperationError))?,
-            tz,
-        )
+        Self::month_before_naive_duration_from_naive_date(naive_date_today(&tz), naive_duration, tz)
     }
 
     /// Creates a new [`BoundedAbsoluteInterval`] of the current month in the given timezone
@@ -3253,7 +3559,7 @@ impl BoundedAbsoluteInterval {
     }
 
     /// Creates a new [`BoundedAbsoluteInterval`] of the year after a given [naive duration](NaiveDuration)
-    /// relative to today in the given timezone
+    /// relative to the given date in the given timezone
     ///
     /// # Errors
     ///
@@ -3267,18 +3573,27 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
-    /// # use chrono::{Duration, FixedOffset};
+    /// # use chrono::{DateTime, Duration, FixedOffset, NaiveDate, Utc};
     /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::meta::BoundInclusivity;
     /// # use periodical::time::NaiveDuration;
     /// // UTC+02:00
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
     /// 
-    /// let year = BoundedAbsoluteInterval::year_after_naive_duration_from_today(
+    /// let year = BoundedAbsoluteInterval::year_after_naive_duration_from_naive_date(
+    ///     NaiveDate::from_ymd_opt(2026, 5, 5).unwrap(),
     ///     NaiveDuration::months(15),
     ///     offset_tz,
-    /// );
+    /// ).unwrap();
+    /// 
+    /// assert_eq!(year.from_time(), "2026-12-31 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(year.from_inclusivity(), BoundInclusivity::Inclusive);
+    /// assert_eq!(year.to_time(), "2027-12-31 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(year.to_inclusivity(), BoundInclusivity::Exclusive);
+    /// # Ok::<(), chrono::format::ParseError>(())
     /// ```
-    pub fn year_after_naive_duration_from_today<Tz>(
+    pub fn year_after_naive_duration_from_naive_date<Tz>(
+        naive_date: NaiveDate,
         naive_duration: NaiveDuration,
         tz: Tz,
     ) -> Result<Self, BoundedAbsoluteIntervalCreationError>
@@ -3286,7 +3601,7 @@ impl BoundedAbsoluteInterval {
         Tz: TimeZone,
     {
         Self::from_year(
-            checked_add_naive_duration_to_naive_date(naive_date_today(&tz), naive_duration)
+            checked_add_naive_duration_to_naive_date(naive_date, naive_duration)
                 .ok_or(BoundedAbsoluteIntervalCreationError::DateOperationError)?
                 .year(),
             tz,
@@ -3294,7 +3609,7 @@ impl BoundedAbsoluteInterval {
     }
 
     /// Creates a new [`BoundedAbsoluteInterval`] of the year before a given [naive duration](NaiveDuration)
-    /// relative to today in the given timezone
+    /// relative to the given date in the given timezone
     ///
     /// # Errors
     ///
@@ -3308,6 +3623,84 @@ impl BoundedAbsoluteInterval {
     /// # Examples
     ///
     /// ```
+    /// # use chrono::{DateTime, Duration, FixedOffset, NaiveDate, Utc};
+    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::meta::BoundInclusivity;
+    /// # use periodical::time::NaiveDuration;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// 
+    /// let year = BoundedAbsoluteInterval::year_before_naive_duration_from_naive_date(
+    ///     NaiveDate::from_ymd_opt(2026, 5, 5).unwrap(),
+    ///     NaiveDuration::months(15),
+    ///     offset_tz,
+    /// ).unwrap();
+    /// 
+    /// assert_eq!(year.from_time(), "2024-12-31 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(year.from_inclusivity(), BoundInclusivity::Inclusive);
+    /// assert_eq!(year.to_time(), "2025-12-31 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(year.to_inclusivity(), BoundInclusivity::Exclusive);
+    /// # Ok::<(), chrono::format::ParseError>(())
+    /// ```
+    pub fn year_before_naive_duration_from_naive_date<Tz>(
+        naive_date: NaiveDate,
+        naive_duration: NaiveDuration,
+        tz: Tz,
+    ) -> Result<Self, BoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::from_year(
+            checked_sub_naive_duration_to_naive_date(naive_date, naive_duration)
+                .ok_or(BoundedAbsoluteIntervalCreationError::DateOperationError)?
+                .year(),
+            tz,
+        )
+    }
+
+    /// Creates a new [`BoundedAbsoluteInterval`] of the year after a given [naive duration](NaiveDuration)
+    /// relative to today in the given timezone
+    ///
+    /// # Errors
+    ///
+    /// See [`year_after_naive_duration_from_naive_date`](BoundedAbsoluteInterval::year_after_naive_duration_from_naive_date)
+    /// for more details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chrono::{Duration, FixedOffset};
+    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::time::NaiveDuration;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// 
+    /// let year = BoundedAbsoluteInterval::year_after_naive_duration_from_today(
+    ///     NaiveDuration::months(15),
+    ///     offset_tz,
+    /// ).unwrap();
+    /// ```
+    pub fn year_after_naive_duration_from_today<Tz>(
+        naive_duration: NaiveDuration,
+        tz: Tz,
+    ) -> Result<Self, BoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::year_after_naive_duration_from_naive_date(naive_date_today(&tz), naive_duration, tz)
+    }
+
+    /// Creates a new [`BoundedAbsoluteInterval`] of the year before a given [naive duration](NaiveDuration)
+    /// relative to today in the given timezone
+    ///
+    /// # Errors
+    ///
+    /// See [`year_before_naive_duration_from_naive_date`](BoundedAbsoluteInterval::year_before_naive_duration_from_naive_date)
+    /// for more details.
+    ///
+    /// # Examples
+    ///
+    /// ```
     /// # use chrono::{Duration, FixedOffset};
     /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
     /// # use periodical::time::NaiveDuration;
@@ -3317,7 +3710,7 @@ impl BoundedAbsoluteInterval {
     /// let year = BoundedAbsoluteInterval::year_before_naive_duration_from_today(
     ///     NaiveDuration::months(15),
     ///     offset_tz,
-    /// );
+    /// ).unwrap();
     /// ```
     pub fn year_before_naive_duration_from_today<Tz>(
         naive_duration: NaiveDuration,
@@ -3326,12 +3719,7 @@ impl BoundedAbsoluteInterval {
     where
         Tz: TimeZone,
     {
-        Self::from_year(
-            checked_sub_naive_duration_to_naive_date(naive_date_today(&tz), naive_duration)
-                .ok_or(BoundedAbsoluteIntervalCreationError::DateOperationError)?
-                .year(),
-            tz,
-        )
+        Self::year_before_naive_duration_from_naive_date(naive_date_today(&tz), naive_duration, tz)
     }
 
     /// Creates a new [`BoundedAbsoluteInterval`] of the current year in the given timezone

--- a/src/intervals/absolute.rs
+++ b/src/intervals/absolute.rs
@@ -26,8 +26,7 @@ use crate::intervals::ops::bound_overlap_ambiguity::{
     BoundOverlapAmbiguity, BoundOverlapDisambiguationRuleSet, DisambiguatedBoundOverlap,
 };
 use crate::time::{
-    NAIVE_TIME_MIDNIGHT, NaiveDuration, NaiveMonth, checked_add_naive_duration_to_naive_date,
-    checked_sub_naive_duration_to_naive_date, naive_date_today,
+    DAYS_IN_COMMON_YEAR, DAYS_IN_LEAP_YEAR, NAIVE_TIME_MIDNIGHT, NaiveDuration, NaiveMonth, checked_add_naive_duration_to_naive_date, checked_sub_naive_duration_to_naive_date, naive_date_today
 };
 
 use super::meta::{
@@ -2848,7 +2847,7 @@ impl BoundedAbsoluteInterval {
     where
         Tz: TimeZone,
     {
-        Self::iso_week_after_naive_duration_from_today(NaiveDuration::Weeks(Weekday::Mon, 1), tz)
+        Self::iso_week_after_naive_duration_from_today(NaiveDuration::weeks(Weekday::Mon, 1), tz)
     }
 
     /// Creates a new [`BoundedAbsoluteInterval`] of the previous ISO week in the given timezone
@@ -2872,7 +2871,7 @@ impl BoundedAbsoluteInterval {
     where
         Tz: TimeZone,
     {
-        Self::iso_week_before_naive_duration_from_today(NaiveDuration::Weeks(Weekday::Mon, 1), tz)
+        Self::iso_week_before_naive_duration_from_today(NaiveDuration::weeks(Weekday::Mon, 1), tz)
     }
 
     /// Creates a new [`BoundedAbsoluteInterval`] of the given month in the given timezone
@@ -3140,7 +3139,269 @@ impl BoundedAbsoluteInterval {
         Self::month_before_naive_duration_from_today(NaiveDuration::months(1), tz)
     }
 
-    // TODO: Years convenience methods
+    /// Creates a new [`BoundedAbsoluteInterval`] from the given year in the given timezone
+    /// 
+    /// # Errors
+    /// 
+    /// Returns [`OutOfRangeStartDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate) if
+    /// the year's first day is out of range.
+    /// 
+    /// Returns [`OutOfRangeEndDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate) if
+    /// the year's last day is out of range.
+    /// 
+    /// See [`from_inclusive_date_range`](BoundedAbsoluteInterval::from_inclusive_date_range) for more errors
+    /// that could occur, as this method uses it.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// # use chrono::{DateTime, Duration, FixedOffset, Utc};
+    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::meta::BoundInclusivity;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// 
+    /// let year = BoundedAbsoluteInterval::from_year(2026, offset_tz).unwrap();
+    /// 
+    /// assert_eq!(year.from_time(), "2025-12-31 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(year.from_inclusivity(), BoundInclusivity::Inclusive);
+    /// assert_eq!(year.to_time(), "2026-12-31 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(year.to_inclusivity(), BoundInclusivity::Exclusive);
+    /// # Ok::<(), chrono::format::ParseError>(())
+    /// ```
+    pub fn from_year<Tz>(year: i32, tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        let first_day_of_year = NaiveDate::from_yo_opt(year, 1)
+            .ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate)?;
+
+        let last_day_of_year = NaiveDate::from_yo_opt(
+            year,
+            if first_day_of_year.leap_year() { u32::from(DAYS_IN_LEAP_YEAR) } else { u32::from(DAYS_IN_COMMON_YEAR) },
+        )
+            .ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate)?;
+
+        Self::from_inclusive_date_range(first_day_of_year, last_day_of_year, tz)
+    }
+
+    /// Creates a new [`BoundedAbsoluteInterval`] from the provided inclusive year range in the given timezone
+    /// 
+    /// Years given in reverse chronological order are treated the same way as if they were provided
+    /// in chronological order.
+    /// 
+    /// # Errors
+    /// 
+    /// Returns [`OutOfRangeStartDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate) if
+    /// the first day of `from_year` is out of range.
+    /// 
+    /// Returns [`DateOperationError`](BoundedAbsoluteIntervalCreationError::DateOperationError) if
+    /// the first day of `to_year` is out of range (needed in order to determine if the year is a leap year).
+    /// 
+    /// Returns [`OutOfRangeEndDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate) if
+    /// the last day of `to_year` is out of range.
+    /// 
+    /// See [`from_inclusive_date_range`](BoundedAbsoluteInterval::from_inclusive_date_range) for more errors
+    /// that could occur, as this method uses it.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// # use chrono::{DateTime, Duration, FixedOffset, Utc};
+    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::intervals::meta::BoundInclusivity;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// 
+    /// let years = BoundedAbsoluteInterval::from_inclusive_year_range(2025, 2030, offset_tz).unwrap();
+    /// 
+    /// assert_eq!(years.from_time(), "2024-12-31 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(years.from_inclusivity(), BoundInclusivity::Inclusive);
+    /// assert_eq!(years.to_time(), "2030-12-31 22:00:00Z".parse::<DateTime<Utc>>()?);
+    /// assert_eq!(years.to_inclusivity(), BoundInclusivity::Exclusive);
+    /// # Ok::<(), chrono::format::ParseError>(())
+    /// ```
+    pub fn from_inclusive_year_range<Tz>(
+        mut from_year: i32,
+        mut to_year: i32,
+        tz: Tz,
+    ) -> Result<Self, BoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        if from_year > to_year {
+            std::mem::swap(&mut from_year, &mut to_year);
+        }
+
+        let first_day_of_from_year = NaiveDate::from_yo_opt(from_year, 1)
+            .ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate)?;
+
+        let first_day_of_to_year = NaiveDate::from_yo_opt(to_year, 1)
+            .ok_or(BoundedAbsoluteIntervalCreationError::DateOperationError)?;
+
+        let last_day_of_to_year = NaiveDate::from_yo_opt(
+            to_year,
+            if first_day_of_to_year.leap_year() {
+                u32::from(DAYS_IN_LEAP_YEAR)
+            } else {
+                u32::from(DAYS_IN_COMMON_YEAR)
+            },
+        )
+            .ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate)?;
+
+        Self::from_inclusive_date_range(first_day_of_from_year, last_day_of_to_year, tz)
+    }
+
+    /// Creates a new [`BoundedAbsoluteInterval`] of the year after a given [naive duration](NaiveDuration)
+    /// relative to today in the given timezone
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DateOperationError`](BoundedAbsoluteIntervalCreationError::DateOperationError) if
+    /// [`time::checked_add_naive_duration_to_naive_date`](`checked_add_naive_duration_to_naive_date)
+    /// returns [`None`].
+    ///
+    /// See [`from_year`](BoundedAbsoluteInterval::from_year) for more errors that could occur,
+    /// as this method uses it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chrono::{Duration, FixedOffset};
+    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::time::NaiveDuration;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// 
+    /// let year = BoundedAbsoluteInterval::year_after_naive_duration_from_today(
+    ///     NaiveDuration::months(15),
+    ///     offset_tz,
+    /// );
+    /// ```
+    pub fn year_after_naive_duration_from_today<Tz>(
+        naive_duration: NaiveDuration,
+        tz: Tz,
+    ) -> Result<Self, BoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::from_year(
+            checked_add_naive_duration_to_naive_date(naive_date_today(&tz), naive_duration)
+                .ok_or(BoundedAbsoluteIntervalCreationError::DateOperationError)?
+                .year(),
+            tz,
+        )
+    }
+
+    /// Creates a new [`BoundedAbsoluteInterval`] of the year before a given [naive duration](NaiveDuration)
+    /// relative to today in the given timezone
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DateOperationError`](BoundedAbsoluteIntervalCreationError::DateOperationError) if
+    /// [`time::checked_sub_naive_duration_to_naive_date`](`checked_sub_naive_duration_to_naive_date)
+    /// returns [`None`].
+    ///
+    /// See [`from_year`](BoundedAbsoluteInterval::from_year) for more errors that could occur,
+    /// as this method uses it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chrono::{Duration, FixedOffset};
+    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// # use periodical::time::NaiveDuration;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// 
+    /// let year = BoundedAbsoluteInterval::year_before_naive_duration_from_today(
+    ///     NaiveDuration::months(15),
+    ///     offset_tz,
+    /// );
+    /// ```
+    pub fn year_before_naive_duration_from_today<Tz>(
+        naive_duration: NaiveDuration,
+        tz: Tz,
+    ) -> Result<Self, BoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::from_year(
+            checked_sub_naive_duration_to_naive_date(naive_date_today(&tz), naive_duration)
+                .ok_or(BoundedAbsoluteIntervalCreationError::DateOperationError)?
+                .year(),
+            tz,
+        )
+    }
+
+    /// Creates a new [`BoundedAbsoluteInterval`] of the current year in the given timezone
+    ///
+    /// # Errors
+    ///
+    /// See [`from_year`](BoundedAbsoluteInterval::from_year) for more details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chrono::{Duration, FixedOffset};
+    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// 
+    /// let year = BoundedAbsoluteInterval::this_year(offset_tz);
+    /// ```
+    pub fn this_year<Tz>(tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::from_year(naive_date_today(&tz).year(), tz)
+    }
+
+    /// Creates a new [`BoundedAbsoluteInterval`] of the next year in the given timezone
+    ///
+    /// # Errors
+    ///
+    /// See [`from_year`](BoundedAbsoluteInterval::from_year) for more details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chrono::{Duration, FixedOffset};
+    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// 
+    /// let year = BoundedAbsoluteInterval::next_year(offset_tz);
+    /// ```
+    pub fn next_year<Tz>(tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::year_after_naive_duration_from_today(NaiveDuration::years(1), tz)
+    }
+
+    /// Creates a new [`BoundedAbsoluteInterval`] of the previous year in the given timezone
+    ///
+    /// # Errors
+    ///
+    /// See [`from_year`](BoundedAbsoluteInterval::from_year) for more details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chrono::{Duration, FixedOffset};
+    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// // UTC+02:00
+    /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    /// 
+    /// let year = BoundedAbsoluteInterval::previous_year(offset_tz);
+    /// ```
+    pub fn previous_year<Tz>(tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
+    where
+        Tz: TimeZone,
+    {
+        Self::year_before_naive_duration_from_today(NaiveDuration::years(1), tz)
+    }
 
     /// Returns the start time
     ///

--- a/src/intervals/absolute.rs
+++ b/src/intervals/absolute.rs
@@ -26,7 +26,8 @@ use crate::intervals::ops::bound_overlap_ambiguity::{
     BoundOverlapAmbiguity, BoundOverlapDisambiguationRuleSet, DisambiguatedBoundOverlap,
 };
 use crate::time::{
-    DAYS_IN_COMMON_YEAR, DAYS_IN_LEAP_YEAR, NAIVE_TIME_MIDNIGHT, NaiveDuration, NaiveMonth, checked_add_naive_duration_to_naive_date, checked_sub_naive_duration_to_naive_date, naive_date_today
+    DAYS_IN_COMMON_YEAR, DAYS_IN_LEAP_YEAR, NAIVE_TIME_MIDNIGHT, NaiveDuration, NaiveMonth,
+    checked_add_naive_duration_to_naive_date, checked_sub_naive_duration_to_naive_date, naive_date_today,
 };
 
 use super::meta::{
@@ -2032,7 +2033,7 @@ impl BoundedAbsoluteInterval {
     ///     NaiveDuration::days(5),
     ///     offset_tz
     /// ).unwrap();
-    /// 
+    ///
     /// assert_eq!(interval.from_time(), "2026-05-03 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(interval.from_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(interval.to_time(), "2026-05-04 22:00:00Z".parse::<DateTime<Utc>>()?);
@@ -2081,7 +2082,7 @@ impl BoundedAbsoluteInterval {
     ///     NaiveDuration::days(5),
     ///     offset_tz
     /// ).unwrap();
-    /// 
+    ///
     /// assert_eq!(interval.from_time(), "2026-04-23 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(interval.from_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(interval.to_time(), "2026-04-24 22:00:00Z".parse::<DateTime<Utc>>()?);
@@ -2169,7 +2170,7 @@ impl BoundedAbsoluteInterval {
         Self::day_before_naive_duration_from_naive_date(naive_date_today(&tz), naive_duration, tz)
     }
 
-    /// Returns the current day in the given [`TimeZone`](chrono::TimeZone) as a [`BoundedAbsoluteInterval`]
+    /// Returns the current day in the given [`TimeZone`] as a [`BoundedAbsoluteInterval`]
     ///
     /// Uses [`from_date`](BoundedAbsoluteInterval::from_date) with the current day.
     ///
@@ -2449,14 +2450,14 @@ impl BoundedAbsoluteInterval {
     /// # use periodical::time::NaiveDuration;
     /// // UTC+02:00
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
-    /// 
+    ///
     /// let week = BoundedAbsoluteInterval::week_after_naive_duration_from_naive_date(
     ///     NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
     ///     NaiveDuration::weeks(Weekday::Mon, 2),
     ///     Weekday::Mon,
     ///     offset_tz,
     /// ).unwrap();
-    /// 
+    ///
     /// assert_eq!(week.from_time(), "2026-05-10 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(week.from_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(week.to_time(), "2026-05-17 22:00:00Z".parse::<DateTime<Utc>>()?);
@@ -2500,14 +2501,14 @@ impl BoundedAbsoluteInterval {
     /// # use periodical::time::NaiveDuration;
     /// // UTC+02:00
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
-    /// 
+    ///
     /// let week = BoundedAbsoluteInterval::week_before_naive_duration_from_naive_date(
     ///     NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
     ///     NaiveDuration::weeks(Weekday::Mon, 2),
     ///     Weekday::Mon,
     ///     offset_tz,
     /// ).unwrap();
-    /// 
+    ///
     /// assert_eq!(week.from_time(), "2026-04-12 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(week.from_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(week.to_time(), "2026-04-19 22:00:00Z".parse::<DateTime<Utc>>()?);
@@ -2546,7 +2547,7 @@ impl BoundedAbsoluteInterval {
     /// # use periodical::time::NaiveDuration;
     /// // UTC+02:00
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
-    /// 
+    ///
     /// let week = BoundedAbsoluteInterval::week_after_naive_duration_from_today(
     ///     NaiveDuration::months(2),
     ///     Weekday::Mon,
@@ -2580,7 +2581,7 @@ impl BoundedAbsoluteInterval {
     /// # use periodical::time::NaiveDuration;
     /// // UTC+02:00
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
-    /// 
+    ///
     /// let week = BoundedAbsoluteInterval::week_before_naive_duration_from_today(
     ///     NaiveDuration::months(2),
     ///     Weekday::Mon,
@@ -2888,13 +2889,13 @@ impl BoundedAbsoluteInterval {
     /// # use periodical::time::NaiveDuration;
     /// // UTC+02:00
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
-    /// 
+    ///
     /// let week = BoundedAbsoluteInterval::iso_week_after_naive_duration_from_naive_date(
     ///     NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
     ///     NaiveDuration::weeks(Weekday::Mon, 2),
     ///     offset_tz,
     /// ).unwrap();
-    /// 
+    ///
     /// assert_eq!(week.from_time(), "2026-05-10 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(week.from_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(week.to_time(), "2026-05-17 22:00:00Z".parse::<DateTime<Utc>>()?);
@@ -2929,13 +2930,13 @@ impl BoundedAbsoluteInterval {
     /// # use periodical::time::NaiveDuration;
     /// // UTC+02:00
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
-    /// 
+    ///
     /// let week = BoundedAbsoluteInterval::iso_week_before_naive_duration_from_naive_date(
     ///     NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
     ///     NaiveDuration::weeks(Weekday::Mon, 2),
     ///     offset_tz,
     /// ).unwrap();
-    /// 
+    ///
     /// assert_eq!(week.from_time(), "2026-04-12 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(week.from_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(week.to_time(), "2026-04-19 22:00:00Z".parse::<DateTime<Utc>>()?);
@@ -3099,20 +3100,20 @@ impl BoundedAbsoluteInterval {
     }
 
     /// Creates a new [`BoundedAbsoluteInterval`] of the given month in the given timezone
-    /// 
+    ///
     /// # Errors
-    /// 
+    ///
     /// Returns [`OutOfRangeStartDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate) if
     /// the first day of the month is out of range.
-    /// 
+    ///
     /// Returns [`OutOfRangeEndDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate) if
     /// the last day of the month is out of range.
-    /// 
+    ///
     /// See [`from_inclusive_date_range`](BoundedAbsoluteInterval::from_inclusive_date_range) for more errors
     /// that could occur, as this method uses it.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// # use chrono::{DateTime, Duration, FixedOffset, Month, Utc};
     /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
@@ -3120,12 +3121,12 @@ impl BoundedAbsoluteInterval {
     /// # use periodical::time::NaiveMonth;
     /// // UTC+02:00
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
-    /// 
+    ///
     /// let month = BoundedAbsoluteInterval::from_month(
     ///     NaiveMonth::new(2026, Month::May),
     ///     offset_tz,
     /// ).unwrap();
-    /// 
+    ///
     /// assert_eq!(month.from_time(), "2026-04-30 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(month.from_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(month.to_time(), "2026-05-31 22:00:00Z".parse::<DateTime<Utc>>()?);
@@ -3137,8 +3138,12 @@ impl BoundedAbsoluteInterval {
         Tz: TimeZone,
     {
         Self::from_inclusive_date_range(
-            month.checked_first_day().ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate)?,
-            month.checked_last_day().ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate)?,
+            month
+                .checked_first_day()
+                .ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate)?,
+            month
+                .checked_last_day()
+                .ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate)?,
             tz,
         )
     }
@@ -3194,8 +3199,10 @@ impl BoundedAbsoluteInterval {
         }
 
         Self::from_inclusive_date_range(
-            from.checked_first_day().ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate)?,
-            to.checked_last_day().ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate)?,
+            from.checked_first_day()
+                .ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate)?,
+            to.checked_last_day()
+                .ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate)?,
             tz,
         )
     }
@@ -3221,13 +3228,13 @@ impl BoundedAbsoluteInterval {
     /// # use periodical::time::NaiveDuration;
     /// // UTC+02:00
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
-    /// 
+    ///
     /// let month = BoundedAbsoluteInterval::month_after_naive_duration_from_naive_date(
     ///     NaiveDate::from_ymd_opt(2026, 5, 5).unwrap(),
     ///     NaiveDuration::months(2),
     ///     offset_tz,
     /// ).unwrap();
-    /// 
+    ///
     /// assert_eq!(month.from_time(), "2026-06-30 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(month.from_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(month.to_time(), "2026-07-31 22:00:00Z".parse::<DateTime<Utc>>()?);
@@ -3272,13 +3279,13 @@ impl BoundedAbsoluteInterval {
     /// # use periodical::time::NaiveDuration;
     /// // UTC+02:00
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
-    /// 
+    ///
     /// let month = BoundedAbsoluteInterval::month_before_naive_duration_from_naive_date(
     ///     NaiveDate::from_ymd_opt(2026, 5, 5).unwrap(),
     ///     NaiveDuration::months(2),
     ///     offset_tz,
     /// ).unwrap();
-    /// 
+    ///
     /// assert_eq!(month.from_time(), "2026-02-28 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(month.from_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(month.to_time(), "2026-03-31 22:00:00Z".parse::<DateTime<Utc>>()?);
@@ -3318,7 +3325,7 @@ impl BoundedAbsoluteInterval {
     /// # use periodical::time::NaiveDuration;
     /// // UTC+02:00
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
-    /// 
+    ///
     /// let month = BoundedAbsoluteInterval::month_after_naive_duration_from_today(
     ///     NaiveDuration::months(2),
     ///     offset_tz,
@@ -3350,7 +3357,7 @@ impl BoundedAbsoluteInterval {
     /// # use periodical::time::NaiveDuration;
     /// // UTC+02:00
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
-    /// 
+    ///
     /// let month = BoundedAbsoluteInterval::month_before_naive_duration_from_today(
     ///     NaiveDuration::months(2),
     ///     offset_tz,
@@ -3367,23 +3374,23 @@ impl BoundedAbsoluteInterval {
     }
 
     /// Creates a new [`BoundedAbsoluteInterval`] of the current month in the given timezone
-    /// 
+    ///
     /// # Errors
-    /// 
+    ///
     /// Returns [`DateOperationError`](BoundedAbsoluteIntervalCreationError::DateOperationError) if
     /// conversion of today's [`NaiveDate`] to a [`NaiveMonth`] failed.
-    /// 
+    ///
     /// See [`from_month`](BoundedAbsoluteInterval::from_month) for more errors that could occur,
     /// as this method uses it.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// # use chrono::{Duration, FixedOffset};
     /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
     /// // UTC+02:00
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
-    /// 
+    ///
     /// let month = BoundedAbsoluteInterval::this_month(offset_tz);
     /// ```
     pub fn this_month<Tz>(tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
@@ -3398,20 +3405,20 @@ impl BoundedAbsoluteInterval {
     }
 
     /// Creates a new [`BoundedAbsoluteInterval`] of the next month in the given timezone
-    /// 
+    ///
     /// # Errors
-    /// 
+    ///
     /// See [`month_after_naive_duration_from_today`](BoundedAbsoluteInterval::month_after_naive_duration_from_today)
     /// for more details.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// # use chrono::{Duration, FixedOffset};
     /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
     /// // UTC+02:00
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
-    /// 
+    ///
     /// let month = BoundedAbsoluteInterval::next_month(offset_tz);
     /// ```
     pub fn next_month<Tz>(tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
@@ -3422,20 +3429,20 @@ impl BoundedAbsoluteInterval {
     }
 
     /// Creates a new [`BoundedAbsoluteInterval`] of the previous month in the given timezone
-    /// 
+    ///
     /// # Errors
-    /// 
+    ///
     /// See [`month_before_naive_duration_from_today`](BoundedAbsoluteInterval::month_before_naive_duration_from_today)
     /// for more details.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// # use chrono::{Duration, FixedOffset};
     /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
     /// // UTC+02:00
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
-    /// 
+    ///
     /// let month = BoundedAbsoluteInterval::previous_month(offset_tz);
     /// ```
     pub fn previous_month<Tz>(tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
@@ -3446,29 +3453,29 @@ impl BoundedAbsoluteInterval {
     }
 
     /// Creates a new [`BoundedAbsoluteInterval`] from the given year in the given timezone
-    /// 
+    ///
     /// # Errors
-    /// 
+    ///
     /// Returns [`OutOfRangeStartDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate) if
     /// the year's first day is out of range.
-    /// 
+    ///
     /// Returns [`OutOfRangeEndDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate) if
     /// the year's last day is out of range.
-    /// 
+    ///
     /// See [`from_inclusive_date_range`](BoundedAbsoluteInterval::from_inclusive_date_range) for more errors
     /// that could occur, as this method uses it.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// # use chrono::{DateTime, Duration, FixedOffset, Utc};
     /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
     /// # use periodical::intervals::meta::BoundInclusivity;
     /// // UTC+02:00
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
-    /// 
+    ///
     /// let year = BoundedAbsoluteInterval::from_year(2026, offset_tz).unwrap();
-    /// 
+    ///
     /// assert_eq!(year.from_time(), "2025-12-31 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(year.from_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(year.to_time(), "2026-12-31 22:00:00Z".parse::<DateTime<Utc>>()?);
@@ -3479,48 +3486,52 @@ impl BoundedAbsoluteInterval {
     where
         Tz: TimeZone,
     {
-        let first_day_of_year = NaiveDate::from_yo_opt(year, 1)
-            .ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate)?;
+        let first_day_of_year =
+            NaiveDate::from_yo_opt(year, 1).ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate)?;
 
         let last_day_of_year = NaiveDate::from_yo_opt(
             year,
-            if first_day_of_year.leap_year() { u32::from(DAYS_IN_LEAP_YEAR) } else { u32::from(DAYS_IN_COMMON_YEAR) },
+            if first_day_of_year.leap_year() {
+                u32::from(DAYS_IN_LEAP_YEAR)
+            } else {
+                u32::from(DAYS_IN_COMMON_YEAR)
+            },
         )
-            .ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate)?;
+        .ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate)?;
 
         Self::from_inclusive_date_range(first_day_of_year, last_day_of_year, tz)
     }
 
     /// Creates a new [`BoundedAbsoluteInterval`] from the provided inclusive year range in the given timezone
-    /// 
+    ///
     /// Years given in reverse chronological order are treated the same way as if they were provided
     /// in chronological order.
-    /// 
+    ///
     /// # Errors
-    /// 
+    ///
     /// Returns [`OutOfRangeStartDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate) if
     /// the first day of `from_year` is out of range.
-    /// 
+    ///
     /// Returns [`DateOperationError`](BoundedAbsoluteIntervalCreationError::DateOperationError) if
     /// the first day of `to_year` is out of range (needed in order to determine if the year is a leap year).
-    /// 
+    ///
     /// Returns [`OutOfRangeEndDate`](BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate) if
     /// the last day of `to_year` is out of range.
-    /// 
+    ///
     /// See [`from_inclusive_date_range`](BoundedAbsoluteInterval::from_inclusive_date_range) for more errors
     /// that could occur, as this method uses it.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// # use chrono::{DateTime, Duration, FixedOffset, Utc};
     /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
     /// # use periodical::intervals::meta::BoundInclusivity;
     /// // UTC+02:00
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
-    /// 
+    ///
     /// let years = BoundedAbsoluteInterval::from_inclusive_year_range(2025, 2030, offset_tz).unwrap();
-    /// 
+    ///
     /// assert_eq!(years.from_time(), "2024-12-31 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(years.from_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(years.to_time(), "2030-12-31 22:00:00Z".parse::<DateTime<Utc>>()?);
@@ -3539,11 +3550,11 @@ impl BoundedAbsoluteInterval {
             std::mem::swap(&mut from_year, &mut to_year);
         }
 
-        let first_day_of_from_year = NaiveDate::from_yo_opt(from_year, 1)
-            .ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate)?;
+        let first_day_of_from_year =
+            NaiveDate::from_yo_opt(from_year, 1).ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeStartDate)?;
 
-        let first_day_of_to_year = NaiveDate::from_yo_opt(to_year, 1)
-            .ok_or(BoundedAbsoluteIntervalCreationError::DateOperationError)?;
+        let first_day_of_to_year =
+            NaiveDate::from_yo_opt(to_year, 1).ok_or(BoundedAbsoluteIntervalCreationError::DateOperationError)?;
 
         let last_day_of_to_year = NaiveDate::from_yo_opt(
             to_year,
@@ -3553,7 +3564,7 @@ impl BoundedAbsoluteInterval {
                 u32::from(DAYS_IN_COMMON_YEAR)
             },
         )
-            .ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate)?;
+        .ok_or(BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate)?;
 
         Self::from_inclusive_date_range(first_day_of_from_year, last_day_of_to_year, tz)
     }
@@ -3579,13 +3590,13 @@ impl BoundedAbsoluteInterval {
     /// # use periodical::time::NaiveDuration;
     /// // UTC+02:00
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
-    /// 
+    ///
     /// let year = BoundedAbsoluteInterval::year_after_naive_duration_from_naive_date(
     ///     NaiveDate::from_ymd_opt(2026, 5, 5).unwrap(),
     ///     NaiveDuration::months(15),
     ///     offset_tz,
     /// ).unwrap();
-    /// 
+    ///
     /// assert_eq!(year.from_time(), "2026-12-31 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(year.from_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(year.to_time(), "2027-12-31 22:00:00Z".parse::<DateTime<Utc>>()?);
@@ -3629,13 +3640,13 @@ impl BoundedAbsoluteInterval {
     /// # use periodical::time::NaiveDuration;
     /// // UTC+02:00
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
-    /// 
+    ///
     /// let year = BoundedAbsoluteInterval::year_before_naive_duration_from_naive_date(
     ///     NaiveDate::from_ymd_opt(2026, 5, 5).unwrap(),
     ///     NaiveDuration::months(15),
     ///     offset_tz,
     /// ).unwrap();
-    /// 
+    ///
     /// assert_eq!(year.from_time(), "2024-12-31 22:00:00Z".parse::<DateTime<Utc>>()?);
     /// assert_eq!(year.from_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(year.to_time(), "2025-12-31 22:00:00Z".parse::<DateTime<Utc>>()?);
@@ -3674,7 +3685,7 @@ impl BoundedAbsoluteInterval {
     /// # use periodical::time::NaiveDuration;
     /// // UTC+02:00
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
-    /// 
+    ///
     /// let year = BoundedAbsoluteInterval::year_after_naive_duration_from_today(
     ///     NaiveDuration::months(15),
     ///     offset_tz,
@@ -3706,7 +3717,7 @@ impl BoundedAbsoluteInterval {
     /// # use periodical::time::NaiveDuration;
     /// // UTC+02:00
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
-    /// 
+    ///
     /// let year = BoundedAbsoluteInterval::year_before_naive_duration_from_today(
     ///     NaiveDuration::months(15),
     ///     offset_tz,
@@ -3735,7 +3746,7 @@ impl BoundedAbsoluteInterval {
     /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
     /// // UTC+02:00
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
-    /// 
+    ///
     /// let year = BoundedAbsoluteInterval::this_year(offset_tz);
     /// ```
     pub fn this_year<Tz>(tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
@@ -3758,7 +3769,7 @@ impl BoundedAbsoluteInterval {
     /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
     /// // UTC+02:00
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
-    /// 
+    ///
     /// let year = BoundedAbsoluteInterval::next_year(offset_tz);
     /// ```
     pub fn next_year<Tz>(tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>
@@ -3781,7 +3792,7 @@ impl BoundedAbsoluteInterval {
     /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
     /// // UTC+02:00
     /// let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
-    /// 
+    ///
     /// let year = BoundedAbsoluteInterval::previous_year(offset_tz);
     /// ```
     pub fn previous_year<Tz>(tz: Tz) -> Result<Self, BoundedAbsoluteIntervalCreationError>

--- a/src/intervals/absolute_tests.rs
+++ b/src/intervals/absolute_tests.rs
@@ -1,7 +1,7 @@
 use std::cmp::Ordering;
 use std::ops::Bound;
 
-use chrono::{DateTime, Duration, FixedOffset, NaiveDate, Utc};
+use chrono::{DateTime, Datelike, Duration, FixedOffset, NaiveDate, Utc, Weekday};
 
 use crate::intervals::meta::{BoundInclusivity, HasBoundInclusivity, OpeningDirection};
 use crate::intervals::special::{EmptyInterval, UnboundedInterval};
@@ -1784,6 +1784,109 @@ fn bounded_absolute_interval_from_inclusive_date_range_reversed_order() {
     assert_eq!(interval.from_inclusivity(), BoundInclusivity::Inclusive);
     assert_eq!(interval.to_time(), datetime(&Utc, 2026, 1, 10, 22, 0, 0));
     assert_eq!(interval.to_inclusivity(), BoundInclusivity::Exclusive);
+}
+
+#[test]
+fn bounded_absolute_interval_from_inclusive_week_range() {
+    let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    let from = NaiveDate::from_ymd_opt(2026, 1, 7).unwrap().week(Weekday::Mon);
+    let to = NaiveDate::from_ymd_opt(2026, 3, 17).unwrap().week(Weekday::Sat);
+    
+    let interval = BoundedAbsoluteInterval::from_inclusive_week_range(from, to, offset_tz).unwrap();
+    
+    assert_eq!(interval.from_time(), datetime(&Utc, 2026, 1, 4, 22, 0, 0));
+    assert_eq!(interval.from_inclusivity(), BoundInclusivity::Inclusive);
+    assert_eq!(interval.to_time(), datetime(&Utc, 2026, 3, 20, 22, 0, 0));
+    assert_eq!(interval.to_inclusivity(), BoundInclusivity::Exclusive);
+}
+
+#[test]
+fn bounded_absolute_interval_from_inclusive_week_range_same_week() {
+    let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    let week = NaiveDate::from_ymd_opt(2026, 1, 7).unwrap().week(Weekday::Mon);
+    
+    let interval = BoundedAbsoluteInterval::from_inclusive_week_range(week, week, offset_tz).unwrap();
+    
+    assert_eq!(interval.from_time(), datetime(&Utc, 2026, 1, 4, 22, 0, 0));
+    assert_eq!(interval.from_inclusivity(), BoundInclusivity::Inclusive);
+    assert_eq!(interval.to_time(), datetime(&Utc, 2026, 1, 11, 22, 0, 0));
+    assert_eq!(interval.to_inclusivity(), BoundInclusivity::Exclusive);
+}
+
+#[test]
+fn bounded_absolute_interval_from_inclusive_week_range_reverse_order() {
+    let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    let from = NaiveDate::from_ymd_opt(2026, 2, 20).unwrap().week(Weekday::Tue);
+    let to = NaiveDate::from_ymd_opt(2026, 1, 7).unwrap().week(Weekday::Sat);
+    
+    let interval = BoundedAbsoluteInterval::from_inclusive_week_range(from, to, offset_tz).unwrap();
+    
+    assert_eq!(interval.from_time(), datetime(&Utc, 2026, 1, 2, 22, 0, 0));
+    assert_eq!(interval.from_inclusivity(), BoundInclusivity::Inclusive);
+    assert_eq!(interval.to_time(), datetime(&Utc, 2026, 2, 23, 22, 0, 0));
+    assert_eq!(interval.to_inclusivity(), BoundInclusivity::Exclusive);
+}
+
+#[test]
+fn bounded_absolute_interval_from_inclusive_iso_week_range() {
+    let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    let from = NaiveDate::from_ymd_opt(2026, 1, 7).unwrap().iso_week();
+    let to = NaiveDate::from_ymd_opt(2026, 3, 17).unwrap().iso_week();
+    
+    let interval = BoundedAbsoluteInterval::from_inclusive_iso_week_range(from, to, offset_tz).unwrap();
+    
+    assert_eq!(interval.from_time(), datetime(&Utc, 2026, 1, 4, 22, 0, 0));
+    assert_eq!(interval.from_inclusivity(), BoundInclusivity::Inclusive);
+    assert_eq!(interval.to_time(), datetime(&Utc, 2026, 3, 22, 22, 0, 0));
+    assert_eq!(interval.to_inclusivity(), BoundInclusivity::Exclusive);
+}
+
+#[test]
+fn bounded_absolute_interval_from_inclusive_iso_week_range_same_week() {
+    let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    let week = NaiveDate::from_ymd_opt(2026, 1, 7).unwrap().iso_week();
+
+    let interval = BoundedAbsoluteInterval::from_inclusive_iso_week_range(week, week, offset_tz).unwrap();
+
+    assert_eq!(interval.from_time(), datetime(&Utc, 2026, 1, 4, 22, 0, 0));
+    assert_eq!(interval.from_inclusivity(), BoundInclusivity::Inclusive);
+    assert_eq!(interval.to_time(), datetime(&Utc, 2026, 1, 11, 22, 0, 0));
+    assert_eq!(interval.to_inclusivity(), BoundInclusivity::Exclusive);
+}
+
+#[test]
+fn bounded_absolute_interval_from_inclusive_iso_week_range_reverse_order() {
+    let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    let from = NaiveDate::from_ymd_opt(2026, 3, 17).unwrap().iso_week();
+    let to = NaiveDate::from_ymd_opt(2026, 1, 7).unwrap().iso_week();
+    
+    let interval = BoundedAbsoluteInterval::from_inclusive_iso_week_range(from, to, offset_tz).unwrap();
+    
+    assert_eq!(interval.from_time(), datetime(&Utc, 2026, 1, 4, 22, 0, 0));
+    assert_eq!(interval.from_inclusivity(), BoundInclusivity::Inclusive);
+    assert_eq!(interval.to_time(), datetime(&Utc, 2026, 3, 22, 22, 0, 0));
+    assert_eq!(interval.to_inclusivity(), BoundInclusivity::Exclusive);
+}
+
+#[test]
+fn bounded_absolute_interval_week_from_iso_year_week() {
+    let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    let iso_week = BoundedAbsoluteInterval::week_from_iso_year_week(2026, 5, offset_tz).unwrap();
+    
+    assert_eq!(iso_week.from_time(), datetime(&Utc, 2026, 1, 25, 22, 0, 0));
+    assert_eq!(iso_week.from_inclusivity(), BoundInclusivity::Inclusive);
+    assert_eq!(iso_week.to_time(), datetime(&Utc, 2026, 2, 1, 22, 0, 0));
+    assert_eq!(iso_week.to_inclusivity(), BoundInclusivity::Exclusive);
+}
+
+#[test]
+fn bounded_absolute_interval_week_from_iso_year_week_invalid_week() {
+    let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    
+    assert_eq!(
+        BoundedAbsoluteInterval::week_from_iso_year_week(2026, 60, offset_tz),
+        Err(BoundedAbsoluteIntervalCreationError::DateOperationError),
+    );
 }
 
 #[test]

--- a/src/intervals/absolute_tests.rs
+++ b/src/intervals/absolute_tests.rs
@@ -1738,6 +1738,20 @@ fn bounded_absolute_interval_from_max_date() {
 }
 
 #[test]
+fn bounded_absolute_interval_day_in_days_from_today_future() {
+    let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    
+    let _interval = BoundedAbsoluteInterval::day_in_days_from_today(5, offset_tz).unwrap();
+}
+
+#[test]
+fn bounded_absolute_interval_day_in_days_from_today_past() {
+    let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    
+    let _interval = BoundedAbsoluteInterval::day_in_days_from_today(-3, offset_tz).unwrap();
+}
+
+#[test]
 fn bounded_absolute_unchecked_set_from() {
     let mut interval = BoundedAbsoluteInterval::new_with_inclusivity(
         date(&Utc, 2025, 1, 1),

--- a/src/intervals/absolute_tests.rs
+++ b/src/intervals/absolute_tests.rs
@@ -1977,6 +1977,61 @@ fn bounded_absolute_interval_from_inclusive_month_range_reverse_order() {
 }
 
 #[test]
+fn bounded_absolute_interval_from_year_common() {
+    let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    let year = BoundedAbsoluteInterval::from_year(2026, offset_tz).unwrap();
+    
+    assert_eq!(year.from_time(), datetime(&Utc, 2025, 12, 31, 22, 0, 0));
+    assert_eq!(year.from_inclusivity(), BoundInclusivity::Inclusive);
+    assert_eq!(year.to_time(), datetime(&Utc, 2026, 12, 31, 22, 0, 0));
+    assert_eq!(year.to_inclusivity(), BoundInclusivity::Exclusive);
+}
+
+#[test]
+fn bounded_absolute_interval_from_year_leap() {
+    let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    let year = BoundedAbsoluteInterval::from_year(2028, offset_tz).unwrap();
+    
+    assert_eq!(year.from_time(), datetime(&Utc, 2027, 12, 31, 22, 0, 0));
+    assert_eq!(year.from_inclusivity(), BoundInclusivity::Inclusive);
+    assert_eq!(year.to_time(), datetime(&Utc, 2028, 12, 31, 22, 0, 0));
+    assert_eq!(year.to_inclusivity(), BoundInclusivity::Exclusive);
+}
+
+#[test]
+fn bounded_absolute_interval_from_inclusive_year_range() {
+    let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    let years = BoundedAbsoluteInterval::from_inclusive_year_range(2025, 2030, offset_tz).unwrap();
+    
+    assert_eq!(years.from_time(), datetime(&Utc, 2024, 12, 31, 22, 0, 0));
+    assert_eq!(years.from_inclusivity(), BoundInclusivity::Inclusive);
+    assert_eq!(years.to_time(), datetime(&Utc, 2030, 12, 31, 22, 0, 0));
+    assert_eq!(years.to_inclusivity(), BoundInclusivity::Exclusive);
+}
+
+#[test]
+fn bounded_absolute_interval_from_inclusive_year_range_same_year() {
+    let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    let year = BoundedAbsoluteInterval::from_inclusive_year_range(2030, 2030, offset_tz).unwrap();
+    
+    assert_eq!(year.from_time(), datetime(&Utc, 2029, 12, 31, 22, 0, 0));
+    assert_eq!(year.from_inclusivity(), BoundInclusivity::Inclusive);
+    assert_eq!(year.to_time(), datetime(&Utc, 2030, 12, 31, 22, 0, 0));
+    assert_eq!(year.to_inclusivity(), BoundInclusivity::Exclusive);
+}
+
+#[test]
+fn bounded_absolute_interval_from_inclusive_year_range_reverse_order() {
+    let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    let years = BoundedAbsoluteInterval::from_inclusive_year_range(2030, 2025, offset_tz).unwrap();
+    
+    assert_eq!(years.from_time(), datetime(&Utc, 2024, 12, 31, 22, 0, 0));
+    assert_eq!(years.from_inclusivity(), BoundInclusivity::Inclusive);
+    assert_eq!(years.to_time(), datetime(&Utc, 2030, 12, 31, 22, 0, 0));
+    assert_eq!(years.to_inclusivity(), BoundInclusivity::Exclusive);
+}
+
+#[test]
 fn bounded_absolute_unchecked_set_from() {
     let mut interval = BoundedAbsoluteInterval::new_with_inclusivity(
         date(&Utc, 2025, 1, 1),

--- a/src/intervals/absolute_tests.rs
+++ b/src/intervals/absolute_tests.rs
@@ -2462,6 +2462,126 @@ fn half_bounded_absolute_interval_new_with_inclusivity() {
 }
 
 #[test]
+fn half_bounded_absolute_interval_since_date() {
+    let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    let from_first_of_may =
+        HalfBoundedAbsoluteInterval::since_date(NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(), offset_tz).unwrap();
+
+    assert_eq!(
+        from_first_of_may.reference_time(),
+        datetime(&Utc, 2026, 4, 30, 22, 0, 0)
+    );
+    assert_eq!(from_first_of_may.reference_inclusivity(), BoundInclusivity::Inclusive);
+    assert_eq!(from_first_of_may.opening_direction(), OpeningDirection::ToFuture);
+}
+
+#[test]
+fn half_bounded_absolute_interval_until_date() {
+    let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    let until_first_of_may =
+        HalfBoundedAbsoluteInterval::until_date(NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(), offset_tz).unwrap();
+
+    assert_eq!(
+        until_first_of_may.reference_time(),
+        datetime(&Utc, 2026, 4, 30, 22, 0, 0)
+    );
+    assert_eq!(until_first_of_may.reference_inclusivity(), BoundInclusivity::Exclusive);
+    assert_eq!(until_first_of_may.opening_direction(), OpeningDirection::ToPast);
+}
+
+#[test]
+fn half_bounded_absolute_interval_since_week() {
+    let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    let interval = HalfBoundedAbsoluteInterval::since_week(
+        NaiveDate::from_ymd_opt(2026, 5, 1).unwrap().week(Weekday::Mon),
+        offset_tz,
+    )
+    .unwrap();
+
+    assert_eq!(interval.reference_time(), datetime(&Utc, 2026, 4, 26, 22, 0, 0));
+    assert_eq!(interval.reference_inclusivity(), BoundInclusivity::Inclusive);
+    assert_eq!(interval.opening_direction(), OpeningDirection::ToFuture);
+}
+
+#[test]
+fn half_bounded_absolute_interval_until_week() {
+    let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    let interval = HalfBoundedAbsoluteInterval::until_week(
+        NaiveDate::from_ymd_opt(2026, 5, 1).unwrap().week(Weekday::Mon),
+        offset_tz,
+    )
+    .unwrap();
+
+    assert_eq!(interval.reference_time(), datetime(&Utc, 2026, 4, 26, 22, 0, 0));
+    assert_eq!(interval.reference_inclusivity(), BoundInclusivity::Exclusive);
+    assert_eq!(interval.opening_direction(), OpeningDirection::ToPast);
+}
+
+#[test]
+fn half_bounded_absolute_interval_since_iso_week() {
+    let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    let interval =
+        HalfBoundedAbsoluteInterval::since_iso_week(NaiveDate::from_ymd_opt(2026, 5, 1).unwrap().iso_week(), offset_tz)
+            .unwrap();
+
+    assert_eq!(interval.reference_time(), datetime(&Utc, 2026, 4, 26, 22, 0, 0));
+    assert_eq!(interval.reference_inclusivity(), BoundInclusivity::Inclusive);
+    assert_eq!(interval.opening_direction(), OpeningDirection::ToFuture);
+}
+
+#[test]
+fn half_bounded_absolute_interval_until_iso_week() {
+    let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    let interval =
+        HalfBoundedAbsoluteInterval::until_iso_week(NaiveDate::from_ymd_opt(2026, 5, 1).unwrap().iso_week(), offset_tz)
+            .unwrap();
+
+    assert_eq!(interval.reference_time(), datetime(&Utc, 2026, 4, 26, 22, 0, 0));
+    assert_eq!(interval.reference_inclusivity(), BoundInclusivity::Exclusive);
+    assert_eq!(interval.opening_direction(), OpeningDirection::ToPast);
+}
+
+#[test]
+fn half_bounded_absolute_interval_since_month() {
+    let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    let since_month = HalfBoundedAbsoluteInterval::since_month(NaiveMonth::new(2026, Month::March), offset_tz).unwrap();
+
+    assert_eq!(since_month.reference_time(), datetime(&Utc, 2026, 2, 28, 22, 0, 0));
+    assert_eq!(since_month.reference_inclusivity(), BoundInclusivity::Inclusive);
+    assert_eq!(since_month.opening_direction(), OpeningDirection::ToFuture);
+}
+
+#[test]
+fn half_bounded_absolute_interval_until_month() {
+    let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    let until_month = HalfBoundedAbsoluteInterval::until_month(NaiveMonth::new(2026, Month::March), offset_tz).unwrap();
+
+    assert_eq!(until_month.reference_time(), datetime(&Utc, 2026, 2, 28, 22, 0, 0));
+    assert_eq!(until_month.reference_inclusivity(), BoundInclusivity::Exclusive);
+    assert_eq!(until_month.opening_direction(), OpeningDirection::ToPast);
+}
+
+#[test]
+fn half_bounded_absolute_interval_since_year() {
+    let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    let since_year = HalfBoundedAbsoluteInterval::since_year(2026, offset_tz).unwrap();
+
+    assert_eq!(since_year.reference_time(), datetime(&Utc, 2025, 12, 31, 22, 0, 0));
+    assert_eq!(since_year.reference_inclusivity(), BoundInclusivity::Inclusive);
+    assert_eq!(since_year.opening_direction(), OpeningDirection::ToFuture);
+}
+
+#[test]
+fn half_bounded_absolute_interval_until_year() {
+    let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    let until_year = HalfBoundedAbsoluteInterval::until_year(2026, offset_tz).unwrap();
+
+    assert_eq!(until_year.reference_time(), datetime(&Utc, 2025, 12, 31, 22, 0, 0));
+    assert_eq!(until_year.reference_inclusivity(), BoundInclusivity::Exclusive);
+    assert_eq!(until_year.opening_direction(), OpeningDirection::ToPast);
+}
+
+#[test]
 fn half_bounded_absolute_interval_set_reference_time() {
     let mut interval = HalfBoundedAbsoluteInterval::new_with_inclusivity(
         date(&Utc, 2025, 1, 1),

--- a/src/intervals/absolute_tests.rs
+++ b/src/intervals/absolute_tests.rs
@@ -1,11 +1,12 @@
 use std::cmp::Ordering;
 use std::ops::Bound;
 
-use chrono::{DateTime, Datelike, Duration, FixedOffset, NaiveDate, Utc, Weekday};
+use chrono::{DateTime, Datelike, Duration, FixedOffset, Month, NaiveDate, Utc, Weekday};
 
 use crate::intervals::meta::{BoundInclusivity, HasBoundInclusivity, OpeningDirection};
 use crate::intervals::special::{EmptyInterval, UnboundedInterval};
 use crate::test_utils::{date, datetime};
+use crate::time::NaiveMonth;
 
 use super::absolute::*;
 
@@ -1913,6 +1914,66 @@ fn bounded_absolute_interval_week_from_iso_year_week_invalid_week() {
         BoundedAbsoluteInterval::week_from_iso_year_week(2026, 60, offset_tz),
         Err(BoundedAbsoluteIntervalCreationError::DateOperationError),
     );
+}
+
+#[test]
+fn bounded_absolute_interval_week_from_month() {
+    let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    
+    let month = BoundedAbsoluteInterval::from_month(
+        NaiveMonth::new(2026, Month::May),
+        offset_tz,
+    ).unwrap();
+    
+    assert_eq!(month.from_time(), datetime(&Utc, 2026, 4, 30, 22, 0, 0));
+    assert_eq!(month.from_inclusivity(), BoundInclusivity::Inclusive);
+    assert_eq!(month.to_time(), datetime(&Utc, 2026, 5, 31, 22, 0, 0));
+    assert_eq!(month.to_inclusivity(), BoundInclusivity::Exclusive);
+}
+
+#[test]
+fn bounded_absolute_interval_from_inclusive_month_range() {
+    let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    
+    let interval = BoundedAbsoluteInterval::from_inclusive_month_range(
+        NaiveMonth::new(2026, Month::January),
+        NaiveMonth::new(2026, Month::May),
+        offset_tz,
+    ).unwrap();
+    
+    assert_eq!(interval.from_time(), datetime(&Utc, 2025, 12, 31, 22, 0, 0));
+    assert_eq!(interval.from_inclusivity(), BoundInclusivity::Inclusive);
+    assert_eq!(interval.to_time(), datetime(&Utc, 2026, 5, 31, 22, 0, 0));
+    assert_eq!(interval.to_inclusivity(), BoundInclusivity::Exclusive);
+}
+
+#[test]
+fn bounded_absolute_interval_from_inclusive_month_range_same_month() {
+    let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    let month = NaiveMonth::new(2026, Month::May);
+    
+    let interval = BoundedAbsoluteInterval::from_inclusive_month_range(month, month, offset_tz).unwrap();
+    
+    assert_eq!(interval.from_time(), datetime(&Utc, 2026, 4, 30, 22, 0, 0));
+    assert_eq!(interval.from_inclusivity(), BoundInclusivity::Inclusive);
+    assert_eq!(interval.to_time(), datetime(&Utc, 2026, 5, 31, 22, 0, 0));
+    assert_eq!(interval.to_inclusivity(), BoundInclusivity::Exclusive);
+}
+
+#[test]
+fn bounded_absolute_interval_from_inclusive_month_range_reverse_order() {
+    let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    
+    let interval = BoundedAbsoluteInterval::from_inclusive_month_range(
+        NaiveMonth::new(2026, Month::May),
+        NaiveMonth::new(2026, Month::January),
+        offset_tz,
+    ).unwrap();
+    
+    assert_eq!(interval.from_time(), datetime(&Utc, 2025, 12, 31, 22, 0, 0));
+    assert_eq!(interval.from_inclusivity(), BoundInclusivity::Inclusive);
+    assert_eq!(interval.to_time(), datetime(&Utc, 2026, 5, 31, 22, 0, 0));
+    assert_eq!(interval.to_inclusivity(), BoundInclusivity::Exclusive);
 }
 
 #[test]

--- a/src/intervals/absolute_tests.rs
+++ b/src/intervals/absolute_tests.rs
@@ -1743,7 +1743,7 @@ fn bounded_absolute_interval_day_after_naive_duration_from_naive_date() {
     let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
     let interval = BoundedAbsoluteInterval::day_after_naive_duration_from_naive_date(
         NaiveDate::from_ymd_opt(2026, 4, 29).unwrap(),
-        NaiveDuration::days(5),
+        NaiveDuration::Days(5),
         offset_tz,
     )
     .unwrap();
@@ -1759,7 +1759,7 @@ fn bounded_absolute_interval_day_before_naive_duration_from_naive_date() {
     let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
     let interval = BoundedAbsoluteInterval::day_before_naive_duration_from_naive_date(
         NaiveDate::from_ymd_opt(2026, 4, 29).unwrap(),
-        NaiveDuration::days(5),
+        NaiveDuration::Days(5),
         offset_tz,
     )
     .unwrap();
@@ -1878,7 +1878,7 @@ fn bounded_absolute_interval_week_after_naive_duration_from_naive_date() {
     let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
     let week = BoundedAbsoluteInterval::week_after_naive_duration_from_naive_date(
         NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
-        NaiveDuration::weeks(Weekday::Mon, 2),
+        NaiveDuration::Weeks(Weekday::Mon, 2),
         Weekday::Mon,
         offset_tz,
     )
@@ -1895,7 +1895,7 @@ fn bounded_absolute_interval_week_before_naive_duration_from_naive_date() {
     let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
     let week = BoundedAbsoluteInterval::week_before_naive_duration_from_naive_date(
         NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
-        NaiveDuration::weeks(Weekday::Mon, 2),
+        NaiveDuration::Weeks(Weekday::Mon, 2),
         Weekday::Mon,
         offset_tz,
     )
@@ -1987,7 +1987,7 @@ fn bounded_absolute_interval_iso_week_after_naive_duration_from_naive_date() {
     let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
     let week = BoundedAbsoluteInterval::iso_week_after_naive_duration_from_naive_date(
         NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
-        NaiveDuration::weeks(Weekday::Mon, 2),
+        NaiveDuration::IsoWeeks(2),
         offset_tz,
     )
     .unwrap();
@@ -2003,7 +2003,7 @@ fn bounded_absolute_interval_iso_week_before_naive_duration_from_naive_date() {
     let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
     let week = BoundedAbsoluteInterval::iso_week_before_naive_duration_from_naive_date(
         NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
-        NaiveDuration::weeks(Weekday::Mon, 2),
+        NaiveDuration::IsoWeeks(2),
         offset_tz,
     )
     .unwrap();
@@ -2078,7 +2078,7 @@ fn bounded_absolute_interval_month_after_naive_duration_from_naive_date() {
     let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
     let month = BoundedAbsoluteInterval::month_after_naive_duration_from_naive_date(
         NaiveDate::from_ymd_opt(2026, 5, 5).unwrap(),
-        NaiveDuration::months(2),
+        NaiveDuration::Months(2),
         offset_tz,
     )
     .unwrap();
@@ -2094,7 +2094,7 @@ fn bounded_absolute_interval_month_before_naive_duration_from_naive_date() {
     let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
     let month = BoundedAbsoluteInterval::month_before_naive_duration_from_naive_date(
         NaiveDate::from_ymd_opt(2026, 5, 5).unwrap(),
-        NaiveDuration::months(2),
+        NaiveDuration::Months(2),
         offset_tz,
     )
     .unwrap();
@@ -2166,7 +2166,7 @@ fn bounded_absolute_interval_year_after_naive_duration_from_naive_date() {
 
     let year = BoundedAbsoluteInterval::year_after_naive_duration_from_naive_date(
         NaiveDate::from_ymd_opt(2026, 5, 5).unwrap(),
-        NaiveDuration::months(15),
+        NaiveDuration::Months(15),
         offset_tz,
     )
     .unwrap();
@@ -2183,7 +2183,7 @@ fn bounded_absolute_interval_year_before_naive_duration_from_naive_date() {
 
     let year = BoundedAbsoluteInterval::year_before_naive_duration_from_naive_date(
         NaiveDate::from_ymd_opt(2026, 5, 5).unwrap(),
-        NaiveDuration::months(15),
+        NaiveDuration::Months(15),
         offset_tz,
     )
     .unwrap();

--- a/src/intervals/absolute_tests.rs
+++ b/src/intervals/absolute_tests.rs
@@ -1,11 +1,11 @@
 use std::cmp::Ordering;
 use std::ops::Bound;
 
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Duration, FixedOffset, NaiveDate, Utc};
 
 use crate::intervals::meta::{BoundInclusivity, HasBoundInclusivity, OpeningDirection};
 use crate::intervals::special::{EmptyInterval, UnboundedInterval};
-use crate::test_utils::date;
+use crate::test_utils::{date, datetime};
 
 use super::absolute::*;
 
@@ -1711,6 +1711,30 @@ fn bounded_absolute_interval_new_with_inclusivity_swap() {
     assert_eq!(interval.to_time(), date(&Utc, 2025, 1, 2));
     assert_eq!(interval.from_inclusivity(), BoundInclusivity::Inclusive);
     assert_eq!(interval.to_inclusivity(), BoundInclusivity::Exclusive);
+}
+
+#[test]
+fn bounded_absolute_interval_from_date() {
+    let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    let date = NaiveDate::from_ymd_opt(2026, 1, 5).unwrap();
+    
+    let interval = BoundedAbsoluteInterval::from_date(date, offset_tz).unwrap();
+    
+    assert_eq!(interval.from_time(), datetime(&Utc, 2026, 1, 4, 22, 0, 0));
+    assert_eq!(interval.from_inclusivity(), BoundInclusivity::Inclusive);
+    assert_eq!(interval.to_time(), datetime(&Utc, 2026, 1, 5, 22, 0, 0));
+    assert_eq!(interval.to_inclusivity(), BoundInclusivity::Exclusive);
+}
+
+#[test]
+fn bounded_absolute_interval_from_max_date() {
+    let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    let date = NaiveDate::MAX;
+    
+    assert_eq!(
+        BoundedAbsoluteInterval::from_date(date, offset_tz),
+        Err(BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate)
+    );
 }
 
 #[test]

--- a/src/intervals/absolute_tests.rs
+++ b/src/intervals/absolute_tests.rs
@@ -1744,9 +1744,10 @@ fn bounded_absolute_interval_day_after_naive_duration_from_naive_date() {
     let interval = BoundedAbsoluteInterval::day_after_naive_duration_from_naive_date(
         NaiveDate::from_ymd_opt(2026, 4, 29).unwrap(),
         NaiveDuration::days(5),
-        offset_tz
-    ).unwrap();
-    
+        offset_tz,
+    )
+    .unwrap();
+
     assert_eq!(interval.from_time(), datetime(&Utc, 2026, 5, 3, 22, 0, 0));
     assert_eq!(interval.from_inclusivity(), BoundInclusivity::Inclusive);
     assert_eq!(interval.to_time(), datetime(&Utc, 2026, 5, 4, 22, 0, 0));
@@ -1759,9 +1760,10 @@ fn bounded_absolute_interval_day_before_naive_duration_from_naive_date() {
     let interval = BoundedAbsoluteInterval::day_before_naive_duration_from_naive_date(
         NaiveDate::from_ymd_opt(2026, 4, 29).unwrap(),
         NaiveDuration::days(5),
-        offset_tz
-    ).unwrap();
-    
+        offset_tz,
+    )
+    .unwrap();
+
     assert_eq!(interval.from_time(), datetime(&Utc, 2026, 4, 23, 22, 0, 0));
     assert_eq!(interval.from_inclusivity(), BoundInclusivity::Inclusive);
     assert_eq!(interval.to_time(), datetime(&Utc, 2026, 4, 24, 22, 0, 0));
@@ -1879,8 +1881,9 @@ fn bounded_absolute_interval_week_after_naive_duration_from_naive_date() {
         NaiveDuration::weeks(Weekday::Mon, 2),
         Weekday::Mon,
         offset_tz,
-    ).unwrap();
-    
+    )
+    .unwrap();
+
     assert_eq!(week.from_time(), datetime(&Utc, 2026, 5, 10, 22, 0, 0));
     assert_eq!(week.from_inclusivity(), BoundInclusivity::Inclusive);
     assert_eq!(week.to_time(), datetime(&Utc, 2026, 5, 17, 22, 0, 0));
@@ -1895,8 +1898,9 @@ fn bounded_absolute_interval_week_before_naive_duration_from_naive_date() {
         NaiveDuration::weeks(Weekday::Mon, 2),
         Weekday::Mon,
         offset_tz,
-    ).unwrap();
-    
+    )
+    .unwrap();
+
     assert_eq!(week.from_time(), datetime(&Utc, 2026, 4, 12, 22, 0, 0));
     assert_eq!(week.from_inclusivity(), BoundInclusivity::Inclusive);
     assert_eq!(week.to_time(), datetime(&Utc, 2026, 4, 19, 22, 0, 0));
@@ -1985,8 +1989,9 @@ fn bounded_absolute_interval_iso_week_after_naive_duration_from_naive_date() {
         NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
         NaiveDuration::weeks(Weekday::Mon, 2),
         offset_tz,
-    ).unwrap();
-    
+    )
+    .unwrap();
+
     assert_eq!(week.from_time(), datetime(&Utc, 2026, 5, 10, 22, 0, 0));
     assert_eq!(week.from_inclusivity(), BoundInclusivity::Inclusive);
     assert_eq!(week.to_time(), datetime(&Utc, 2026, 5, 17, 22, 0, 0));
@@ -2000,8 +2005,9 @@ fn bounded_absolute_interval_iso_week_before_naive_duration_from_naive_date() {
         NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
         NaiveDuration::weeks(Weekday::Mon, 2),
         offset_tz,
-    ).unwrap();
-    
+    )
+    .unwrap();
+
     assert_eq!(week.from_time(), datetime(&Utc, 2026, 4, 12, 22, 0, 0));
     assert_eq!(week.from_inclusivity(), BoundInclusivity::Inclusive);
     assert_eq!(week.to_time(), datetime(&Utc, 2026, 4, 19, 22, 0, 0));
@@ -2011,12 +2017,9 @@ fn bounded_absolute_interval_iso_week_before_naive_duration_from_naive_date() {
 #[test]
 fn bounded_absolute_interval_week_from_month() {
     let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
-    
-    let month = BoundedAbsoluteInterval::from_month(
-        NaiveMonth::new(2026, Month::May),
-        offset_tz,
-    ).unwrap();
-    
+
+    let month = BoundedAbsoluteInterval::from_month(NaiveMonth::new(2026, Month::May), offset_tz).unwrap();
+
     assert_eq!(month.from_time(), datetime(&Utc, 2026, 4, 30, 22, 0, 0));
     assert_eq!(month.from_inclusivity(), BoundInclusivity::Inclusive);
     assert_eq!(month.to_time(), datetime(&Utc, 2026, 5, 31, 22, 0, 0));
@@ -2026,13 +2029,14 @@ fn bounded_absolute_interval_week_from_month() {
 #[test]
 fn bounded_absolute_interval_from_inclusive_month_range() {
     let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
-    
+
     let interval = BoundedAbsoluteInterval::from_inclusive_month_range(
         NaiveMonth::new(2026, Month::January),
         NaiveMonth::new(2026, Month::May),
         offset_tz,
-    ).unwrap();
-    
+    )
+    .unwrap();
+
     assert_eq!(interval.from_time(), datetime(&Utc, 2025, 12, 31, 22, 0, 0));
     assert_eq!(interval.from_inclusivity(), BoundInclusivity::Inclusive);
     assert_eq!(interval.to_time(), datetime(&Utc, 2026, 5, 31, 22, 0, 0));
@@ -2043,9 +2047,9 @@ fn bounded_absolute_interval_from_inclusive_month_range() {
 fn bounded_absolute_interval_from_inclusive_month_range_same_month() {
     let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
     let month = NaiveMonth::new(2026, Month::May);
-    
+
     let interval = BoundedAbsoluteInterval::from_inclusive_month_range(month, month, offset_tz).unwrap();
-    
+
     assert_eq!(interval.from_time(), datetime(&Utc, 2026, 4, 30, 22, 0, 0));
     assert_eq!(interval.from_inclusivity(), BoundInclusivity::Inclusive);
     assert_eq!(interval.to_time(), datetime(&Utc, 2026, 5, 31, 22, 0, 0));
@@ -2055,13 +2059,14 @@ fn bounded_absolute_interval_from_inclusive_month_range_same_month() {
 #[test]
 fn bounded_absolute_interval_from_inclusive_month_range_reverse_order() {
     let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
-    
+
     let interval = BoundedAbsoluteInterval::from_inclusive_month_range(
         NaiveMonth::new(2026, Month::May),
         NaiveMonth::new(2026, Month::January),
         offset_tz,
-    ).unwrap();
-    
+    )
+    .unwrap();
+
     assert_eq!(interval.from_time(), datetime(&Utc, 2025, 12, 31, 22, 0, 0));
     assert_eq!(interval.from_inclusivity(), BoundInclusivity::Inclusive);
     assert_eq!(interval.to_time(), datetime(&Utc, 2026, 5, 31, 22, 0, 0));
@@ -2075,8 +2080,9 @@ fn bounded_absolute_interval_month_after_naive_duration_from_naive_date() {
         NaiveDate::from_ymd_opt(2026, 5, 5).unwrap(),
         NaiveDuration::months(2),
         offset_tz,
-    ).unwrap();
-    
+    )
+    .unwrap();
+
     assert_eq!(month.from_time(), datetime(&Utc, 2026, 6, 30, 22, 0, 0));
     assert_eq!(month.from_inclusivity(), BoundInclusivity::Inclusive);
     assert_eq!(month.to_time(), datetime(&Utc, 2026, 7, 31, 22, 0, 0));
@@ -2090,8 +2096,9 @@ fn bounded_absolute_interval_month_before_naive_duration_from_naive_date() {
         NaiveDate::from_ymd_opt(2026, 5, 5).unwrap(),
         NaiveDuration::months(2),
         offset_tz,
-    ).unwrap();
-    
+    )
+    .unwrap();
+
     assert_eq!(month.from_time(), datetime(&Utc, 2026, 2, 28, 22, 0, 0));
     assert_eq!(month.from_inclusivity(), BoundInclusivity::Inclusive);
     assert_eq!(month.to_time(), datetime(&Utc, 2026, 3, 31, 22, 0, 0));
@@ -2102,7 +2109,7 @@ fn bounded_absolute_interval_month_before_naive_duration_from_naive_date() {
 fn bounded_absolute_interval_from_year_common() {
     let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
     let year = BoundedAbsoluteInterval::from_year(2026, offset_tz).unwrap();
-    
+
     assert_eq!(year.from_time(), datetime(&Utc, 2025, 12, 31, 22, 0, 0));
     assert_eq!(year.from_inclusivity(), BoundInclusivity::Inclusive);
     assert_eq!(year.to_time(), datetime(&Utc, 2026, 12, 31, 22, 0, 0));
@@ -2113,7 +2120,7 @@ fn bounded_absolute_interval_from_year_common() {
 fn bounded_absolute_interval_from_year_leap() {
     let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
     let year = BoundedAbsoluteInterval::from_year(2028, offset_tz).unwrap();
-    
+
     assert_eq!(year.from_time(), datetime(&Utc, 2027, 12, 31, 22, 0, 0));
     assert_eq!(year.from_inclusivity(), BoundInclusivity::Inclusive);
     assert_eq!(year.to_time(), datetime(&Utc, 2028, 12, 31, 22, 0, 0));
@@ -2124,7 +2131,7 @@ fn bounded_absolute_interval_from_year_leap() {
 fn bounded_absolute_interval_from_inclusive_year_range() {
     let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
     let years = BoundedAbsoluteInterval::from_inclusive_year_range(2025, 2030, offset_tz).unwrap();
-    
+
     assert_eq!(years.from_time(), datetime(&Utc, 2024, 12, 31, 22, 0, 0));
     assert_eq!(years.from_inclusivity(), BoundInclusivity::Inclusive);
     assert_eq!(years.to_time(), datetime(&Utc, 2030, 12, 31, 22, 0, 0));
@@ -2135,7 +2142,7 @@ fn bounded_absolute_interval_from_inclusive_year_range() {
 fn bounded_absolute_interval_from_inclusive_year_range_same_year() {
     let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
     let year = BoundedAbsoluteInterval::from_inclusive_year_range(2030, 2030, offset_tz).unwrap();
-    
+
     assert_eq!(year.from_time(), datetime(&Utc, 2029, 12, 31, 22, 0, 0));
     assert_eq!(year.from_inclusivity(), BoundInclusivity::Inclusive);
     assert_eq!(year.to_time(), datetime(&Utc, 2030, 12, 31, 22, 0, 0));
@@ -2146,7 +2153,7 @@ fn bounded_absolute_interval_from_inclusive_year_range_same_year() {
 fn bounded_absolute_interval_from_inclusive_year_range_reverse_order() {
     let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
     let years = BoundedAbsoluteInterval::from_inclusive_year_range(2030, 2025, offset_tz).unwrap();
-    
+
     assert_eq!(years.from_time(), datetime(&Utc, 2024, 12, 31, 22, 0, 0));
     assert_eq!(years.from_inclusivity(), BoundInclusivity::Inclusive);
     assert_eq!(years.to_time(), datetime(&Utc, 2030, 12, 31, 22, 0, 0));
@@ -2156,13 +2163,14 @@ fn bounded_absolute_interval_from_inclusive_year_range_reverse_order() {
 #[test]
 fn bounded_absolute_interval_year_after_naive_duration_from_naive_date() {
     let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
-    
+
     let year = BoundedAbsoluteInterval::year_after_naive_duration_from_naive_date(
         NaiveDate::from_ymd_opt(2026, 5, 5).unwrap(),
         NaiveDuration::months(15),
         offset_tz,
-    ).unwrap();
-    
+    )
+    .unwrap();
+
     assert_eq!(year.from_time(), datetime(&Utc, 2026, 12, 31, 22, 0, 0));
     assert_eq!(year.from_inclusivity(), BoundInclusivity::Inclusive);
     assert_eq!(year.to_time(), datetime(&Utc, 2027, 12, 31, 22, 0, 0));
@@ -2172,13 +2180,14 @@ fn bounded_absolute_interval_year_after_naive_duration_from_naive_date() {
 #[test]
 fn bounded_absolute_interval_year_before_naive_duration_from_naive_date() {
     let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
-    
+
     let year = BoundedAbsoluteInterval::year_before_naive_duration_from_naive_date(
         NaiveDate::from_ymd_opt(2026, 5, 5).unwrap(),
         NaiveDuration::months(15),
         offset_tz,
-    ).unwrap();
-    
+    )
+    .unwrap();
+
     assert_eq!(year.from_time(), datetime(&Utc, 2024, 12, 31, 22, 0, 0));
     assert_eq!(year.from_inclusivity(), BoundInclusivity::Inclusive);
     assert_eq!(year.to_time(), datetime(&Utc, 2025, 12, 31, 22, 0, 0));

--- a/src/intervals/absolute_tests.rs
+++ b/src/intervals/absolute_tests.rs
@@ -1717,9 +1717,9 @@ fn bounded_absolute_interval_new_with_inclusivity_swap() {
 fn bounded_absolute_interval_from_date() {
     let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
     let date = NaiveDate::from_ymd_opt(2026, 1, 5).unwrap();
-    
+
     let interval = BoundedAbsoluteInterval::from_date(date, offset_tz).unwrap();
-    
+
     assert_eq!(interval.from_time(), datetime(&Utc, 2026, 1, 4, 22, 0, 0));
     assert_eq!(interval.from_inclusivity(), BoundInclusivity::Inclusive);
     assert_eq!(interval.to_time(), datetime(&Utc, 2026, 1, 5, 22, 0, 0));
@@ -1730,7 +1730,7 @@ fn bounded_absolute_interval_from_date() {
 fn bounded_absolute_interval_from_max_date() {
     let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
     let date = NaiveDate::MAX;
-    
+
     assert_eq!(
         BoundedAbsoluteInterval::from_date(date, offset_tz),
         Err(BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate)
@@ -1738,17 +1738,52 @@ fn bounded_absolute_interval_from_max_date() {
 }
 
 #[test]
-fn bounded_absolute_interval_day_in_days_from_today_future() {
+fn bounded_absolute_interval_from_inclusive_date_range() {
     let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
-    
-    let _interval = BoundedAbsoluteInterval::day_in_days_from_today(5, offset_tz).unwrap();
+    let from = NaiveDate::from_ymd_opt(2026, 1, 5).unwrap();
+    let to = NaiveDate::from_ymd_opt(2026, 1, 10).unwrap();
+
+    let interval = BoundedAbsoluteInterval::from_inclusive_date_range(from, to, offset_tz).unwrap();
+
+    assert_eq!(interval.from_time(), datetime(&Utc, 2026, 1, 4, 22, 0, 0));
+    assert_eq!(interval.from_inclusivity(), BoundInclusivity::Inclusive);
+    assert_eq!(interval.to_time(), datetime(&Utc, 2026, 1, 10, 22, 0, 0));
+    assert_eq!(interval.to_inclusivity(), BoundInclusivity::Exclusive);
 }
 
 #[test]
-fn bounded_absolute_interval_day_in_days_from_today_past() {
+fn bounded_absolute_interval_from_inclusive_date_range_max_from_and_to() {
     let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
-    
-    let _interval = BoundedAbsoluteInterval::day_in_days_from_today(-3, offset_tz).unwrap();
+
+    assert_eq!(
+        BoundedAbsoluteInterval::from_inclusive_date_range(NaiveDate::MAX, NaiveDate::MAX, offset_tz),
+        Err(BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate)
+    );
+}
+
+#[test]
+fn bounded_absolute_interval_from_inclusive_date_range_max_to() {
+    let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    let from = NaiveDate::from_ymd_opt(2026, 1, 1).unwrap();
+
+    assert_eq!(
+        BoundedAbsoluteInterval::from_inclusive_date_range(from, NaiveDate::MAX, offset_tz),
+        Err(BoundedAbsoluteIntervalCreationError::OutOfRangeEndDate)
+    );
+}
+
+#[test]
+fn bounded_absolute_interval_from_inclusive_date_range_reversed_order() {
+    let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    let from = NaiveDate::from_ymd_opt(2026, 1, 10).unwrap();
+    let to = NaiveDate::from_ymd_opt(2026, 1, 5).unwrap();
+
+    let interval = BoundedAbsoluteInterval::from_inclusive_date_range(from, to, offset_tz).unwrap();
+
+    assert_eq!(interval.from_time(), datetime(&Utc, 2026, 1, 4, 22, 0, 0));
+    assert_eq!(interval.from_inclusivity(), BoundInclusivity::Inclusive);
+    assert_eq!(interval.to_time(), datetime(&Utc, 2026, 1, 10, 22, 0, 0));
+    assert_eq!(interval.to_inclusivity(), BoundInclusivity::Exclusive);
 }
 
 #[test]

--- a/src/intervals/absolute_tests.rs
+++ b/src/intervals/absolute_tests.rs
@@ -1787,6 +1787,19 @@ fn bounded_absolute_interval_from_inclusive_date_range_reversed_order() {
 }
 
 #[test]
+fn bounded_absolute_interval_from_week() {
+    let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    let week = NaiveDate::from_ymd_opt(2026, 5, 1).unwrap().week(Weekday::Tue);
+
+    let week_interval = BoundedAbsoluteInterval::from_week(week, offset_tz).unwrap();
+
+    assert_eq!(week_interval.from_time(), datetime(&Utc, 2026, 4, 27, 22, 0, 0));
+    assert_eq!(week_interval.from_inclusivity(), BoundInclusivity::Inclusive);
+    assert_eq!(week_interval.to_time(), datetime(&Utc, 2026, 5, 4, 22, 0, 0));
+    assert_eq!(week_interval.to_inclusivity(), BoundInclusivity::Exclusive);
+}
+
+#[test]
 fn bounded_absolute_interval_from_inclusive_week_range() {
     let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
     let from = NaiveDate::from_ymd_opt(2026, 1, 7).unwrap().week(Weekday::Mon);
@@ -1825,6 +1838,19 @@ fn bounded_absolute_interval_from_inclusive_week_range_reverse_order() {
     assert_eq!(interval.from_inclusivity(), BoundInclusivity::Inclusive);
     assert_eq!(interval.to_time(), datetime(&Utc, 2026, 2, 23, 22, 0, 0));
     assert_eq!(interval.to_inclusivity(), BoundInclusivity::Exclusive);
+}
+
+#[test]
+fn bounded_absolute_interval_from_iso_week() {
+    let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    let iso_week = NaiveDate::from_ymd_opt(2026, 5, 1).unwrap().iso_week();
+
+    let iso_week_interval = BoundedAbsoluteInterval::from_iso_week(iso_week, offset_tz).unwrap();
+
+    assert_eq!(iso_week_interval.from_time(), datetime(&Utc, 2026, 4, 26, 22, 0, 0));
+    assert_eq!(iso_week_interval.from_inclusivity(), BoundInclusivity::Inclusive);
+    assert_eq!(iso_week_interval.to_time(), datetime(&Utc, 2026, 5, 3, 22, 0, 0));
+    assert_eq!(iso_week_interval.to_inclusivity(), BoundInclusivity::Exclusive);
 }
 
 #[test]

--- a/src/intervals/absolute_tests.rs
+++ b/src/intervals/absolute_tests.rs
@@ -6,7 +6,7 @@ use chrono::{DateTime, Datelike, Duration, FixedOffset, Month, NaiveDate, Utc, W
 use crate::intervals::meta::{BoundInclusivity, HasBoundInclusivity, OpeningDirection};
 use crate::intervals::special::{EmptyInterval, UnboundedInterval};
 use crate::test_utils::{date, datetime};
-use crate::time::NaiveMonth;
+use crate::time::{NaiveDuration, NaiveMonth};
 
 use super::absolute::*;
 
@@ -1739,6 +1739,36 @@ fn bounded_absolute_interval_from_max_date() {
 }
 
 #[test]
+fn bounded_absolute_interval_day_after_naive_duration_from_naive_date() {
+    let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    let interval = BoundedAbsoluteInterval::day_after_naive_duration_from_naive_date(
+        NaiveDate::from_ymd_opt(2026, 4, 29).unwrap(),
+        NaiveDuration::days(5),
+        offset_tz
+    ).unwrap();
+    
+    assert_eq!(interval.from_time(), datetime(&Utc, 2026, 5, 3, 22, 0, 0));
+    assert_eq!(interval.from_inclusivity(), BoundInclusivity::Inclusive);
+    assert_eq!(interval.to_time(), datetime(&Utc, 2026, 5, 4, 22, 0, 0));
+    assert_eq!(interval.to_inclusivity(), BoundInclusivity::Exclusive);
+}
+
+#[test]
+fn bounded_absolute_interval_day_before_naive_duration_from_naive_date() {
+    let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    let interval = BoundedAbsoluteInterval::day_before_naive_duration_from_naive_date(
+        NaiveDate::from_ymd_opt(2026, 4, 29).unwrap(),
+        NaiveDuration::days(5),
+        offset_tz
+    ).unwrap();
+    
+    assert_eq!(interval.from_time(), datetime(&Utc, 2026, 4, 23, 22, 0, 0));
+    assert_eq!(interval.from_inclusivity(), BoundInclusivity::Inclusive);
+    assert_eq!(interval.to_time(), datetime(&Utc, 2026, 4, 24, 22, 0, 0));
+    assert_eq!(interval.to_inclusivity(), BoundInclusivity::Exclusive);
+}
+
+#[test]
 fn bounded_absolute_interval_from_inclusive_date_range() {
     let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
     let from = NaiveDate::from_ymd_opt(2026, 1, 5).unwrap();
@@ -1842,6 +1872,38 @@ fn bounded_absolute_interval_from_inclusive_week_range_reverse_order() {
 }
 
 #[test]
+fn bounded_absolute_interval_week_after_naive_duration_from_naive_date() {
+    let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    let week = BoundedAbsoluteInterval::week_after_naive_duration_from_naive_date(
+        NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
+        NaiveDuration::weeks(Weekday::Mon, 2),
+        Weekday::Mon,
+        offset_tz,
+    ).unwrap();
+    
+    assert_eq!(week.from_time(), datetime(&Utc, 2026, 5, 10, 22, 0, 0));
+    assert_eq!(week.from_inclusivity(), BoundInclusivity::Inclusive);
+    assert_eq!(week.to_time(), datetime(&Utc, 2026, 5, 17, 22, 0, 0));
+    assert_eq!(week.to_inclusivity(), BoundInclusivity::Exclusive);
+}
+
+#[test]
+fn bounded_absolute_interval_week_before_naive_duration_from_naive_date() {
+    let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    let week = BoundedAbsoluteInterval::week_before_naive_duration_from_naive_date(
+        NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
+        NaiveDuration::weeks(Weekday::Mon, 2),
+        Weekday::Mon,
+        offset_tz,
+    ).unwrap();
+    
+    assert_eq!(week.from_time(), datetime(&Utc, 2026, 4, 12, 22, 0, 0));
+    assert_eq!(week.from_inclusivity(), BoundInclusivity::Inclusive);
+    assert_eq!(week.to_time(), datetime(&Utc, 2026, 4, 19, 22, 0, 0));
+    assert_eq!(week.to_inclusivity(), BoundInclusivity::Exclusive);
+}
+
+#[test]
 fn bounded_absolute_interval_from_iso_week() {
     let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
     let iso_week = NaiveDate::from_ymd_opt(2026, 5, 1).unwrap().iso_week();
@@ -1917,6 +1979,36 @@ fn bounded_absolute_interval_week_from_iso_year_week_invalid_week() {
 }
 
 #[test]
+fn bounded_absolute_interval_iso_week_after_naive_duration_from_naive_date() {
+    let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    let week = BoundedAbsoluteInterval::iso_week_after_naive_duration_from_naive_date(
+        NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
+        NaiveDuration::weeks(Weekday::Mon, 2),
+        offset_tz,
+    ).unwrap();
+    
+    assert_eq!(week.from_time(), datetime(&Utc, 2026, 5, 10, 22, 0, 0));
+    assert_eq!(week.from_inclusivity(), BoundInclusivity::Inclusive);
+    assert_eq!(week.to_time(), datetime(&Utc, 2026, 5, 17, 22, 0, 0));
+    assert_eq!(week.to_inclusivity(), BoundInclusivity::Exclusive);
+}
+
+#[test]
+fn bounded_absolute_interval_iso_week_before_naive_duration_from_naive_date() {
+    let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    let week = BoundedAbsoluteInterval::iso_week_before_naive_duration_from_naive_date(
+        NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
+        NaiveDuration::weeks(Weekday::Mon, 2),
+        offset_tz,
+    ).unwrap();
+    
+    assert_eq!(week.from_time(), datetime(&Utc, 2026, 4, 12, 22, 0, 0));
+    assert_eq!(week.from_inclusivity(), BoundInclusivity::Inclusive);
+    assert_eq!(week.to_time(), datetime(&Utc, 2026, 4, 19, 22, 0, 0));
+    assert_eq!(week.to_inclusivity(), BoundInclusivity::Exclusive);
+}
+
+#[test]
 fn bounded_absolute_interval_week_from_month() {
     let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
     
@@ -1977,6 +2069,36 @@ fn bounded_absolute_interval_from_inclusive_month_range_reverse_order() {
 }
 
 #[test]
+fn bounded_absolute_interval_month_after_naive_duration_from_naive_date() {
+    let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    let month = BoundedAbsoluteInterval::month_after_naive_duration_from_naive_date(
+        NaiveDate::from_ymd_opt(2026, 5, 5).unwrap(),
+        NaiveDuration::months(2),
+        offset_tz,
+    ).unwrap();
+    
+    assert_eq!(month.from_time(), datetime(&Utc, 2026, 6, 30, 22, 0, 0));
+    assert_eq!(month.from_inclusivity(), BoundInclusivity::Inclusive);
+    assert_eq!(month.to_time(), datetime(&Utc, 2026, 7, 31, 22, 0, 0));
+    assert_eq!(month.to_inclusivity(), BoundInclusivity::Exclusive);
+}
+
+#[test]
+fn bounded_absolute_interval_month_before_naive_duration_from_naive_date() {
+    let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    let month = BoundedAbsoluteInterval::month_before_naive_duration_from_naive_date(
+        NaiveDate::from_ymd_opt(2026, 5, 5).unwrap(),
+        NaiveDuration::months(2),
+        offset_tz,
+    ).unwrap();
+    
+    assert_eq!(month.from_time(), datetime(&Utc, 2026, 2, 28, 22, 0, 0));
+    assert_eq!(month.from_inclusivity(), BoundInclusivity::Inclusive);
+    assert_eq!(month.to_time(), datetime(&Utc, 2026, 3, 31, 22, 0, 0));
+    assert_eq!(month.to_inclusivity(), BoundInclusivity::Exclusive);
+}
+
+#[test]
 fn bounded_absolute_interval_from_year_common() {
     let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
     let year = BoundedAbsoluteInterval::from_year(2026, offset_tz).unwrap();
@@ -2029,6 +2151,38 @@ fn bounded_absolute_interval_from_inclusive_year_range_reverse_order() {
     assert_eq!(years.from_inclusivity(), BoundInclusivity::Inclusive);
     assert_eq!(years.to_time(), datetime(&Utc, 2030, 12, 31, 22, 0, 0));
     assert_eq!(years.to_inclusivity(), BoundInclusivity::Exclusive);
+}
+
+#[test]
+fn bounded_absolute_interval_year_after_naive_duration_from_naive_date() {
+    let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    
+    let year = BoundedAbsoluteInterval::year_after_naive_duration_from_naive_date(
+        NaiveDate::from_ymd_opt(2026, 5, 5).unwrap(),
+        NaiveDuration::months(15),
+        offset_tz,
+    ).unwrap();
+    
+    assert_eq!(year.from_time(), datetime(&Utc, 2026, 12, 31, 22, 0, 0));
+    assert_eq!(year.from_inclusivity(), BoundInclusivity::Inclusive);
+    assert_eq!(year.to_time(), datetime(&Utc, 2027, 12, 31, 22, 0, 0));
+    assert_eq!(year.to_inclusivity(), BoundInclusivity::Exclusive);
+}
+
+#[test]
+fn bounded_absolute_interval_year_before_naive_duration_from_naive_date() {
+    let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+    
+    let year = BoundedAbsoluteInterval::year_before_naive_duration_from_naive_date(
+        NaiveDate::from_ymd_opt(2026, 5, 5).unwrap(),
+        NaiveDuration::months(15),
+        offset_tz,
+    ).unwrap();
+    
+    assert_eq!(year.from_time(), datetime(&Utc, 2024, 12, 31, 22, 0, 0));
+    assert_eq!(year.from_inclusivity(), BoundInclusivity::Inclusive);
+    assert_eq!(year.to_time(), datetime(&Utc, 2025, 12, 31, 22, 0, 0));
+    assert_eq!(year.to_inclusivity(), BoundInclusivity::Exclusive);
 }
 
 #[test]

--- a/src/intervals/absolute_tests.rs
+++ b/src/intervals/absolute_tests.rs
@@ -1791,9 +1791,9 @@ fn bounded_absolute_interval_from_inclusive_week_range() {
     let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
     let from = NaiveDate::from_ymd_opt(2026, 1, 7).unwrap().week(Weekday::Mon);
     let to = NaiveDate::from_ymd_opt(2026, 3, 17).unwrap().week(Weekday::Sat);
-    
+
     let interval = BoundedAbsoluteInterval::from_inclusive_week_range(from, to, offset_tz).unwrap();
-    
+
     assert_eq!(interval.from_time(), datetime(&Utc, 2026, 1, 4, 22, 0, 0));
     assert_eq!(interval.from_inclusivity(), BoundInclusivity::Inclusive);
     assert_eq!(interval.to_time(), datetime(&Utc, 2026, 3, 20, 22, 0, 0));
@@ -1804,9 +1804,9 @@ fn bounded_absolute_interval_from_inclusive_week_range() {
 fn bounded_absolute_interval_from_inclusive_week_range_same_week() {
     let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
     let week = NaiveDate::from_ymd_opt(2026, 1, 7).unwrap().week(Weekday::Mon);
-    
+
     let interval = BoundedAbsoluteInterval::from_inclusive_week_range(week, week, offset_tz).unwrap();
-    
+
     assert_eq!(interval.from_time(), datetime(&Utc, 2026, 1, 4, 22, 0, 0));
     assert_eq!(interval.from_inclusivity(), BoundInclusivity::Inclusive);
     assert_eq!(interval.to_time(), datetime(&Utc, 2026, 1, 11, 22, 0, 0));
@@ -1818,9 +1818,9 @@ fn bounded_absolute_interval_from_inclusive_week_range_reverse_order() {
     let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
     let from = NaiveDate::from_ymd_opt(2026, 2, 20).unwrap().week(Weekday::Tue);
     let to = NaiveDate::from_ymd_opt(2026, 1, 7).unwrap().week(Weekday::Sat);
-    
+
     let interval = BoundedAbsoluteInterval::from_inclusive_week_range(from, to, offset_tz).unwrap();
-    
+
     assert_eq!(interval.from_time(), datetime(&Utc, 2026, 1, 2, 22, 0, 0));
     assert_eq!(interval.from_inclusivity(), BoundInclusivity::Inclusive);
     assert_eq!(interval.to_time(), datetime(&Utc, 2026, 2, 23, 22, 0, 0));
@@ -1832,9 +1832,9 @@ fn bounded_absolute_interval_from_inclusive_iso_week_range() {
     let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
     let from = NaiveDate::from_ymd_opt(2026, 1, 7).unwrap().iso_week();
     let to = NaiveDate::from_ymd_opt(2026, 3, 17).unwrap().iso_week();
-    
+
     let interval = BoundedAbsoluteInterval::from_inclusive_iso_week_range(from, to, offset_tz).unwrap();
-    
+
     assert_eq!(interval.from_time(), datetime(&Utc, 2026, 1, 4, 22, 0, 0));
     assert_eq!(interval.from_inclusivity(), BoundInclusivity::Inclusive);
     assert_eq!(interval.to_time(), datetime(&Utc, 2026, 3, 22, 22, 0, 0));
@@ -1859,9 +1859,9 @@ fn bounded_absolute_interval_from_inclusive_iso_week_range_reverse_order() {
     let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
     let from = NaiveDate::from_ymd_opt(2026, 3, 17).unwrap().iso_week();
     let to = NaiveDate::from_ymd_opt(2026, 1, 7).unwrap().iso_week();
-    
+
     let interval = BoundedAbsoluteInterval::from_inclusive_iso_week_range(from, to, offset_tz).unwrap();
-    
+
     assert_eq!(interval.from_time(), datetime(&Utc, 2026, 1, 4, 22, 0, 0));
     assert_eq!(interval.from_inclusivity(), BoundInclusivity::Inclusive);
     assert_eq!(interval.to_time(), datetime(&Utc, 2026, 3, 22, 22, 0, 0));
@@ -1872,7 +1872,7 @@ fn bounded_absolute_interval_from_inclusive_iso_week_range_reverse_order() {
 fn bounded_absolute_interval_week_from_iso_year_week() {
     let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
     let iso_week = BoundedAbsoluteInterval::week_from_iso_year_week(2026, 5, offset_tz).unwrap();
-    
+
     assert_eq!(iso_week.from_time(), datetime(&Utc, 2026, 1, 25, 22, 0, 0));
     assert_eq!(iso_week.from_inclusivity(), BoundInclusivity::Inclusive);
     assert_eq!(iso_week.to_time(), datetime(&Utc, 2026, 2, 1, 22, 0, 0));
@@ -1882,7 +1882,7 @@ fn bounded_absolute_interval_week_from_iso_year_week() {
 #[test]
 fn bounded_absolute_interval_week_from_iso_year_week_invalid_week() {
     let offset_tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
-    
+
     assert_eq!(
         BoundedAbsoluteInterval::week_from_iso_year_week(2026, 60, offset_tz),
         Err(BoundedAbsoluteIntervalCreationError::DateOperationError),

--- a/src/intervals/ops.rs
+++ b/src/intervals/ops.rs
@@ -38,6 +38,7 @@ pub mod remove_overlap;
 pub mod remove_overlap_or_gap;
 pub mod set_ops;
 pub mod shrink;
+pub mod split;
 
 tests! {
     mod abridge_tests;
@@ -58,6 +59,7 @@ tests! {
     mod remove_overlap_tests;
     mod set_ops_tests;
     mod shrink_tests;
+    mod split_tests;
 }
 
 inline_docs! {

--- a/src/intervals/ops/split.rs
+++ b/src/intervals/ops/split.rs
@@ -1,0 +1,310 @@
+//! Interval splittability
+//! 
+//! # Splitting by [`NaiveDuration`]
+//! 
+//! Practical approach for splitting an interval into common human naive durations, such as days and weeks.
+//! As explained in [`NaiveDuration`], days, weeks, etc. don't have a constant length.
+//! 
+//! You can produce a [`NaiveDurationSplit`] iterator by calling
+//! [`split_by_naive_duration`](NaiveDurationSplittable::split_by_naive_duration) which will split the interval
+//! in chronological order.
+//! 
+//! You can also produce a [`NaiveDurationRSplit`] iterator by calling
+//! [`rsplit_by_naive_duration`](NaiveDurationSplittable::rsplit_by_naive_duration) which will split the interval
+//! in reverse chronological order.
+//! 
+//! # Splitting by [`BoundedRelativeInterval`]
+//!
+//! Approach for splitting an interval into splits of precise duration using a [`BoundedRelativeInterval`]
+//! as a reference.
+//! 
+//! The provided [`IntervalSplit`] iterator, which is produced by
+//! [`split_by_interval`](IntervalSplittable::split_by_interval),
+//! will process this splitting approach.
+//! 
+//! Since this iterator takes a [`BoundedRelativeInterval`] which has [bound inclusivities](BoundInclusivity),
+//! the resulting splits will reflect the same bound inclusivities as the reference, out of convenience.
+
+// TODO UPDATE MODULE OUTER DOC
+
+use std::cmp::Ordering;
+
+use chrono::TimeZone;
+
+use crate::intervals::absolute::{BoundedAbsoluteInterval, HalfBoundedAbsoluteInterval, HasAbsoluteBounds};
+use crate::iter::intervals::split::NaiveDurationSplit;
+use crate::time::NaiveDuration;
+
+/// A [`NaiveDurationSplit`]'s result
+/// 
+/// Depending on the interval being split, it can result in different kinds of splits.
+/// 
+/// This enum groups them in one common structure so that it gives the caller the freedom to choose
+/// which to keep and which to filter out without having to consult the contained interval's data.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum NaiveDurationSplitResult {
+    /// Infinite split
+    /// 
+    /// This is the result of splitting a
+    /// [`HalfBoundedAbsoluteInterval`](crate::intervals::absolute::HalfBoundedAbsoluteInterval).
+    /// 
+    /// If we have a half-bounded interval, with its opening direction being
+    /// [`ToPast`](crate::intervals::meta::OpeningDirection::ToPast), then the [`NaiveDurationSplit`] iterator
+    /// will produce such a result spanning from the relevant time extremity, here minus infinity, to the closest
+    /// relevant representable point in time, in this case, [`NaiveDate::MIN`].
+    Infinite(HalfBoundedAbsoluteInterval),
+    /// Full split
+    /// 
+    /// A split of the expected duration.
+    Full(BoundedAbsoluteInterval),
+    /// Partial split
+    /// 
+    /// The remainder of the interval splitting process.
+    Partial(BoundedAbsoluteInterval),
+}
+
+impl NaiveDurationSplitResult {
+    /// Returns the content of the [`Infinite`](NaiveDurationSplitResult::Infinite) variant
+    ///
+    /// Consumes `self` and puts the content of the [`Infinite`](NaiveDurationSplitResult::Infinite) variant
+    /// in an [`Option`]. If instead `self` is another variant, the method returns [`None`].
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// # use chrono::{DateTime, Utc};
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, HalfBoundedAbsoluteInterval};
+    /// # use periodical::intervals::meta::OpeningDirection;
+    /// # use periodical::iter::intervals::split::NaiveDurationSplitResult;
+    /// let infinite_split = HalfBoundedAbsoluteInterval::new(
+    ///     "2026-01-01 00:00:00Z".parse::<DateTime<Utc>>()?,
+    ///     OpeningDirection::ToPast,
+    /// );
+    /// let infinite_result = NaiveDurationSplitResult::Infinite(infinite_split);
+    /// 
+    /// let full_split = BoundedAbsoluteInterval::new(
+    ///     "2026-01-01 00:00:00Z".parse::<DateTime<Utc>>()?,
+    ///     "2026-01-02 00:00:00Z".parse::<DateTime<Utc>>()?,
+    /// );
+    /// let full_result = NaiveDurationSplitResult::Full(full_split);
+    /// 
+    /// assert_eq!(infinite_result.infinite(), Some(infinite_split));
+    /// assert_eq!(full_result.infinite(), None);
+    /// # Ok::<(), chrono::format::ParseError>(())
+    /// ```
+    #[must_use]
+    pub fn infinite(self) -> Option<HalfBoundedAbsoluteInterval> {
+        match self {
+            Self::Infinite(x) => Some(x),
+            _ => None,
+        }
+    }
+
+    /// Returns the content of the [`Full`](NaiveDurationSplitResult::Full) variant
+    ///
+    /// Consumes `self` and puts the content of the [`Full`](NaiveDurationSplitResult::Full) variant
+    /// in an [`Option`]. If instead `self` is another variant, the method returns [`None`].
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// # use chrono::{DateTime, Utc};
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, HalfBoundedAbsoluteInterval};
+    /// # use periodical::intervals::meta::OpeningDirection;
+    /// # use periodical::iter::intervals::split::NaiveDurationSplitResult;
+    /// let full_split = BoundedAbsoluteInterval::new(
+    ///     "2026-01-01 00:00:00Z".parse::<DateTime<Utc>>()?,
+    ///     "2026-01-02 00:00:00Z".parse::<DateTime<Utc>>()?,
+    /// );
+    /// let full_result = NaiveDurationSplitResult::Full(full_split);
+    /// 
+    /// let infinite_split = HalfBoundedAbsoluteInterval::new(
+    ///     "2026-01-01 00:00:00Z".parse::<DateTime<Utc>>()?,
+    ///     OpeningDirection::ToPast,
+    /// );
+    /// let infinite_result = NaiveDurationSplitResult::Infinite(infinite_split);
+    /// 
+    /// assert_eq!(full_result.full(), Some(full_split));
+    /// assert_eq!(infinite_result.full(), None);
+    /// # Ok::<(), chrono::format::ParseError>(())
+    /// ```
+    #[must_use]
+    pub fn full(self) -> Option<BoundedAbsoluteInterval> {
+        match self {
+            Self::Full(x) => Some(x),
+            _ => None,
+        }
+    }
+
+    /// Returns the content of the [`Partial`](NaiveDurationSplitResult::Partial) variant
+    ///
+    /// Consumes `self` and puts the content of the [`Partial`](NaiveDurationSplitResult::Partial) variant
+    /// in an [`Option`]. If instead `self` is another variant, the method returns [`None`].
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// # use chrono::{DateTime, Utc};
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, HalfBoundedAbsoluteInterval};
+    /// # use periodical::intervals::meta::OpeningDirection;
+    /// # use periodical::iter::intervals::split::NaiveDurationSplitResult;
+    /// let partial_split = BoundedAbsoluteInterval::new(
+    ///     "2026-01-01 00:00:00Z".parse::<DateTime<Utc>>()?,
+    ///     "2026-01-02 00:00:00Z".parse::<DateTime<Utc>>()?,
+    /// );
+    /// let partial_result = NaiveDurationSplitResult::Partial(partial_split);
+    /// 
+    /// let infinite_split = HalfBoundedAbsoluteInterval::new(
+    ///     "2026-01-01 00:00:00Z".parse::<DateTime<Utc>>()?,
+    ///     OpeningDirection::ToPast,
+    /// );
+    /// let infinite_result = NaiveDurationSplitResult::Infinite(infinite_split);
+    /// 
+    /// assert_eq!(partial_result.partial(), Some(partial_split));
+    /// assert_eq!(infinite_result.partial(), None);
+    /// # Ok::<(), chrono::format::ParseError>(())
+    /// ```
+    #[must_use]
+    pub fn partial(self) -> Option<BoundedAbsoluteInterval> {
+        match self {
+            Self::Partial(x) => Some(x),
+            _ => None,
+        }
+    }
+
+    /// Returns whether it is of the [`Infinite`](NaiveDurationSplitResult::Infinite) variant
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// # use chrono::{DateTime, Utc};
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, HalfBoundedAbsoluteInterval};
+    /// # use periodical::intervals::meta::OpeningDirection;
+    /// # use periodical::iter::intervals::split::NaiveDurationSplitResult;
+    /// let infinite_split = HalfBoundedAbsoluteInterval::new(
+    ///     "2026-01-01 00:00:00Z".parse::<DateTime<Utc>>()?,
+    ///     OpeningDirection::ToPast,
+    /// );
+    /// let infinite_result = NaiveDurationSplitResult::Infinite(infinite_split);
+    /// 
+    /// let full_split = BoundedAbsoluteInterval::new(
+    ///     "2026-01-01 00:00:00Z".parse::<DateTime<Utc>>()?,
+    ///     "2026-01-02 00:00:00Z".parse::<DateTime<Utc>>()?,
+    /// );
+    /// let full_result = NaiveDurationSplitResult::Full(full_split);
+    /// 
+    /// assert!(infinite_result.is_infinite());
+    /// assert!(!full_result.is_infinite());
+    /// # Ok::<(), chrono::format::ParseError>(())
+    /// ```
+    #[must_use]
+    pub fn is_infinite(&self) -> bool {
+        matches!(self, Self::Infinite(_))
+    }
+
+    /// Returns whether it is of the [`Full`](NaiveDurationSplitResult::Full) variant
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// # use chrono::{DateTime, Utc};
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, HalfBoundedAbsoluteInterval};
+    /// # use periodical::intervals::meta::OpeningDirection;
+    /// # use periodical::iter::intervals::split::NaiveDurationSplitResult;
+    /// let full_split = BoundedAbsoluteInterval::new(
+    ///     "2026-01-01 00:00:00Z".parse::<DateTime<Utc>>()?,
+    ///     "2026-01-02 00:00:00Z".parse::<DateTime<Utc>>()?,
+    /// );
+    /// let full_result = NaiveDurationSplitResult::Full(full_split);
+    /// 
+    /// let infinite_split = HalfBoundedAbsoluteInterval::new(
+    ///     "2026-01-01 00:00:00Z".parse::<DateTime<Utc>>()?,
+    ///     OpeningDirection::ToPast,
+    /// );
+    /// let infinite_result = NaiveDurationSplitResult::Infinite(infinite_split);
+    /// 
+    /// assert!(full_result.is_full());
+    /// assert!(!infinite_result.is_full());
+    /// # Ok::<(), chrono::format::ParseError>(())
+    /// ```
+    #[must_use]
+    pub fn is_full(&self) -> bool {
+        matches!(self, Self::Full(_))
+    }
+
+    /// Returns whether it is of the [`Full`](NaiveDurationSplitResult::Full) variant
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// # use chrono::{DateTime, Utc};
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, HalfBoundedAbsoluteInterval};
+    /// # use periodical::intervals::meta::OpeningDirection;
+    /// # use periodical::iter::intervals::split::NaiveDurationSplitResult;
+    /// let partial_split = BoundedAbsoluteInterval::new(
+    ///     "2026-01-01 00:00:00Z".parse::<DateTime<Utc>>()?,
+    ///     "2026-01-02 00:00:00Z".parse::<DateTime<Utc>>()?,
+    /// );
+    /// let partial_result = NaiveDurationSplitResult::Partial(partial_split);
+    /// 
+    /// let infinite_split = HalfBoundedAbsoluteInterval::new(
+    ///     "2026-01-01 00:00:00Z".parse::<DateTime<Utc>>()?,
+    ///     OpeningDirection::ToPast,
+    /// );
+    /// let infinite_result = NaiveDurationSplitResult::Infinite(infinite_split);
+    /// 
+    /// assert!(partial_result.is_partial());
+    /// assert!(!infinite_result.is_partial());
+    /// # Ok::<(), chrono::format::ParseError>(())
+    /// ```
+    #[must_use]
+    pub fn is_partial(&self) -> bool {
+        matches!(self, Self::Partial(_))
+    }
+}
+
+impl PartialOrd for NaiveDurationSplitResult {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for NaiveDurationSplitResult {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match (self, other) {
+            (Self::Infinite(_), Self::Infinite(_))
+            | (Self::Full(_), Self::Full(_))
+            | (Self::Partial(_), Self::Partial(_)) => Ordering::Equal,
+            (Self::Infinite(_), _)
+            | (Self::Full(_), Self::Partial(_)) => Ordering::Greater,
+            (Self::Full(_), Self::Infinite(_))
+            | (Self::Partial(_), _) => Ordering::Less,
+        }
+    }
+}
+
+/// Dispatcher trait for the [`NaiveDurationSplit`] and [`NaiveDurationRSplit`] iterators
+pub trait NaiveDurationSplittable
+where
+    Self: Sized,
+{
+    fn split_by_naive_duration<Tz>(self, naive_duration: NaiveDuration, tz: Tz) -> NaiveDurationSplit<Tz>
+    where
+        Tz: TimeZone;
+
+    // fn rsplit_by_naive_duration<Tz>(self, naive_duration: NaiveDuration, tz: Tz) -> NaiveDurationRSplit<Tz>
+    // where
+    //     Tz: TimeZone,
+}
+
+impl<T> NaiveDurationSplittable for T
+where
+    T: HasAbsoluteBounds,
+{
+    fn split_by_naive_duration<Tz>(self, naive_duration: NaiveDuration, tz: Tz) -> NaiveDurationSplit<Tz>
+    where
+        Tz: TimeZone,
+    {
+        NaiveDurationSplit::new(&self, naive_duration, tz)
+    }
+}

--- a/src/intervals/ops/split.rs
+++ b/src/intervals/ops/split.rs
@@ -1,27 +1,27 @@
 //! Interval splittability
-//! 
+//!
 //! # Splitting by [`NaiveDuration`]
-//! 
+//!
 //! Practical approach for splitting an interval into common human naive durations, such as days and weeks.
 //! As explained in [`NaiveDuration`], days, weeks, etc. don't have a constant length.
-//! 
+//!
 //! You can produce a [`NaiveDurationSplit`] iterator by calling
 //! [`split_by_naive_duration`](NaiveDurationSplittable::split_by_naive_duration) which will split the interval
 //! in chronological order.
-//! 
+//!
 //! You can also produce a [`NaiveDurationRSplit`] iterator by calling
 //! [`rsplit_by_naive_duration`](NaiveDurationSplittable::rsplit_by_naive_duration) which will split the interval
 //! in reverse chronological order.
-//! 
+//!
 //! # Splitting by [`BoundedRelativeInterval`]
 //!
 //! Approach for splitting an interval into splits of precise duration using a [`BoundedRelativeInterval`]
 //! as a reference.
-//! 
+//!
 //! The provided [`IntervalSplit`] iterator, which is produced by
 //! [`split_by_interval`](IntervalSplittable::split_by_interval),
 //! will process this splitting approach.
-//! 
+//!
 //! Since this iterator takes a [`BoundedRelativeInterval`] which has [bound inclusivities](BoundInclusivity),
 //! the resulting splits will reflect the same bound inclusivities as the reference, out of convenience.
 
@@ -36,29 +36,29 @@ use crate::iter::intervals::split::NaiveDurationSplit;
 use crate::time::NaiveDuration;
 
 /// A [`NaiveDurationSplit`]'s result
-/// 
+///
 /// Depending on the interval being split, it can result in different kinds of splits.
-/// 
+///
 /// This enum groups them in one common structure so that it gives the caller the freedom to choose
 /// which to keep and which to filter out without having to consult the contained interval's data.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum NaiveDurationSplitResult {
     /// Infinite split
-    /// 
+    ///
     /// This is the result of splitting a
     /// [`HalfBoundedAbsoluteInterval`](crate::intervals::absolute::HalfBoundedAbsoluteInterval).
-    /// 
+    ///
     /// If we have a half-bounded interval, with its opening direction being
     /// [`ToPast`](crate::intervals::meta::OpeningDirection::ToPast), then the [`NaiveDurationSplit`] iterator
     /// will produce such a result spanning from the relevant time extremity, here minus infinity, to the closest
     /// relevant representable point in time, in this case, [`NaiveDate::MIN`].
     Infinite(HalfBoundedAbsoluteInterval),
     /// Full split
-    /// 
+    ///
     /// A split of the expected duration.
     Full(BoundedAbsoluteInterval),
     /// Partial split
-    /// 
+    ///
     /// The remainder of the interval splitting process.
     Partial(BoundedAbsoluteInterval),
 }
@@ -68,9 +68,9 @@ impl NaiveDurationSplitResult {
     ///
     /// Consumes `self` and puts the content of the [`Infinite`](NaiveDurationSplitResult::Infinite) variant
     /// in an [`Option`]. If instead `self` is another variant, the method returns [`None`].
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// # use chrono::{DateTime, Utc};
     /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, HalfBoundedAbsoluteInterval};
@@ -81,13 +81,13 @@ impl NaiveDurationSplitResult {
     ///     OpeningDirection::ToPast,
     /// );
     /// let infinite_result = NaiveDurationSplitResult::Infinite(infinite_split.clone());
-    /// 
+    ///
     /// let full_split = BoundedAbsoluteInterval::new(
     ///     "2026-01-01 00:00:00Z".parse::<DateTime<Utc>>()?,
     ///     "2026-01-02 00:00:00Z".parse::<DateTime<Utc>>()?,
     /// );
     /// let full_result = NaiveDurationSplitResult::Full(full_split);
-    /// 
+    ///
     /// assert_eq!(infinite_result.infinite(), Some(infinite_split));
     /// assert_eq!(full_result.infinite(), None);
     /// # Ok::<(), chrono::format::ParseError>(())
@@ -104,9 +104,9 @@ impl NaiveDurationSplitResult {
     ///
     /// Consumes `self` and puts the content of the [`Full`](NaiveDurationSplitResult::Full) variant
     /// in an [`Option`]. If instead `self` is another variant, the method returns [`None`].
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// # use chrono::{DateTime, Utc};
     /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, HalfBoundedAbsoluteInterval};
@@ -117,13 +117,13 @@ impl NaiveDurationSplitResult {
     ///     "2026-01-02 00:00:00Z".parse::<DateTime<Utc>>()?,
     /// );
     /// let full_result = NaiveDurationSplitResult::Full(full_split.clone());
-    /// 
+    ///
     /// let infinite_split = HalfBoundedAbsoluteInterval::new(
     ///     "2026-01-01 00:00:00Z".parse::<DateTime<Utc>>()?,
     ///     OpeningDirection::ToPast,
     /// );
     /// let infinite_result = NaiveDurationSplitResult::Infinite(infinite_split);
-    /// 
+    ///
     /// assert_eq!(full_result.full(), Some(full_split));
     /// assert_eq!(infinite_result.full(), None);
     /// # Ok::<(), chrono::format::ParseError>(())
@@ -140,9 +140,9 @@ impl NaiveDurationSplitResult {
     ///
     /// Consumes `self` and puts the content of the [`Partial`](NaiveDurationSplitResult::Partial) variant
     /// in an [`Option`]. If instead `self` is another variant, the method returns [`None`].
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// # use chrono::{DateTime, Utc};
     /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, HalfBoundedAbsoluteInterval};
@@ -153,13 +153,13 @@ impl NaiveDurationSplitResult {
     ///     "2026-01-02 00:00:00Z".parse::<DateTime<Utc>>()?,
     /// );
     /// let partial_result = NaiveDurationSplitResult::Partial(partial_split.clone());
-    /// 
+    ///
     /// let infinite_split = HalfBoundedAbsoluteInterval::new(
     ///     "2026-01-01 00:00:00Z".parse::<DateTime<Utc>>()?,
     ///     OpeningDirection::ToPast,
     /// );
     /// let infinite_result = NaiveDurationSplitResult::Infinite(infinite_split);
-    /// 
+    ///
     /// assert_eq!(partial_result.partial(), Some(partial_split));
     /// assert_eq!(infinite_result.partial(), None);
     /// # Ok::<(), chrono::format::ParseError>(())
@@ -173,9 +173,9 @@ impl NaiveDurationSplitResult {
     }
 
     /// Returns whether it is of the [`Infinite`](NaiveDurationSplitResult::Infinite) variant
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// # use chrono::{DateTime, Utc};
     /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, HalfBoundedAbsoluteInterval};
@@ -186,13 +186,13 @@ impl NaiveDurationSplitResult {
     ///     OpeningDirection::ToPast,
     /// );
     /// let infinite_result = NaiveDurationSplitResult::Infinite(infinite_split);
-    /// 
+    ///
     /// let full_split = BoundedAbsoluteInterval::new(
     ///     "2026-01-01 00:00:00Z".parse::<DateTime<Utc>>()?,
     ///     "2026-01-02 00:00:00Z".parse::<DateTime<Utc>>()?,
     /// );
     /// let full_result = NaiveDurationSplitResult::Full(full_split);
-    /// 
+    ///
     /// assert!(infinite_result.is_infinite());
     /// assert!(!full_result.is_infinite());
     /// # Ok::<(), chrono::format::ParseError>(())
@@ -203,9 +203,9 @@ impl NaiveDurationSplitResult {
     }
 
     /// Returns whether it is of the [`Full`](NaiveDurationSplitResult::Full) variant
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// # use chrono::{DateTime, Utc};
     /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, HalfBoundedAbsoluteInterval};
@@ -216,13 +216,13 @@ impl NaiveDurationSplitResult {
     ///     "2026-01-02 00:00:00Z".parse::<DateTime<Utc>>()?,
     /// );
     /// let full_result = NaiveDurationSplitResult::Full(full_split);
-    /// 
+    ///
     /// let infinite_split = HalfBoundedAbsoluteInterval::new(
     ///     "2026-01-01 00:00:00Z".parse::<DateTime<Utc>>()?,
     ///     OpeningDirection::ToPast,
     /// );
     /// let infinite_result = NaiveDurationSplitResult::Infinite(infinite_split);
-    /// 
+    ///
     /// assert!(full_result.is_full());
     /// assert!(!infinite_result.is_full());
     /// # Ok::<(), chrono::format::ParseError>(())
@@ -233,9 +233,9 @@ impl NaiveDurationSplitResult {
     }
 
     /// Returns whether it is of the [`Full`](NaiveDurationSplitResult::Full) variant
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// # use chrono::{DateTime, Utc};
     /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, HalfBoundedAbsoluteInterval};
@@ -246,13 +246,13 @@ impl NaiveDurationSplitResult {
     ///     "2026-01-02 00:00:00Z".parse::<DateTime<Utc>>()?,
     /// );
     /// let partial_result = NaiveDurationSplitResult::Partial(partial_split);
-    /// 
+    ///
     /// let infinite_split = HalfBoundedAbsoluteInterval::new(
     ///     "2026-01-01 00:00:00Z".parse::<DateTime<Utc>>()?,
     ///     OpeningDirection::ToPast,
     /// );
     /// let infinite_result = NaiveDurationSplitResult::Infinite(infinite_split);
-    /// 
+    ///
     /// assert!(partial_result.is_partial());
     /// assert!(!infinite_result.is_partial());
     /// # Ok::<(), chrono::format::ParseError>(())
@@ -275,10 +275,8 @@ impl Ord for NaiveDurationSplitResult {
             (Self::Infinite(_), Self::Infinite(_))
             | (Self::Full(_), Self::Full(_))
             | (Self::Partial(_), Self::Partial(_)) => Ordering::Equal,
-            (Self::Infinite(_), _)
-            | (Self::Full(_), Self::Partial(_)) => Ordering::Greater,
-            (Self::Full(_), Self::Infinite(_))
-            | (Self::Partial(_), _) => Ordering::Less,
+            (Self::Infinite(_), _) | (Self::Full(_), Self::Partial(_)) => Ordering::Greater,
+            (Self::Full(_), Self::Infinite(_)) | (Self::Partial(_), _) => Ordering::Less,
         }
     }
 }

--- a/src/intervals/ops/split.rs
+++ b/src/intervals/ops/split.rs
@@ -75,12 +75,12 @@ impl NaiveDurationSplitResult {
     /// # use chrono::{DateTime, Utc};
     /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, HalfBoundedAbsoluteInterval};
     /// # use periodical::intervals::meta::OpeningDirection;
-    /// # use periodical::iter::intervals::split::NaiveDurationSplitResult;
+    /// # use periodical::intervals::ops::split::NaiveDurationSplitResult;
     /// let infinite_split = HalfBoundedAbsoluteInterval::new(
     ///     "2026-01-01 00:00:00Z".parse::<DateTime<Utc>>()?,
     ///     OpeningDirection::ToPast,
     /// );
-    /// let infinite_result = NaiveDurationSplitResult::Infinite(infinite_split);
+    /// let infinite_result = NaiveDurationSplitResult::Infinite(infinite_split.clone());
     /// 
     /// let full_split = BoundedAbsoluteInterval::new(
     ///     "2026-01-01 00:00:00Z".parse::<DateTime<Utc>>()?,
@@ -111,12 +111,12 @@ impl NaiveDurationSplitResult {
     /// # use chrono::{DateTime, Utc};
     /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, HalfBoundedAbsoluteInterval};
     /// # use periodical::intervals::meta::OpeningDirection;
-    /// # use periodical::iter::intervals::split::NaiveDurationSplitResult;
+    /// # use periodical::intervals::ops::split::NaiveDurationSplitResult;
     /// let full_split = BoundedAbsoluteInterval::new(
     ///     "2026-01-01 00:00:00Z".parse::<DateTime<Utc>>()?,
     ///     "2026-01-02 00:00:00Z".parse::<DateTime<Utc>>()?,
     /// );
-    /// let full_result = NaiveDurationSplitResult::Full(full_split);
+    /// let full_result = NaiveDurationSplitResult::Full(full_split.clone());
     /// 
     /// let infinite_split = HalfBoundedAbsoluteInterval::new(
     ///     "2026-01-01 00:00:00Z".parse::<DateTime<Utc>>()?,
@@ -147,12 +147,12 @@ impl NaiveDurationSplitResult {
     /// # use chrono::{DateTime, Utc};
     /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, HalfBoundedAbsoluteInterval};
     /// # use periodical::intervals::meta::OpeningDirection;
-    /// # use periodical::iter::intervals::split::NaiveDurationSplitResult;
+    /// # use periodical::intervals::ops::split::NaiveDurationSplitResult;
     /// let partial_split = BoundedAbsoluteInterval::new(
     ///     "2026-01-01 00:00:00Z".parse::<DateTime<Utc>>()?,
     ///     "2026-01-02 00:00:00Z".parse::<DateTime<Utc>>()?,
     /// );
-    /// let partial_result = NaiveDurationSplitResult::Partial(partial_split);
+    /// let partial_result = NaiveDurationSplitResult::Partial(partial_split.clone());
     /// 
     /// let infinite_split = HalfBoundedAbsoluteInterval::new(
     ///     "2026-01-01 00:00:00Z".parse::<DateTime<Utc>>()?,
@@ -180,7 +180,7 @@ impl NaiveDurationSplitResult {
     /// # use chrono::{DateTime, Utc};
     /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, HalfBoundedAbsoluteInterval};
     /// # use periodical::intervals::meta::OpeningDirection;
-    /// # use periodical::iter::intervals::split::NaiveDurationSplitResult;
+    /// # use periodical::intervals::ops::split::NaiveDurationSplitResult;
     /// let infinite_split = HalfBoundedAbsoluteInterval::new(
     ///     "2026-01-01 00:00:00Z".parse::<DateTime<Utc>>()?,
     ///     OpeningDirection::ToPast,
@@ -210,7 +210,7 @@ impl NaiveDurationSplitResult {
     /// # use chrono::{DateTime, Utc};
     /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, HalfBoundedAbsoluteInterval};
     /// # use periodical::intervals::meta::OpeningDirection;
-    /// # use periodical::iter::intervals::split::NaiveDurationSplitResult;
+    /// # use periodical::intervals::ops::split::NaiveDurationSplitResult;
     /// let full_split = BoundedAbsoluteInterval::new(
     ///     "2026-01-01 00:00:00Z".parse::<DateTime<Utc>>()?,
     ///     "2026-01-02 00:00:00Z".parse::<DateTime<Utc>>()?,
@@ -240,7 +240,7 @@ impl NaiveDurationSplitResult {
     /// # use chrono::{DateTime, Utc};
     /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, HalfBoundedAbsoluteInterval};
     /// # use periodical::intervals::meta::OpeningDirection;
-    /// # use periodical::iter::intervals::split::NaiveDurationSplitResult;
+    /// # use periodical::intervals::ops::split::NaiveDurationSplitResult;
     /// let partial_split = BoundedAbsoluteInterval::new(
     ///     "2026-01-01 00:00:00Z".parse::<DateTime<Utc>>()?,
     ///     "2026-01-02 00:00:00Z".parse::<DateTime<Utc>>()?,

--- a/src/intervals/ops/split_tests.rs
+++ b/src/intervals/ops/split_tests.rs
@@ -1,0 +1,1 @@
+use super::split::*;

--- a/src/iter/intervals.rs
+++ b/src/iter/intervals.rs
@@ -21,6 +21,7 @@ pub mod layered_bounds;
 pub mod layered_bounds_set_ops;
 pub mod remove_empty;
 pub mod set_ops;
+pub mod split;
 pub mod united_bounds;
 
 tests! {
@@ -28,6 +29,7 @@ tests! {
     mod complement_tests;
     mod layered_bounds_tests;
     mod remove_empty_tests;
+    mod split_tests;
     mod united_bounds_tests;
 }
 

--- a/src/iter/intervals/split.rs
+++ b/src/iter/intervals/split.rs
@@ -1,5 +1,5 @@
 //! Interval splitting iterators
-//! 
+//!
 //! See [`intervals::ops::split`](crate::intervals::ops::split) for more details.
 
 use chrono::{NaiveDate, TimeZone, Utc};
@@ -63,7 +63,7 @@ where
                     self.exhausted = true;
                     return None;
                 };
-    
+
                 let CutResult::Cut(infinite_start, remaining_interval) = self.remaining_interval.cut_at(
                     new_end.with_timezone(&Utc),
                     CutType::new(BoundInclusivity::Exclusive, BoundInclusivity::Inclusive),
@@ -71,11 +71,11 @@ where
                     self.exhausted = true;
                     return None;
                 };
-    
+
                 self.remaining_interval = remaining_interval;
-                return Some(infinite_start);
+                Some(infinite_start)
             },
-            Some(start) => {
+            Some(start_bound) => {
                 todo!()
             },
         }

--- a/src/iter/intervals/split.rs
+++ b/src/iter/intervals/split.rs
@@ -1,0 +1,151 @@
+//! Interval splitting iterators
+//! 
+//! See [`intervals::ops::split`](crate::intervals::ops::split) for more details.
+
+use chrono::{NaiveDate, TimeZone, Utc};
+
+use crate::intervals::absolute::{
+    AbsoluteBounds, AbsoluteFiniteBound, AbsoluteStartBound, BoundedAbsoluteInterval, HalfBoundedAbsoluteInterval,
+    HasAbsoluteBounds,
+};
+use crate::intervals::meta::BoundInclusivity;
+use crate::intervals::ops::cut::{CutResult, CutType, Cuttable};
+use crate::intervals::relative::BoundedRelativeInterval;
+use crate::time::{NAIVE_TIME_MIDNIGHT, NaiveDuration, checked_add_naive_duration_to_naive_date};
+
+/// Split by [`NaiveDuration`] iterator
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct NaiveDurationSplit<Tz> {
+    remaining_interval: AbsoluteBounds,
+    naive_duration: NaiveDuration,
+    tz: Tz,
+    exhausted: bool,
+}
+
+impl<Tz> NaiveDurationSplit<Tz>
+where
+    Tz: TimeZone + Clone,
+{
+    #[must_use]
+    pub fn new<I>(interval: &I, naive_duration: NaiveDuration, tz: Tz) -> Self
+    where
+        I: HasAbsoluteBounds,
+    {
+        NaiveDurationSplit {
+            remaining_interval: interval.abs_bounds(),
+            naive_duration,
+            tz,
+            exhausted: false,
+        }
+    }
+}
+
+impl<Tz> Iterator for NaiveDurationSplit<Tz>
+where
+    Tz: TimeZone + Clone,
+{
+    type Item = AbsoluteBounds;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.exhausted {
+            return None;
+        }
+
+        match self.remaining_interval.start().finite() {
+            None => {
+                // If the start is infinite, then we create an interval that spans
+                // from -inf to midnight (in the given timezone) of the minimum supported date (excluded)
+                let Some(new_end) = NaiveDate::MIN
+                    .and_time(NAIVE_TIME_MIDNIGHT)
+                    .and_local_timezone(self.tz.clone())
+                    .earliest()
+                else {
+                    self.exhausted = true;
+                    return None;
+                };
+    
+                let CutResult::Cut(infinite_start, remaining_interval) = self.remaining_interval.cut_at(
+                    new_end.with_timezone(&Utc),
+                    CutType::new(BoundInclusivity::Exclusive, BoundInclusivity::Inclusive),
+                ) else {
+                    self.exhausted = true;
+                    return None;
+                };
+    
+                self.remaining_interval = remaining_interval;
+                return Some(infinite_start);
+            },
+            Some(start) => {
+                todo!()
+            },
+        }
+    }
+}
+
+// #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+// pub struct NaiveDurationRSplit<Tz> {
+//     remaining_interval: AbsoluteBounds,
+//     naive_duration: NaiveDuration,
+//     splitting_strategy: SplittingStrategy,
+//     tz: Tz,
+//     exhausted: bool,
+// }
+
+// impl<Tz> NaiveDurationRSplit<Tz>
+// where
+//     Tz: TimeZone,
+// {
+//     #[must_use]
+//     pub fn new<I>(interval: I, naive_duration: NaiveDuration, splitting_strategy: SplittingStrategy, tz: Tz) -> Self
+//     where
+//         I: HasAbsoluteBounds,
+//     {
+//         NaiveDurationRSplit {
+//             remaining_interval: interval.abs_bounds(),
+//             naive_duration,
+//             splitting_strategy,
+//             tz,
+//             exhausted: false,
+//         }
+//     }
+// }
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct IntervalSplit<I> {
+    remaining_interval: I,
+    splitter: BoundedRelativeInterval,
+}
+
+impl<I> IntervalSplit<I>
+where
+    I: HasAbsoluteBounds,
+{
+    #[must_use]
+    pub fn new(interval: I, splitter: BoundedRelativeInterval) -> Self {
+        IntervalSplit {
+            remaining_interval: interval,
+            splitter,
+        }
+    }
+}
+
+// #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+// pub struct IntervalRSplit<I> {
+//     remaining_interval: I,
+//     splitter: BoundedRelativeInterval,
+//     splitting_strategy: SplittingStrategy,
+// }
+
+// impl<I> IntervalRSplit<I>
+// where
+//     I: HasAbsoluteBounds,
+// {
+//     #[must_use]
+//     pub fn new(interval: I, splitter: BoundedRelativeInterval, splitting_strategy: SplittingStrategy) -> Self {
+//         IntervalRSplit {
+//             remaining_interval: interval,
+//             splitter,
+//             splitting_strategy,
+//         }
+//     }
+// }

--- a/src/iter/intervals/split_tests.rs
+++ b/src/iter/intervals/split_tests.rs
@@ -1,0 +1,1 @@
+use super::split::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,7 @@ pub mod ops;
 pub mod prelude;
 
 mod utils;
+mod time_constants;
 
 #[cfg(feature = "arbitrary")]
 mod arbitrary_impl;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,9 +59,9 @@ pub mod intervals;
 pub mod iter;
 pub mod ops;
 pub mod prelude;
+pub mod time;
 
 mod utils;
-mod time_constants;
 
 #[cfg(feature = "arbitrary")]
 mod arbitrary_impl;
@@ -71,4 +71,5 @@ use utils::tests;
 tests! {
     mod ops_tests;
     mod test_utils;
+    mod time_tests;
 }

--- a/src/time.rs
+++ b/src/time.rs
@@ -72,7 +72,7 @@ impl NaiveMonth {
     }
 
     /// Returns the first day of the month
-    /// 
+    ///
     /// Returns [`None`] if a [`NaiveDate`] cannot be created with the year and month, usually meaning
     /// the date is out of range, see [`NaiveDate::from_ymd_opt`].
     #[must_use]
@@ -81,7 +81,7 @@ impl NaiveMonth {
     }
 
     /// Returns the first day of the month
-    /// 
+    ///
     /// Returns [`None`] if a [`NaiveDate`] cannot be created with the year and month, usually meaning
     /// the date is out of range, see [`NaiveDate::from_ymd_opt`].
     #[must_use]
@@ -114,9 +114,8 @@ impl TryFrom<NaiveDate> for NaiveMonth {
     fn try_from(value: NaiveDate) -> Result<Self, Self::Error> {
         Ok(NaiveMonth::new(
             value.year(),
-            Month::try_from(
-                u8::try_from(value.month()).or(Err(NaiveMonthTryFromNaiveDateError))?
-            ).or(Err(NaiveMonthTryFromNaiveDateError))?,
+            Month::try_from(u8::try_from(value.month()).or(Err(NaiveMonthTryFromNaiveDateError))?)
+                .or(Err(NaiveMonthTryFromNaiveDateError))?,
         ))
     }
 }

--- a/src/time.rs
+++ b/src/time.rs
@@ -194,7 +194,7 @@ pub enum NaiveDuration {
     /// </div>
     Weeks(Weekday, i64),
     /// Naive ISO weeks duration
-    /// 
+    ///
     /// Equivalent to [`NaiveDuration::Weeks`] using [monday](Weekday::Mon) as the week start.
     IsoWeeks(i64),
     /// Naive months duration
@@ -352,11 +352,7 @@ pub fn checked_add_naive_duration_to_naive_date(
     }
 }
 
-fn checked_add_naive_weeks_to_naive_date(
-    week_start: Weekday,
-    amount: i64,
-    naive_date: NaiveDate,
-) -> Option<NaiveDate> {
+fn checked_add_naive_weeks_to_naive_date(week_start: Weekday, amount: i64, naive_date: NaiveDate) -> Option<NaiveDate> {
     // The absolute value of i64 is always storable in a u64, as we get rid of the sign bit
     let weeks = amount.unsigned_abs();
     // Since the now-removed sign bit isn't used, we can multiply the value by 2
@@ -472,11 +468,7 @@ pub fn checked_sub_naive_duration_to_naive_date(
     }
 }
 
-fn checked_sub_naive_weeks_to_naive_date(
-    week_start: Weekday,
-    amount: i64,
-    naive_date: NaiveDate,
-) -> Option<NaiveDate> {
+fn checked_sub_naive_weeks_to_naive_date(week_start: Weekday, amount: i64, naive_date: NaiveDate) -> Option<NaiveDate> {
     // The absolute value of i64 is always storable in a u64, as we get rid of the sign bit
     let weeks = amount.unsigned_abs();
     // Since the now-removed sign bit isn't used, we can multiply the value by 2

--- a/src/time.rs
+++ b/src/time.rs
@@ -4,7 +4,7 @@
 //!
 //! It also contains structures to represent naive durations, used for convenience.
 
-use chrono::{Datelike, NaiveDate, NaiveTime, Weekday};
+use chrono::{Datelike, NaiveDate, NaiveTime, TimeZone, Utc, Weekday};
 
 /// Number of days in a week
 pub const DAYS_IN_WEEK: u8 = 7;
@@ -19,6 +19,23 @@ pub const NAIVE_TIME_MIDNIGHT: NaiveTime =
 /// Represents noon as a [`NaiveTime`]
 pub const NAIVE_TIME_NOON: NaiveTime =
     NaiveTime::from_hms_opt(12, 0, 0).expect("Provided valid hour/minute/second (hms) combination");
+
+/// Gets the [`NaiveDate`] for today
+/// 
+/// # Examples
+/// 
+/// ```
+/// # use chrono::{Duration, FixedOffset, NaiveDate};
+/// # use periodical::time::naive_date_today;
+/// let tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap()
+/// let today_date = naive_date_today(tz);
+/// ```
+pub fn naive_date_today<Tz>(tz: &Tz) -> NaiveDate
+where
+    Tz: TimeZone,
+{
+    Utc::now().with_timezone(tz).date_naive()
+}
 
 /// A naive duration
 ///

--- a/src/time.rs
+++ b/src/time.rs
@@ -64,6 +64,28 @@ impl NaiveMonth {
     pub fn month(&self) -> Month {
         self.month
     }
+
+    /// Returns the first day of the month
+    /// 
+    /// Returns [`None`] if a [`NaiveDate`] cannot be created with the year and month, usually meaning
+    /// the date is out of range, see [`NaiveDate::from_ymd_opt`].
+    #[must_use]
+    pub fn checked_first_day(&self) -> Option<NaiveDate> {
+        NaiveDate::from_ymd_opt(self.year(), self.month().number_from_month(), 1)
+    }
+
+    /// Returns the first day of the month
+    /// 
+    /// Returns [`None`] if a [`NaiveDate`] cannot be created with the year and month, usually meaning
+    /// the date is out of range, see [`NaiveDate::from_ymd_opt`].
+    #[must_use]
+    pub fn checked_last_day(&self) -> Option<NaiveDate> {
+        NaiveDate::from_ymd_opt(
+            self.year(),
+            self.month().number_from_month(),
+            u32::from(self.month().num_days(self.year())?),
+        )
+    }
 }
 
 impl PartialOrd for NaiveMonth {

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,0 +1,410 @@
+//! Time-related values and structures
+//!
+//! This module contains constants to refer to midnight, noon, and other similar values.
+//!
+//! It also contains structures to represent naive durations, used for convenience.
+
+use chrono::{Datelike, NaiveDate, NaiveTime, Weekday};
+
+/// Number of days in a week
+pub const DAYS_IN_WEEK: u8 = 7;
+
+/// Number of months in a year
+pub const MONTHS_IN_YEAR: u8 = 12;
+
+/// Represents midnight as a [`NaiveTime`]
+pub const NAIVE_TIME_MIDNIGHT: NaiveTime =
+    NaiveTime::from_hms_opt(0, 0, 0).expect("Provided valid hour/minute/second (hms) combination");
+
+/// Represents noon as a [`NaiveTime`]
+pub const NAIVE_TIME_NOON: NaiveTime =
+    NaiveTime::from_hms_opt(12, 0, 0).expect("Provided valid hour/minute/second (hms) combination");
+
+/// A naive duration
+///
+/// Naive durations are similar to [`chrono::Duration`], but follow the same convention as
+/// other naive structures from the [`chrono`] crate.
+/// That is to say, it is not a precise amount, rather an abstract value that we often use
+/// in common speech.
+///
+/// For example, _a day_ is ambiguous. It can either refer to what we would call a _naive day_
+/// or a duration of 24 hours.
+/// A _naive day_ is often made of 24 hours, **but not always**, as if the day goes over
+/// a daylight savings time change, the _naive day_ could be made up of 25 hours or 23 hours.
+/// This is the key difference that requires the use of naive structures.
+///
+/// The goal of this structure is to represent naive durations that can be applied to naive structures
+/// such as [`NaiveDate`s](NaiveDate).
+///
+/// The reason [`NaiveDuration`]s can't be combined into one structure (as in you can't add
+/// two instances together) as the order in which they are applied to a naive structure such as [`NaiveDate`]
+/// matters.
+///
+/// In the future, this may be the object of a PR to the [`chrono`] crate and therefore may move.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum NaiveDuration {
+    /// Naive days duration
+    ///
+    /// Equivalent to [`chrono::Days`].
+    Days(i64),
+    /// Naive weeks duration
+    ///
+    /// The naive week is defined using a given [`Weekday`] as its start day.
+    ///
+    /// <div class="warning">
+    ///
+    /// Moving 2 weeks away **does not mean 14 naive days**.
+    ///
+    /// Instead, it refers to the second week to come after the current one.
+    ///
+    /// </div>
+    Weeks(Weekday, i64),
+    /// Naive months duration
+    ///
+    /// <div class="warning">
+    ///
+    /// Moving 1 month away **does not mean 30/31 naive days**.
+    ///
+    /// Instead, it refers to the first month to come after the current one.
+    ///
+    /// </div>
+    Months(i64),
+    /// Naive years duration
+    ///
+    /// <div class="warning">
+    ///
+    /// Moving 1 year away **does not mean 365 naive days**.
+    ///
+    /// Instead, it refers to the first year to come after the current one.
+    ///
+    /// </div>
+    Years(i32),
+}
+
+impl NaiveDuration {
+    /// Creates a [`NaiveDuration`] for N [days](NaiveDuration::Days)
+    #[must_use]
+    pub fn days(n: i64) -> Self {
+        Self::Days(n)
+    }
+
+    /// Creates a [`NaiveDuration`] for N [weeks](NaiveDuration::Weeks)
+    #[must_use]
+    pub fn weeks(week_start: Weekday, n: i64) -> Self {
+        Self::Weeks(week_start, n)
+    }
+
+    /// Creates a [`NaiveDuration`] for N [months](NaiveDuration::Months)
+    #[must_use]
+    pub fn months(n: i64) -> Self {
+        Self::Months(n)
+    }
+
+    /// Creates a [`NaiveDuration`] for N [years](NaiveDuration::Years)
+    #[must_use]
+    pub fn years(n: i32) -> Self {
+        Self::Years(n)
+    }
+
+    /// Whether the stored naive duration is zero
+    ///
+    /// This does **not** mean that after applying the [`NaiveDuration`] to another naive structure
+    /// will result in the same naive structure.
+    #[must_use]
+    pub fn is_zero(&self) -> bool {
+        match self {
+            Self::Days(x) | Self::Weeks(_, x) | Self::Months(x) => *x == 0,
+            Self::Years(x) => *x == 0,
+        }
+    }
+
+    /// Whether the stored naive duration is positive (`> 0`)
+    ///
+    /// This does **not** mean that after applying the [`NaiveDuration`] to another naive structure
+    /// will result in a naive structure that go after the original one.
+    #[must_use]
+    pub fn is_positive(&self) -> bool {
+        match self {
+            Self::Days(x) | Self::Weeks(_, x) | Self::Months(x) => x.is_positive(),
+            Self::Years(x) => x.is_positive(),
+        }
+    }
+
+    /// Whether the stored naive duration is negative (`< 0`)
+    ///
+    /// This does **not** mean that after applying the [`NaiveDuration`] to another naive structure
+    /// will result in a naive structure that precedes the original one.
+    #[must_use]
+    pub fn is_negative(&self) -> bool {
+        match self {
+            Self::Days(x) | Self::Weeks(_, x) | Self::Months(x) => x.is_negative(),
+            Self::Years(x) => x.is_negative(),
+        }
+    }
+}
+
+impl PartialOrd for NaiveDuration {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        match (self, other) {
+            (Self::Days(x), Self::Days(y))
+            | (Self::Weeks(_, x), Self::Weeks(_, y))
+            | (Self::Months(x), Self::Months(y)) => Some(x.cmp(y)),
+            (Self::Years(x), Self::Years(y)) => Some(x.cmp(y)),
+            _ => None,
+        }
+    }
+}
+
+/// Checked addition of a [`NaiveDuration`] to a [`NaiveDate`]
+///
+/// Adding [days](NaiveDuration::Days) to a [`NaiveDate`] simply uses [`NaiveDate::checked_add_days`].
+///
+/// For other naive durations, the standard behavior is to select the first day of the unit.
+/// For example, adding one [naive week](NaiveDuration::Weeks) will result in the date of the start
+/// of next week.
+///
+/// That also means that adding zero of some unit will result in the first day of that unit.
+/// For example, adding zero [naive years](NaiveDuration::Years) will result in the first January
+/// of the current year.
+///
+/// Returns [`None`] if the resulting date is out of range or if a duration to add during operations
+/// overflows its container.
+///
+/// For example, if a [naive months duration](NaiveDuration::Months) such that the number of months divided
+/// by the number of months in a year (12) is greater than what [i32] can store, i.e. [`i32::MAX`].
+#[must_use]
+pub fn checked_add_naive_duration_to_naive_date(
+    naive_date: NaiveDate,
+    naive_duration: NaiveDuration,
+) -> Option<NaiveDate> {
+    match naive_duration {
+        NaiveDuration::Days(x) => {
+            let duration = chrono::Days::new(x.unsigned_abs());
+
+            if x >= 0 {
+                naive_date.checked_add_days(duration)
+            } else {
+                naive_date.checked_sub_days(duration)
+            }
+        },
+        NaiveDuration::Weeks(week_start, x) => {
+            // The absolute value of i64 is always storable in a u64, as we get rid of the sign bit
+            let weeks = x.unsigned_abs();
+            // Since the now-removed sign bit isn't used, we can multiply the value by 2
+            // so that we do make use of this last bit (as *2 = <<1).
+            // We use the checked multiplication so that we still prevent potential panics, even though
+            // they should not happen.
+            let double_weeks = chrono::Days::new(weeks.checked_mul(2)?);
+            // Shadow the weeks variable in order to store it in the structure chrono expects
+            let weeks = chrono::Days::new(weeks);
+
+            let week_first_day = naive_date.week(week_start).checked_first_day()?;
+
+            // (3*2 + 1)*weeks = 7*weeks = weeks in days
+            if x >= 0 {
+                week_first_day
+                    .checked_add_days(double_weeks)?
+                    .checked_add_days(double_weeks)?
+                    .checked_add_days(double_weeks)?
+                    .checked_add_days(weeks)
+            } else {
+                week_first_day
+                    .checked_sub_days(double_weeks)?
+                    .checked_sub_days(double_weeks)?
+                    .checked_sub_days(double_weeks)?
+                    .checked_sub_days(weeks)
+            }
+        },
+        NaiveDuration::Months(x) => {
+            // How many years in the given amount of months
+            let mut years_offset = x.unsigned_abs() / u64::from(MONTHS_IN_YEAR);
+            // Removing the extra years in the duration, how many months are we actually offset from?
+            let months_offset = u32::try_from(x.unsigned_abs() % u64::from(MONTHS_IN_YEAR)).ok()?;
+
+            if x >= 0 {
+                // Checks if after applying the month offset we get an additional year
+                if months_offset > (u32::from(MONTHS_IN_YEAR) - naive_date.month()) {
+                    years_offset += 1;
+                }
+
+                // Since for the first part of the computation we use 0-based months, we add 1 at the end
+                let month = ((naive_date.month0() + months_offset) % u32::from(MONTHS_IN_YEAR)) + 1;
+
+                NaiveDate::from_ymd_opt(
+                    naive_date.year().checked_add(i32::try_from(years_offset).ok()?)?,
+                    month,
+                    1,
+                )
+            } else {
+                // Checks if after applying the month offset we get an additional year
+                // We use 0-based months to simplify the check
+                if months_offset > naive_date.month0() {
+                    years_offset += 1;
+                }
+
+                let month = (
+                    (
+                        // modulo subtraction
+                        naive_date.month0()
+                        + u32::from(MONTHS_IN_YEAR) // we add 12 to the 0-based month to prevent underflow
+                        - months_offset
+                        // subtract the computed offset
+                    ) % u32::from(MONTHS_IN_YEAR)
+                    // get the actual 0-based month
+                ) + 1; // convert to 1-based month
+
+                NaiveDate::from_ymd_opt(
+                    naive_date.year().checked_sub(i32::try_from(years_offset).ok()?)?,
+                    month,
+                    1,
+                )
+            }
+        },
+        NaiveDuration::Years(x) => NaiveDate::from_ymd_opt(naive_date.year().checked_add(x)?, 1, 1),
+    }
+}
+
+/// Checked subtraction of a [`NaiveDuration`] to a [`NaiveDate`]
+///
+/// Subtracting [days](NaiveDuration::Days) to a [`NaiveDate`] simply uses [`NaiveDate::checked_sub_days`].
+///
+/// For other naive durations, the standard behavior is to select the first day of the unit.
+/// For example, subtracting one [naive week](NaiveDuration::Weeks) will result in the date of the start
+/// of the previous week.
+///
+/// That also means that subtracting zero of some unit will result in the first day of that unit.
+/// For example, subtracting zero [naive years](NaiveDuration::Years) will result in the first January
+/// of the current year.
+///
+/// Returns [`None`] if the resulting date is out of range or if a duration to subtract during operations
+/// overflows its container.
+///
+/// For example, if a [naive months duration](NaiveDuration::Months) such that the number of months divided
+/// by the number of months in a year (12) is greater than what [i32] can store, i.e. [`i32::MAX`].
+#[must_use]
+pub fn checked_sub_naive_duration_to_naive_date(
+    naive_date: NaiveDate,
+    naive_duration: NaiveDuration,
+) -> Option<NaiveDate> {
+    // Most add/sub operations are reversed from `checked_add_naive_duration_to_naive_date`
+    // We _could_ just make this function a wrapper of the aforementioned one, but that would require
+    // flipping the sign of the stored naive duration quantity, which can't be done "safely" as
+    // abs(i32::MIN) > abs(i32::MAX)
+    match naive_duration {
+        NaiveDuration::Days(x) => {
+            let duration = chrono::Days::new(x.unsigned_abs());
+
+            if x >= 0 {
+                naive_date.checked_sub_days(duration)
+            } else {
+                naive_date.checked_add_days(duration)
+            }
+        },
+        NaiveDuration::Weeks(week_start, x) => {
+            // The absolute value of i64 is always storable in a u64, as we get rid of the sign bit
+            let weeks = x.unsigned_abs();
+            // Since the now-removed sign bit isn't used, we can multiply the value by 2
+            // so that we do make use of this last bit (as *2 = <<1).
+            // We use the checked multiplication so that we still prevent potential panics, even though
+            // they should not happen.
+            let double_weeks = chrono::Days::new(weeks.checked_mul(2)?);
+            // Shadow the weeks variable in order to store it in the structure chrono expects
+            let weeks = chrono::Days::new(weeks);
+
+            let week_first_day = naive_date.week(week_start).checked_first_day()?;
+
+            // (3*2 + 1)*weeks = 7*weeks = weeks in days
+            if x >= 0 {
+                week_first_day
+                    .checked_sub_days(double_weeks)?
+                    .checked_sub_days(double_weeks)?
+                    .checked_sub_days(double_weeks)?
+                    .checked_sub_days(weeks)
+            } else {
+                week_first_day
+                    .checked_add_days(double_weeks)?
+                    .checked_add_days(double_weeks)?
+                    .checked_add_days(double_weeks)?
+                    .checked_add_days(weeks)
+            }
+        },
+        NaiveDuration::Months(x) => {
+            // How many years in the given amount of months
+            let mut years_offset = x.unsigned_abs() / u64::from(MONTHS_IN_YEAR);
+            // Removing the extra years in the duration, how many months are we actually offset from?
+            let months_offset = u32::try_from(x.unsigned_abs() % u64::from(MONTHS_IN_YEAR)).ok()?;
+
+            if x >= 0 {
+                // Checks if after applying the month offset we get an additional year
+                // We use 0-based months to simplify the check
+                if months_offset > naive_date.month0() {
+                    years_offset += 1;
+                }
+
+                let month = (
+                    (
+                        // modulo subtraction
+                        naive_date.month0()
+                        + u32::from(MONTHS_IN_YEAR) // we add 12 to the 0-based month to prevent underflow
+                        - months_offset
+                        // subtract the computed offset
+                    ) % u32::from(MONTHS_IN_YEAR)
+                    // get the actual 0-based month
+                ) + 1; // convert to 1-based month
+
+                NaiveDate::from_ymd_opt(
+                    naive_date.year().checked_sub(i32::try_from(years_offset).ok()?)?,
+                    month,
+                    1,
+                )
+            } else {
+                // Checks if after applying the month offset we get an additional year
+                if months_offset > (u32::from(MONTHS_IN_YEAR) - naive_date.month()) {
+                    years_offset += 1;
+                }
+
+                // Since for the first part of the computation we use 0-based months, we add 1 at the end
+                let month = ((naive_date.month0() + months_offset) % u32::from(MONTHS_IN_YEAR)) + 1;
+
+                NaiveDate::from_ymd_opt(
+                    naive_date.year().checked_add(i32::try_from(years_offset).ok()?)?,
+                    month,
+                    1,
+                )
+            }
+        },
+        NaiveDuration::Years(x) => NaiveDate::from_ymd_opt(naive_date.year().checked_sub(x)?, 1, 1),
+    }
+}
+
+/// Sequentially applies [`checked_add_naive_duration_to_naive_date`] on a [`NaiveDate`]
+///
+/// Returns [`None`] as soon as one [`checked_add_naive_duration_to_naive_date`] returns [`None`].
+///
+/// Returns [`None`] if the given list of [`NaiveDuration`s](NaiveDuration) is empty.
+#[must_use]
+pub fn checked_add_naive_durations_to_naive_date<I>(naive_date: NaiveDate, naive_durations: I) -> Option<NaiveDate>
+where
+    I: IntoIterator<Item = NaiveDuration>,
+{
+    naive_durations
+        .into_iter()
+        .try_fold(naive_date, checked_add_naive_duration_to_naive_date)
+}
+
+/// Sequentially applies [`checked_sub_naive_duration_to_naive_date`] on a [`NaiveDate`]
+///
+/// Returns [`None`] as soon as one [`checked_sub_naive_duration_to_naive_date`] returns [`None`].
+///
+/// Returns [`None`] if the given list of [`NaiveDuration`s](NaiveDuration) is empty.
+#[must_use]
+pub fn checked_sub_naive_durations_to_naive_date<I>(naive_date: NaiveDate, naive_durations: I) -> Option<NaiveDate>
+where
+    I: IntoIterator<Item = NaiveDuration>,
+{
+    naive_durations
+        .into_iter()
+        .try_fold(naive_date, checked_sub_naive_duration_to_naive_date)
+}
+
+// TODO: checked add/sub for naive weeks, naive months, etc.

--- a/src/time.rs
+++ b/src/time.rs
@@ -5,6 +5,8 @@
 //! It also contains structures to represent naive durations, used for convenience.
 
 use std::cmp::Ordering;
+use std::error::Error;
+use std::fmt::Display;
 
 use chrono::{Datelike, Month, NaiveDate, NaiveTime, TimeZone, Utc, Weekday};
 
@@ -98,9 +100,33 @@ impl Ord for NaiveMonth {
     fn cmp(&self, other: &Self) -> Ordering {
         self.year()
             .cmp(&other.year())
-            .then_with(|| self.month().cmp(&self.month()))
+            .then_with(|| self.month().cmp(&other.month()))
     }
 }
+
+impl TryFrom<NaiveDate> for NaiveMonth {
+    type Error = NaiveMonthTryFromNaiveDateError;
+
+    fn try_from(value: NaiveDate) -> Result<Self, Self::Error> {
+        Ok(NaiveMonth::new(
+            value.year(),
+            Month::try_from(
+                u8::try_from(value.month()).or(Err(NaiveMonthTryFromNaiveDateError))?
+            ).or(Err(NaiveMonthTryFromNaiveDateError))?,
+        ))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct NaiveMonthTryFromNaiveDateError;
+
+impl Display for NaiveMonthTryFromNaiveDateError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Error when trying to convert a `NaiveDate` into a `NaiveMonth`")
+    }
+}
+
+impl Error for NaiveMonthTryFromNaiveDateError {}
 
 /// A naive duration
 ///

--- a/src/time.rs
+++ b/src/time.rs
@@ -21,9 +21,9 @@ pub const NAIVE_TIME_NOON: NaiveTime =
     NaiveTime::from_hms_opt(12, 0, 0).expect("Provided valid hour/minute/second (hms) combination");
 
 /// Gets the [`NaiveDate`] for today
-/// 
+///
 /// # Examples
-/// 
+///
 /// ```
 /// # use chrono::{Duration, FixedOffset, NaiveDate};
 /// # use periodical::time::naive_date_today;

--- a/src/time.rs
+++ b/src/time.rs
@@ -27,8 +27,8 @@ pub const NAIVE_TIME_NOON: NaiveTime =
 /// ```
 /// # use chrono::{Duration, FixedOffset, NaiveDate};
 /// # use periodical::time::naive_date_today;
-/// let tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap()
-/// let today_date = naive_date_today(tz);
+/// let tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+/// let today_date = naive_date_today(&tz);
 /// ```
 pub fn naive_date_today<Tz>(tz: &Tz) -> NaiveDate
 where

--- a/src/time.rs
+++ b/src/time.rs
@@ -33,10 +33,33 @@ pub const NAIVE_TIME_NOON: NaiveTime =
 /// # Examples
 ///
 /// ```
+/// # use std::num::TryFromIntError;
 /// # use chrono::{Duration, FixedOffset, NaiveDate};
 /// # use periodical::time::naive_date_today;
-/// let tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into().unwrap()).unwrap();
+/// #
+/// # #[derive(Debug)]
+/// # struct FixedOffsetError;
+/// #
+/// # #[derive(Debug)]
+/// # enum ExampleErr {
+/// #     TryFromIntError(TryFromIntError),
+/// #     FixedOffsetError(FixedOffsetError),
+/// # }
+/// #
+/// # impl From<TryFromIntError> for ExampleErr {
+/// #     fn from(value: TryFromIntError) -> Self {
+/// #         ExampleErr::TryFromIntError(value)
+/// #     }
+/// # }
+/// #
+/// # impl From<FixedOffsetError> for ExampleErr {
+/// #     fn from(value: FixedOffsetError) -> Self {
+/// #         ExampleErr::FixedOffsetError(value)
+/// #     }
+/// # }
+/// let tz = FixedOffset::east_opt(Duration::hours(2).num_seconds().try_into()?).ok_or(FixedOffsetError)?;
 /// let today_date = naive_date_today(&tz);
+/// # Ok::<(), ExampleErr>(())
 /// ```
 pub fn naive_date_today<Tz>(tz: &Tz) -> NaiveDate
 where

--- a/src/time.rs
+++ b/src/time.rs
@@ -16,6 +16,10 @@ pub const DAYS_IN_WEEK: u8 = 7;
 /// Number of months in a year
 pub const MONTHS_IN_YEAR: u8 = 12;
 
+pub const DAYS_IN_COMMON_YEAR: u16 = 365;
+
+pub const DAYS_IN_LEAP_YEAR: u16 = 366;
+
 /// Represents midnight as a [`NaiveTime`]
 pub const NAIVE_TIME_MIDNIGHT: NaiveTime =
     NaiveTime::from_hms_opt(0, 0, 0).expect("Provided valid hour/minute/second (hms) combination");

--- a/src/time.rs
+++ b/src/time.rs
@@ -170,6 +170,10 @@ pub enum NaiveDuration {
     ///
     /// </div>
     Weeks(Weekday, i64),
+    /// Naive ISO weeks duration
+    /// 
+    /// Equivalent to [`NaiveDuration::Weeks`] using [monday](Weekday::Mon) as the week start.
+    IsoWeeks(i64),
     /// Naive months duration
     ///
     /// <div class="warning">
@@ -193,30 +197,6 @@ pub enum NaiveDuration {
 }
 
 impl NaiveDuration {
-    /// Creates a [`NaiveDuration`] for N [days](NaiveDuration::Days)
-    #[must_use]
-    pub fn days(n: i64) -> Self {
-        Self::Days(n)
-    }
-
-    /// Creates a [`NaiveDuration`] for N [weeks](NaiveDuration::Weeks)
-    #[must_use]
-    pub fn weeks(week_start: Weekday, n: i64) -> Self {
-        Self::Weeks(week_start, n)
-    }
-
-    /// Creates a [`NaiveDuration`] for N [months](NaiveDuration::Months)
-    #[must_use]
-    pub fn months(n: i64) -> Self {
-        Self::Months(n)
-    }
-
-    /// Creates a [`NaiveDuration`] for N [years](NaiveDuration::Years)
-    #[must_use]
-    pub fn years(n: i32) -> Self {
-        Self::Years(n)
-    }
-
     /// Whether the stored naive duration is zero
     ///
     /// This does **not** mean that after applying the [`NaiveDuration`] to another naive structure
@@ -224,7 +204,7 @@ impl NaiveDuration {
     #[must_use]
     pub fn is_zero(&self) -> bool {
         match self {
-            Self::Days(x) | Self::Weeks(_, x) | Self::Months(x) => *x == 0,
+            Self::Days(x) | Self::Weeks(_, x) | Self::IsoWeeks(x) | Self::Months(x) => *x == 0,
             Self::Years(x) => *x == 0,
         }
     }
@@ -236,7 +216,7 @@ impl NaiveDuration {
     #[must_use]
     pub fn is_positive(&self) -> bool {
         match self {
-            Self::Days(x) | Self::Weeks(_, x) | Self::Months(x) => x.is_positive(),
+            Self::Days(x) | Self::Weeks(_, x) | Self::IsoWeeks(x) | Self::Months(x) => x.is_positive(),
             Self::Years(x) => x.is_positive(),
         }
     }
@@ -248,7 +228,7 @@ impl NaiveDuration {
     #[must_use]
     pub fn is_negative(&self) -> bool {
         match self {
-            Self::Days(x) | Self::Weeks(_, x) | Self::Months(x) => x.is_negative(),
+            Self::Days(x) | Self::Weeks(_, x) | Self::IsoWeeks(x) | Self::Months(x) => x.is_negative(),
             Self::Years(x) => x.is_negative(),
         }
     }
@@ -298,34 +278,8 @@ pub fn checked_add_naive_duration_to_naive_date(
                 naive_date.checked_sub_days(duration)
             }
         },
-        NaiveDuration::Weeks(week_start, x) => {
-            // The absolute value of i64 is always storable in a u64, as we get rid of the sign bit
-            let weeks = x.unsigned_abs();
-            // Since the now-removed sign bit isn't used, we can multiply the value by 2
-            // so that we do make use of this last bit (as *2 = <<1).
-            // We use the checked multiplication so that we still prevent potential panics, even though
-            // they should not happen.
-            let double_weeks = chrono::Days::new(weeks.checked_mul(2)?);
-            // Shadow the weeks variable in order to store it in the structure chrono expects
-            let weeks = chrono::Days::new(weeks);
-
-            let week_first_day = naive_date.week(week_start).checked_first_day()?;
-
-            // (3*2 + 1)*weeks = 7*weeks = weeks in days
-            if x >= 0 {
-                week_first_day
-                    .checked_add_days(double_weeks)?
-                    .checked_add_days(double_weeks)?
-                    .checked_add_days(double_weeks)?
-                    .checked_add_days(weeks)
-            } else {
-                week_first_day
-                    .checked_sub_days(double_weeks)?
-                    .checked_sub_days(double_weeks)?
-                    .checked_sub_days(double_weeks)?
-                    .checked_sub_days(weeks)
-            }
-        },
+        NaiveDuration::Weeks(week_start, x) => checked_add_naive_weeks_to_naive_date(week_start, x, naive_date),
+        NaiveDuration::IsoWeeks(x) => checked_add_naive_weeks_to_naive_date(Weekday::Mon, x, naive_date),
         NaiveDuration::Months(x) => {
             // How many years in the given amount of months
             let mut years_offset = x.unsigned_abs() / u64::from(MONTHS_IN_YEAR);
@@ -375,6 +329,39 @@ pub fn checked_add_naive_duration_to_naive_date(
     }
 }
 
+fn checked_add_naive_weeks_to_naive_date(
+    week_start: Weekday,
+    amount: i64,
+    naive_date: NaiveDate,
+) -> Option<NaiveDate> {
+    // The absolute value of i64 is always storable in a u64, as we get rid of the sign bit
+    let weeks = amount.unsigned_abs();
+    // Since the now-removed sign bit isn't used, we can multiply the value by 2
+    // so that we do make use of this last bit (as *2 = <<1).
+    // We use the checked multiplication so that we still prevent potential panics, even though
+    // they should not happen.
+    let double_weeks = chrono::Days::new(weeks.checked_mul(2)?);
+    // Shadow the weeks variable in order to store it in the structure chrono expects
+    let weeks = chrono::Days::new(weeks);
+
+    let week_first_day = naive_date.week(week_start).checked_first_day()?;
+
+    // (3*2 + 1)*weeks = 7*weeks = weeks in days
+    if amount >= 0 {
+        week_first_day
+            .checked_add_days(double_weeks)?
+            .checked_add_days(double_weeks)?
+            .checked_add_days(double_weeks)?
+            .checked_add_days(weeks)
+    } else {
+        week_first_day
+            .checked_sub_days(double_weeks)?
+            .checked_sub_days(double_weeks)?
+            .checked_sub_days(double_weeks)?
+            .checked_sub_days(weeks)
+    }
+}
+
 /// Checked subtraction of a [`NaiveDuration`] to a [`NaiveDate`]
 ///
 /// Subtracting [days](NaiveDuration::Days) to a [`NaiveDate`] simply uses [`NaiveDate::checked_sub_days`].
@@ -411,34 +398,8 @@ pub fn checked_sub_naive_duration_to_naive_date(
                 naive_date.checked_add_days(duration)
             }
         },
-        NaiveDuration::Weeks(week_start, x) => {
-            // The absolute value of i64 is always storable in a u64, as we get rid of the sign bit
-            let weeks = x.unsigned_abs();
-            // Since the now-removed sign bit isn't used, we can multiply the value by 2
-            // so that we do make use of this last bit (as *2 = <<1).
-            // We use the checked multiplication so that we still prevent potential panics, even though
-            // they should not happen.
-            let double_weeks = chrono::Days::new(weeks.checked_mul(2)?);
-            // Shadow the weeks variable in order to store it in the structure chrono expects
-            let weeks = chrono::Days::new(weeks);
-
-            let week_first_day = naive_date.week(week_start).checked_first_day()?;
-
-            // (3*2 + 1)*weeks = 7*weeks = weeks in days
-            if x >= 0 {
-                week_first_day
-                    .checked_sub_days(double_weeks)?
-                    .checked_sub_days(double_weeks)?
-                    .checked_sub_days(double_weeks)?
-                    .checked_sub_days(weeks)
-            } else {
-                week_first_day
-                    .checked_add_days(double_weeks)?
-                    .checked_add_days(double_weeks)?
-                    .checked_add_days(double_weeks)?
-                    .checked_add_days(weeks)
-            }
-        },
+        NaiveDuration::Weeks(week_start, x) => checked_sub_naive_weeks_to_naive_date(week_start, x, naive_date),
+        NaiveDuration::IsoWeeks(x) => checked_sub_naive_weeks_to_naive_date(Weekday::Mon, x, naive_date),
         NaiveDuration::Months(x) => {
             // How many years in the given amount of months
             let mut years_offset = x.unsigned_abs() / u64::from(MONTHS_IN_YEAR);
@@ -485,6 +446,39 @@ pub fn checked_sub_naive_duration_to_naive_date(
             }
         },
         NaiveDuration::Years(x) => NaiveDate::from_ymd_opt(naive_date.year().checked_sub(x)?, 1, 1),
+    }
+}
+
+fn checked_sub_naive_weeks_to_naive_date(
+    week_start: Weekday,
+    amount: i64,
+    naive_date: NaiveDate,
+) -> Option<NaiveDate> {
+    // The absolute value of i64 is always storable in a u64, as we get rid of the sign bit
+    let weeks = amount.unsigned_abs();
+    // Since the now-removed sign bit isn't used, we can multiply the value by 2
+    // so that we do make use of this last bit (as *2 = <<1).
+    // We use the checked multiplication so that we still prevent potential panics, even though
+    // they should not happen.
+    let double_weeks = chrono::Days::new(weeks.checked_mul(2)?);
+    // Shadow the weeks variable in order to store it in the structure chrono expects
+    let weeks = chrono::Days::new(weeks);
+
+    let week_first_day = naive_date.week(week_start).checked_first_day()?;
+
+    // (3*2 + 1)*weeks = 7*weeks = weeks in days
+    if amount >= 0 {
+        week_first_day
+            .checked_sub_days(double_weeks)?
+            .checked_sub_days(double_weeks)?
+            .checked_sub_days(double_weeks)?
+            .checked_sub_days(weeks)
+    } else {
+        week_first_day
+            .checked_add_days(double_weeks)?
+            .checked_add_days(double_weeks)?
+            .checked_add_days(double_weeks)?
+            .checked_add_days(weeks)
     }
 }
 

--- a/src/time.rs
+++ b/src/time.rs
@@ -4,7 +4,9 @@
 //!
 //! It also contains structures to represent naive durations, used for convenience.
 
-use chrono::{Datelike, NaiveDate, NaiveTime, TimeZone, Utc, Weekday};
+use std::cmp::Ordering;
+
+use chrono::{Datelike, Month, NaiveDate, NaiveTime, TimeZone, Utc, Weekday};
 
 /// Number of days in a week
 pub const DAYS_IN_WEEK: u8 = 7;
@@ -35,6 +37,47 @@ where
     Tz: TimeZone,
 {
     Utc::now().with_timezone(tz).date_naive()
+}
+
+/// Naive month within a year
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct NaiveMonth {
+    year: i32,
+    month: Month,
+}
+
+impl NaiveMonth {
+    /// Creates a new [`NaiveMonth`] from the given year and month
+    #[must_use]
+    pub fn new(year: i32, month: Month) -> Self {
+        Self { year, month }
+    }
+
+    /// Returns the year of the [`NaiveMonth`]
+    #[must_use]
+    pub fn year(&self) -> i32 {
+        self.year
+    }
+
+    /// Returns the [`Month`] of the [`NaiveMonth`]
+    #[must_use]
+    pub fn month(&self) -> Month {
+        self.month
+    }
+}
+
+impl PartialOrd for NaiveMonth {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for NaiveMonth {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.year()
+            .cmp(&other.year())
+            .then_with(|| self.month().cmp(&self.month()))
+    }
 }
 
 /// A naive duration
@@ -423,5 +466,3 @@ where
         .into_iter()
         .try_fold(naive_date, checked_sub_naive_duration_to_naive_date)
 }
-
-// TODO: checked add/sub for naive weeks, naive months, etc.

--- a/src/time_constants.rs
+++ b/src/time_constants.rs
@@ -1,9 +1,0 @@
-use chrono::NaiveTime;
-
-/// Represents midnight as a [`NaiveTime`]
-pub const NAIVE_TIME_MIDNIGHT: NaiveTime = NaiveTime::from_hms_opt(0, 0, 0)
-    .expect("Provided valid hour/minute/second (hms) combination");
-
-/// Represents noon as a [`NaiveTime`]
-pub const NAIVE_TIME_NOON: NaiveTime = NaiveTime::from_hms_opt(12, 0, 0)
-    .expect("Provided valid hour/minute/second (hms) combination");

--- a/src/time_constants.rs
+++ b/src/time_constants.rs
@@ -1,0 +1,9 @@
+use chrono::NaiveTime;
+
+/// Represents midnight as a [`NaiveTime`]
+pub const NAIVE_TIME_MIDNIGHT: NaiveTime = NaiveTime::from_hms_opt(0, 0, 0)
+    .expect("Provided valid hour/minute/second (hms) combination");
+
+/// Represents noon as a [`NaiveTime`]
+pub const NAIVE_TIME_NOON: NaiveTime = NaiveTime::from_hms_opt(12, 0, 0)
+    .expect("Provided valid hour/minute/second (hms) combination");

--- a/src/time_tests.rs
+++ b/src/time_tests.rs
@@ -1,0 +1,619 @@
+use std::cmp::Ordering;
+
+use chrono::{NaiveDate, Weekday};
+
+use super::time::*;
+
+#[test]
+fn naive_duration_days_is_zero() {
+    assert!(!NaiveDuration::days(1).is_zero());
+    assert!(NaiveDuration::days(0).is_zero());
+    assert!(!NaiveDuration::days(-1).is_zero());
+}
+
+#[test]
+fn naive_duration_weeks_is_zero() {
+    assert!(!NaiveDuration::weeks(Weekday::Mon, 1).is_zero());
+    assert!(NaiveDuration::weeks(Weekday::Mon, 0).is_zero());
+    assert!(!NaiveDuration::weeks(Weekday::Mon, -1).is_zero());
+}
+
+#[test]
+fn naive_duration_months_is_zero() {
+    assert!(!NaiveDuration::months(1).is_zero());
+    assert!(NaiveDuration::months(0).is_zero());
+    assert!(!NaiveDuration::months(-1).is_zero());
+}
+
+#[test]
+fn naive_duration_years_is_zero() {
+    assert!(!NaiveDuration::years(1).is_zero());
+    assert!(NaiveDuration::years(0).is_zero());
+    assert!(!NaiveDuration::years(-1).is_zero());
+}
+
+#[test]
+fn naive_duration_days_is_positive() {
+    assert!(NaiveDuration::days(1).is_positive());
+    assert!(!NaiveDuration::days(0).is_positive());
+    assert!(!NaiveDuration::days(-1).is_positive());
+}
+
+#[test]
+fn naive_duration_weeks_is_positive() {
+    assert!(NaiveDuration::weeks(Weekday::Mon, 1).is_positive());
+    assert!(!NaiveDuration::weeks(Weekday::Mon, 0).is_positive());
+    assert!(!NaiveDuration::weeks(Weekday::Mon, -1).is_positive());
+}
+
+#[test]
+fn naive_duration_months_is_positive() {
+    assert!(NaiveDuration::months(1).is_positive());
+    assert!(!NaiveDuration::months(0).is_positive());
+    assert!(!NaiveDuration::months(-1).is_positive());
+}
+
+#[test]
+fn naive_duration_years_is_positive() {
+    assert!(NaiveDuration::years(1).is_positive());
+    assert!(!NaiveDuration::years(0).is_positive());
+    assert!(!NaiveDuration::years(-1).is_positive());
+}
+
+#[test]
+fn naive_duration_days_is_negative() {
+    assert!(!NaiveDuration::days(1).is_negative());
+    assert!(!NaiveDuration::days(0).is_negative());
+    assert!(NaiveDuration::days(-1).is_negative());
+}
+
+#[test]
+fn naive_duration_weeks_is_negative() {
+    assert!(!NaiveDuration::weeks(Weekday::Mon, 1).is_negative());
+    assert!(!NaiveDuration::weeks(Weekday::Mon, 0).is_negative());
+    assert!(NaiveDuration::weeks(Weekday::Mon, -1).is_negative());
+}
+
+#[test]
+fn naive_duration_months_is_negative() {
+    assert!(!NaiveDuration::months(1).is_negative());
+    assert!(!NaiveDuration::months(0).is_negative());
+    assert!(NaiveDuration::months(-1).is_negative());
+}
+
+#[test]
+fn naive_duration_years_is_negative() {
+    assert!(!NaiveDuration::years(1).is_negative());
+    assert!(!NaiveDuration::years(0).is_negative());
+    assert!(NaiveDuration::years(-1).is_negative());
+}
+
+#[test]
+fn naive_duration_cant_compare_different_units() {
+    assert_eq!(
+        NaiveDuration::days(1).partial_cmp(&NaiveDuration::weeks(Weekday::Mon, 1)),
+        None
+    );
+    assert_eq!(NaiveDuration::days(1).partial_cmp(&NaiveDuration::months(1)), None);
+    assert_eq!(NaiveDuration::days(1).partial_cmp(&NaiveDuration::years(1)), None);
+    assert_eq!(
+        NaiveDuration::weeks(Weekday::Mon, 1).partial_cmp(&NaiveDuration::days(1)),
+        None
+    );
+    assert_eq!(
+        NaiveDuration::weeks(Weekday::Mon, 1).partial_cmp(&NaiveDuration::months(1)),
+        None
+    );
+    assert_eq!(
+        NaiveDuration::weeks(Weekday::Mon, 1).partial_cmp(&NaiveDuration::years(1)),
+        None
+    );
+    assert_eq!(NaiveDuration::months(1).partial_cmp(&NaiveDuration::days(1)), None);
+    assert_eq!(
+        NaiveDuration::months(1).partial_cmp(&NaiveDuration::weeks(Weekday::Mon, 1)),
+        None
+    );
+    assert_eq!(NaiveDuration::months(1).partial_cmp(&NaiveDuration::years(1)), None);
+    assert_eq!(NaiveDuration::years(1).partial_cmp(&NaiveDuration::days(1)), None);
+    assert_eq!(
+        NaiveDuration::years(1).partial_cmp(&NaiveDuration::weeks(Weekday::Mon, 1)),
+        None
+    );
+    assert_eq!(NaiveDuration::years(1).partial_cmp(&NaiveDuration::months(1)), None);
+}
+
+#[test]
+fn naive_duration_compare_days() {
+    assert_eq!(
+        NaiveDuration::days(1).partial_cmp(&NaiveDuration::days(0)),
+        Some(Ordering::Greater)
+    );
+    assert_eq!(
+        NaiveDuration::days(0).partial_cmp(&NaiveDuration::days(1)),
+        Some(Ordering::Less)
+    );
+    assert_eq!(
+        NaiveDuration::days(0).partial_cmp(&NaiveDuration::days(0)),
+        Some(Ordering::Equal)
+    );
+}
+
+#[test]
+fn naive_duration_compare_weeks_same_ref_day() {
+    assert_eq!(
+        NaiveDuration::weeks(Weekday::Mon, 1).partial_cmp(&NaiveDuration::weeks(Weekday::Mon, 0)),
+        Some(Ordering::Greater),
+    );
+    assert_eq!(
+        NaiveDuration::weeks(Weekday::Mon, 0).partial_cmp(&NaiveDuration::weeks(Weekday::Mon, 1)),
+        Some(Ordering::Less),
+    );
+    assert_eq!(
+        NaiveDuration::weeks(Weekday::Mon, 0).partial_cmp(&NaiveDuration::weeks(Weekday::Mon, 0)),
+        Some(Ordering::Equal),
+    );
+}
+
+#[test]
+fn naive_duration_compare_weeks_different_ref_day() {
+    assert_eq!(
+        NaiveDuration::weeks(Weekday::Mon, 1).partial_cmp(&NaiveDuration::weeks(Weekday::Sun, 0)),
+        Some(Ordering::Greater),
+    );
+    assert_eq!(
+        NaiveDuration::weeks(Weekday::Mon, 0).partial_cmp(&NaiveDuration::weeks(Weekday::Sun, 1)),
+        Some(Ordering::Less),
+    );
+    assert_eq!(
+        NaiveDuration::weeks(Weekday::Mon, 0).partial_cmp(&NaiveDuration::weeks(Weekday::Sun, 0)),
+        Some(Ordering::Equal),
+    );
+}
+
+#[test]
+fn naive_duration_compare_months() {
+    assert_eq!(
+        NaiveDuration::months(1).partial_cmp(&NaiveDuration::months(0)),
+        Some(Ordering::Greater)
+    );
+    assert_eq!(
+        NaiveDuration::months(0).partial_cmp(&NaiveDuration::months(1)),
+        Some(Ordering::Less)
+    );
+    assert_eq!(
+        NaiveDuration::months(0).partial_cmp(&NaiveDuration::months(0)),
+        Some(Ordering::Equal)
+    );
+}
+
+#[test]
+fn naive_duration_compare_years() {
+    assert_eq!(
+        NaiveDuration::years(1).partial_cmp(&NaiveDuration::years(0)),
+        Some(Ordering::Greater)
+    );
+    assert_eq!(
+        NaiveDuration::years(0).partial_cmp(&NaiveDuration::years(1)),
+        Some(Ordering::Less)
+    );
+    assert_eq!(
+        NaiveDuration::years(0).partial_cmp(&NaiveDuration::years(0)),
+        Some(Ordering::Equal)
+    );
+}
+
+#[test]
+fn checked_add_naive_duration_to_naive_date_zero_days() {
+    let naive_date = NaiveDate::from_ymd_opt(2026, 5, 1).unwrap();
+
+    assert_eq!(
+        checked_add_naive_duration_to_naive_date(naive_date, NaiveDuration::Days(0)).unwrap(),
+        naive_date,
+    );
+}
+
+#[test]
+fn checked_add_naive_duration_to_naive_date_positive_days() {
+    assert_eq!(
+        checked_add_naive_duration_to_naive_date(
+            NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
+            NaiveDuration::days(420),
+        )
+        .unwrap(),
+        NaiveDate::from_ymd_opt(2027, 6, 25).unwrap(),
+    );
+}
+
+#[test]
+fn checked_add_naive_duration_to_naive_date_negative_days() {
+    assert_eq!(
+        checked_add_naive_duration_to_naive_date(
+            NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
+            NaiveDuration::days(-420),
+        )
+        .unwrap(),
+        NaiveDate::from_ymd_opt(2025, 3, 7).unwrap(),
+    );
+}
+
+#[test]
+fn checked_add_naive_duration_to_naive_date_zero_weeks_monday_ref() {
+    // Per `checked_add_naive_duration_to_naive_date`'s doc, adding weeks to get a day
+    // returns the first day of the week.
+    assert_eq!(
+        checked_add_naive_duration_to_naive_date(
+            NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
+            NaiveDuration::weeks(Weekday::Mon, 0),
+        )
+        .unwrap(),
+        NaiveDate::from_ymd_opt(2026, 4, 27).unwrap(),
+    );
+}
+
+#[test]
+fn checked_add_naive_duration_to_naive_date_zero_weeks_sunday_ref() {
+    assert_eq!(
+        checked_add_naive_duration_to_naive_date(
+            NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
+            NaiveDuration::weeks(Weekday::Sun, 0),
+        )
+        .unwrap(),
+        NaiveDate::from_ymd_opt(2026, 4, 26).unwrap(),
+    );
+}
+
+#[test]
+fn checked_add_naive_duration_to_naive_date_zero_weeks_monday_ref_on_sunday() {
+    assert_eq!(
+        checked_add_naive_duration_to_naive_date(
+            NaiveDate::from_ymd_opt(2026, 2, 8).unwrap(),
+            NaiveDuration::weeks(Weekday::Mon, 0),
+        )
+        .unwrap(),
+        NaiveDate::from_ymd_opt(2026, 2, 2).unwrap(),
+    );
+}
+
+#[test]
+fn checked_add_naive_duration_to_naive_date_zero_weeks_sunday_ref_on_sunday() {
+    assert_eq!(
+        checked_add_naive_duration_to_naive_date(
+            NaiveDate::from_ymd_opt(2026, 2, 8).unwrap(),
+            NaiveDuration::weeks(Weekday::Sun, 0),
+        )
+        .unwrap(),
+        NaiveDate::from_ymd_opt(2026, 2, 8).unwrap(),
+    );
+}
+
+#[test]
+fn checked_add_naive_duration_to_naive_date_positive_weeks() {
+    assert_eq!(
+        checked_add_naive_duration_to_naive_date(
+            NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
+            NaiveDuration::weeks(Weekday::Mon, 15),
+        )
+        .unwrap(),
+        NaiveDate::from_ymd_opt(2026, 8, 10).unwrap(),
+    );
+}
+
+#[test]
+fn checked_add_naive_duration_to_naive_date_negative_weeks() {
+    assert_eq!(
+        checked_add_naive_duration_to_naive_date(
+            NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
+            NaiveDuration::weeks(Weekday::Mon, -10),
+        )
+        .unwrap(),
+        NaiveDate::from_ymd_opt(2026, 2, 16).unwrap(),
+    );
+}
+
+#[test]
+fn checked_add_naive_duration_to_naive_date_zero_months() {
+    // Per `checked_add_naive_duration_to_naive_date`'s doc, adding months to get a day
+    // returns the first day of the month.
+    assert_eq!(
+        checked_add_naive_duration_to_naive_date(
+            NaiveDate::from_ymd_opt(2026, 5, 20).unwrap(),
+            NaiveDuration::months(0),
+        )
+        .unwrap(),
+        NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
+    );
+}
+
+#[test]
+fn checked_add_naive_duration_to_naive_date_positive_months_no_extra_year() {
+    assert_eq!(
+        checked_add_naive_duration_to_naive_date(
+            NaiveDate::from_ymd_opt(2026, 5, 20).unwrap(),
+            NaiveDuration::months(30),
+        )
+        .unwrap(),
+        NaiveDate::from_ymd_opt(2028, 11, 1).unwrap(),
+    );
+}
+
+#[test]
+fn checked_add_naive_duration_to_naive_date_positive_months_extra_year() {
+    assert_eq!(
+        checked_add_naive_duration_to_naive_date(
+            NaiveDate::from_ymd_opt(2026, 10, 20).unwrap(),
+            NaiveDuration::months(30),
+        )
+        .unwrap(),
+        NaiveDate::from_ymd_opt(2029, 4, 1).unwrap(),
+    );
+}
+
+#[test]
+fn checked_add_naive_duration_to_naive_date_negative_months_no_extra_year() {
+    assert_eq!(
+        checked_add_naive_duration_to_naive_date(
+            NaiveDate::from_ymd_opt(2026, 8, 20).unwrap(),
+            NaiveDuration::months(-30),
+        )
+        .unwrap(),
+        NaiveDate::from_ymd_opt(2024, 2, 1).unwrap(),
+    );
+}
+
+#[test]
+fn checked_add_naive_duration_to_naive_date_negative_months_extra_year() {
+    assert_eq!(
+        checked_add_naive_duration_to_naive_date(
+            NaiveDate::from_ymd_opt(2026, 5, 20).unwrap(),
+            NaiveDuration::months(-30),
+        )
+        .unwrap(),
+        NaiveDate::from_ymd_opt(2023, 11, 1).unwrap(),
+    );
+}
+
+#[test]
+fn checked_add_naive_duration_to_naive_date_zero_years() {
+    // Per `checked_add_naive_duration_to_naive_date`'s doc, adding years to get a day
+    // returns the first day of the year.
+    assert_eq!(
+        checked_add_naive_duration_to_naive_date(
+            NaiveDate::from_ymd_opt(2026, 5, 20).unwrap(),
+            NaiveDuration::years(0),
+        )
+        .unwrap(),
+        NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
+    );
+}
+
+#[test]
+fn checked_add_naive_duration_to_naive_date_positive_years() {
+    assert_eq!(
+        checked_add_naive_duration_to_naive_date(
+            NaiveDate::from_ymd_opt(2026, 5, 20).unwrap(),
+            NaiveDuration::years(10),
+        )
+        .unwrap(),
+        NaiveDate::from_ymd_opt(2036, 1, 1).unwrap(),
+    );
+}
+
+#[test]
+fn checked_add_naive_duration_to_naive_date_negative_years() {
+    assert_eq!(
+        checked_add_naive_duration_to_naive_date(
+            NaiveDate::from_ymd_opt(2026, 5, 20).unwrap(),
+            NaiveDuration::years(-10),
+        )
+        .unwrap(),
+        NaiveDate::from_ymd_opt(2016, 1, 1).unwrap(),
+    );
+}
+
+#[test]
+fn checked_sub_naive_duration_to_naive_date_zero_days() {
+    let naive_date = NaiveDate::from_ymd_opt(2026, 5, 1).unwrap();
+
+    assert_eq!(
+        checked_sub_naive_duration_to_naive_date(naive_date, NaiveDuration::Days(0)).unwrap(),
+        naive_date,
+    );
+}
+
+#[test]
+fn checked_sub_naive_duration_to_naive_date_positive_days() {
+    assert_eq!(
+        checked_sub_naive_duration_to_naive_date(
+            NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
+            NaiveDuration::days(420),
+        )
+        .unwrap(),
+        NaiveDate::from_ymd_opt(2025, 3, 7).unwrap(),
+    );
+}
+
+#[test]
+fn checked_sub_naive_duration_to_naive_date_negative_days() {
+    assert_eq!(
+        checked_sub_naive_duration_to_naive_date(
+            NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
+            NaiveDuration::days(-420),
+        )
+        .unwrap(),
+        NaiveDate::from_ymd_opt(2027, 6, 25).unwrap(),
+    );
+}
+
+#[test]
+fn checked_sub_naive_duration_to_naive_date_zero_weeks_monday_ref() {
+    // Per `checked_sub_naive_duration_to_naive_date`'s doc, subtracting weeks to get a day
+    // returns the first day of the week.
+    assert_eq!(
+        checked_sub_naive_duration_to_naive_date(
+            NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
+            NaiveDuration::weeks(Weekday::Mon, 0),
+        )
+        .unwrap(),
+        NaiveDate::from_ymd_opt(2026, 4, 27).unwrap(),
+    );
+}
+
+#[test]
+fn checked_sub_naive_duration_to_naive_date_zero_weeks_sunday_ref() {
+    assert_eq!(
+        checked_sub_naive_duration_to_naive_date(
+            NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
+            NaiveDuration::weeks(Weekday::Sun, 0),
+        )
+        .unwrap(),
+        NaiveDate::from_ymd_opt(2026, 4, 26).unwrap(),
+    );
+}
+
+#[test]
+fn checked_sub_naive_duration_to_naive_date_zero_weeks_monday_ref_on_sunday() {
+    assert_eq!(
+        checked_sub_naive_duration_to_naive_date(
+            NaiveDate::from_ymd_opt(2026, 2, 8).unwrap(),
+            NaiveDuration::weeks(Weekday::Mon, 0),
+        )
+        .unwrap(),
+        NaiveDate::from_ymd_opt(2026, 2, 2).unwrap(),
+    );
+}
+
+#[test]
+fn checked_sub_naive_duration_to_naive_date_zero_weeks_sunday_ref_on_sunday() {
+    assert_eq!(
+        checked_sub_naive_duration_to_naive_date(
+            NaiveDate::from_ymd_opt(2026, 2, 8).unwrap(),
+            NaiveDuration::weeks(Weekday::Sun, 0),
+        )
+        .unwrap(),
+        NaiveDate::from_ymd_opt(2026, 2, 8).unwrap(),
+    );
+}
+
+#[test]
+fn checked_sub_naive_duration_to_naive_date_positive_weeks() {
+    assert_eq!(
+        checked_sub_naive_duration_to_naive_date(
+            NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
+            NaiveDuration::weeks(Weekday::Mon, 15),
+        )
+        .unwrap(),
+        NaiveDate::from_ymd_opt(2026, 1, 12).unwrap(),
+    );
+}
+
+#[test]
+fn checked_sub_naive_duration_to_naive_date_negative_weeks() {
+    assert_eq!(
+        checked_sub_naive_duration_to_naive_date(
+            NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
+            NaiveDuration::weeks(Weekday::Mon, -10),
+        )
+        .unwrap(),
+        NaiveDate::from_ymd_opt(2026, 7, 6).unwrap(),
+    );
+}
+
+#[test]
+fn checked_sub_naive_duration_to_naive_date_zero_months() {
+    // Per `checked_sub_naive_duration_to_naive_date`'s doc, subtracting months to get a day
+    // returns the first day of the month.
+    assert_eq!(
+        checked_sub_naive_duration_to_naive_date(
+            NaiveDate::from_ymd_opt(2026, 5, 20).unwrap(),
+            NaiveDuration::months(0),
+        )
+        .unwrap(),
+        NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
+    );
+}
+
+#[test]
+fn checked_sub_naive_duration_to_naive_date_positive_months_no_extra_year() {
+    assert_eq!(
+        checked_sub_naive_duration_to_naive_date(
+            NaiveDate::from_ymd_opt(2026, 8, 20).unwrap(),
+            NaiveDuration::months(30),
+        )
+        .unwrap(),
+        NaiveDate::from_ymd_opt(2024, 2, 1).unwrap(),
+    );
+}
+
+#[test]
+fn checked_sub_naive_duration_to_naive_date_positive_months_extra_year() {
+    assert_eq!(
+        checked_sub_naive_duration_to_naive_date(
+            NaiveDate::from_ymd_opt(2026, 5, 20).unwrap(),
+            NaiveDuration::months(30),
+        )
+        .unwrap(),
+        NaiveDate::from_ymd_opt(2023, 11, 1).unwrap(),
+    );
+}
+
+#[test]
+fn checked_sub_naive_duration_to_naive_date_negative_months_no_extra_year() {
+    assert_eq!(
+        checked_sub_naive_duration_to_naive_date(
+            NaiveDate::from_ymd_opt(2026, 10, 20).unwrap(),
+            NaiveDuration::months(-30),
+        )
+        .unwrap(),
+        NaiveDate::from_ymd_opt(2029, 4, 1).unwrap(),
+    );
+}
+
+#[test]
+fn checked_sub_naive_duration_to_naive_date_negative_months_extra_year() {
+    assert_eq!(
+        checked_sub_naive_duration_to_naive_date(
+            NaiveDate::from_ymd_opt(2026, 5, 20).unwrap(),
+            NaiveDuration::months(-30),
+        )
+        .unwrap(),
+        NaiveDate::from_ymd_opt(2028, 11, 1).unwrap(),
+    );
+}
+
+#[test]
+fn checked_sub_naive_duration_to_naive_date_zero_years() {
+    // Per `checked_sub_naive_duration_to_naive_date`'s doc, adding years to get a day
+    // returns the first day of the year.
+    assert_eq!(
+        checked_sub_naive_duration_to_naive_date(
+            NaiveDate::from_ymd_opt(2026, 5, 20).unwrap(),
+            NaiveDuration::years(0),
+        )
+        .unwrap(),
+        NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
+    );
+}
+
+#[test]
+fn checked_sub_naive_duration_to_naive_date_positive_years() {
+    assert_eq!(
+        checked_sub_naive_duration_to_naive_date(
+            NaiveDate::from_ymd_opt(2026, 5, 20).unwrap(),
+            NaiveDuration::years(10),
+        )
+        .unwrap(),
+        NaiveDate::from_ymd_opt(2016, 1, 1).unwrap(),
+    );
+}
+
+#[test]
+fn checked_sub_naive_duration_to_naive_date_negative_years() {
+    assert_eq!(
+        checked_sub_naive_duration_to_naive_date(
+            NaiveDate::from_ymd_opt(2026, 5, 20).unwrap(),
+            NaiveDuration::years(-10),
+        )
+        .unwrap(),
+        NaiveDate::from_ymd_opt(2036, 1, 1).unwrap(),
+    );
+}

--- a/src/time_tests.rs
+++ b/src/time_tests.rs
@@ -46,134 +46,134 @@ fn naive_month_ord() {
 
 #[test]
 fn naive_duration_days_is_zero() {
-    assert!(!NaiveDuration::days(1).is_zero());
-    assert!(NaiveDuration::days(0).is_zero());
-    assert!(!NaiveDuration::days(-1).is_zero());
+    assert!(!NaiveDuration::Days(1).is_zero());
+    assert!(NaiveDuration::Days(0).is_zero());
+    assert!(!NaiveDuration::Days(-1).is_zero());
 }
 
 #[test]
 fn naive_duration_weeks_is_zero() {
-    assert!(!NaiveDuration::weeks(Weekday::Mon, 1).is_zero());
-    assert!(NaiveDuration::weeks(Weekday::Mon, 0).is_zero());
-    assert!(!NaiveDuration::weeks(Weekday::Mon, -1).is_zero());
+    assert!(!NaiveDuration::Weeks(Weekday::Mon, 1).is_zero());
+    assert!(NaiveDuration::Weeks(Weekday::Mon, 0).is_zero());
+    assert!(!NaiveDuration::Weeks(Weekday::Mon, -1).is_zero());
 }
 
 #[test]
 fn naive_duration_months_is_zero() {
-    assert!(!NaiveDuration::months(1).is_zero());
-    assert!(NaiveDuration::months(0).is_zero());
-    assert!(!NaiveDuration::months(-1).is_zero());
+    assert!(!NaiveDuration::Months(1).is_zero());
+    assert!(NaiveDuration::Months(0).is_zero());
+    assert!(!NaiveDuration::Months(-1).is_zero());
 }
 
 #[test]
 fn naive_duration_years_is_zero() {
-    assert!(!NaiveDuration::years(1).is_zero());
-    assert!(NaiveDuration::years(0).is_zero());
-    assert!(!NaiveDuration::years(-1).is_zero());
+    assert!(!NaiveDuration::Years(1).is_zero());
+    assert!(NaiveDuration::Years(0).is_zero());
+    assert!(!NaiveDuration::Years(-1).is_zero());
 }
 
 #[test]
 fn naive_duration_days_is_positive() {
-    assert!(NaiveDuration::days(1).is_positive());
-    assert!(!NaiveDuration::days(0).is_positive());
-    assert!(!NaiveDuration::days(-1).is_positive());
+    assert!(NaiveDuration::Days(1).is_positive());
+    assert!(!NaiveDuration::Days(0).is_positive());
+    assert!(!NaiveDuration::Days(-1).is_positive());
 }
 
 #[test]
 fn naive_duration_weeks_is_positive() {
-    assert!(NaiveDuration::weeks(Weekday::Mon, 1).is_positive());
-    assert!(!NaiveDuration::weeks(Weekday::Mon, 0).is_positive());
-    assert!(!NaiveDuration::weeks(Weekday::Mon, -1).is_positive());
+    assert!(NaiveDuration::Weeks(Weekday::Mon, 1).is_positive());
+    assert!(!NaiveDuration::Weeks(Weekday::Mon, 0).is_positive());
+    assert!(!NaiveDuration::Weeks(Weekday::Mon, -1).is_positive());
 }
 
 #[test]
 fn naive_duration_months_is_positive() {
-    assert!(NaiveDuration::months(1).is_positive());
-    assert!(!NaiveDuration::months(0).is_positive());
-    assert!(!NaiveDuration::months(-1).is_positive());
+    assert!(NaiveDuration::Months(1).is_positive());
+    assert!(!NaiveDuration::Months(0).is_positive());
+    assert!(!NaiveDuration::Months(-1).is_positive());
 }
 
 #[test]
 fn naive_duration_years_is_positive() {
-    assert!(NaiveDuration::years(1).is_positive());
-    assert!(!NaiveDuration::years(0).is_positive());
-    assert!(!NaiveDuration::years(-1).is_positive());
+    assert!(NaiveDuration::Years(1).is_positive());
+    assert!(!NaiveDuration::Years(0).is_positive());
+    assert!(!NaiveDuration::Years(-1).is_positive());
 }
 
 #[test]
 fn naive_duration_days_is_negative() {
-    assert!(!NaiveDuration::days(1).is_negative());
-    assert!(!NaiveDuration::days(0).is_negative());
-    assert!(NaiveDuration::days(-1).is_negative());
+    assert!(!NaiveDuration::Days(1).is_negative());
+    assert!(!NaiveDuration::Days(0).is_negative());
+    assert!(NaiveDuration::Days(-1).is_negative());
 }
 
 #[test]
 fn naive_duration_weeks_is_negative() {
-    assert!(!NaiveDuration::weeks(Weekday::Mon, 1).is_negative());
-    assert!(!NaiveDuration::weeks(Weekday::Mon, 0).is_negative());
-    assert!(NaiveDuration::weeks(Weekday::Mon, -1).is_negative());
+    assert!(!NaiveDuration::Weeks(Weekday::Mon, 1).is_negative());
+    assert!(!NaiveDuration::Weeks(Weekday::Mon, 0).is_negative());
+    assert!(NaiveDuration::Weeks(Weekday::Mon, -1).is_negative());
 }
 
 #[test]
 fn naive_duration_months_is_negative() {
-    assert!(!NaiveDuration::months(1).is_negative());
-    assert!(!NaiveDuration::months(0).is_negative());
-    assert!(NaiveDuration::months(-1).is_negative());
+    assert!(!NaiveDuration::Months(1).is_negative());
+    assert!(!NaiveDuration::Months(0).is_negative());
+    assert!(NaiveDuration::Months(-1).is_negative());
 }
 
 #[test]
 fn naive_duration_years_is_negative() {
-    assert!(!NaiveDuration::years(1).is_negative());
-    assert!(!NaiveDuration::years(0).is_negative());
-    assert!(NaiveDuration::years(-1).is_negative());
+    assert!(!NaiveDuration::Years(1).is_negative());
+    assert!(!NaiveDuration::Years(0).is_negative());
+    assert!(NaiveDuration::Years(-1).is_negative());
 }
 
 #[test]
 fn naive_duration_cant_compare_different_units() {
     assert_eq!(
-        NaiveDuration::days(1).partial_cmp(&NaiveDuration::weeks(Weekday::Mon, 1)),
+        NaiveDuration::Days(1).partial_cmp(&NaiveDuration::Weeks(Weekday::Mon, 1)),
         None
     );
-    assert_eq!(NaiveDuration::days(1).partial_cmp(&NaiveDuration::months(1)), None);
-    assert_eq!(NaiveDuration::days(1).partial_cmp(&NaiveDuration::years(1)), None);
+    assert_eq!(NaiveDuration::Days(1).partial_cmp(&NaiveDuration::Months(1)), None);
+    assert_eq!(NaiveDuration::Days(1).partial_cmp(&NaiveDuration::Years(1)), None);
     assert_eq!(
-        NaiveDuration::weeks(Weekday::Mon, 1).partial_cmp(&NaiveDuration::days(1)),
-        None
-    );
-    assert_eq!(
-        NaiveDuration::weeks(Weekday::Mon, 1).partial_cmp(&NaiveDuration::months(1)),
+        NaiveDuration::Weeks(Weekday::Mon, 1).partial_cmp(&NaiveDuration::Days(1)),
         None
     );
     assert_eq!(
-        NaiveDuration::weeks(Weekday::Mon, 1).partial_cmp(&NaiveDuration::years(1)),
+        NaiveDuration::Weeks(Weekday::Mon, 1).partial_cmp(&NaiveDuration::Months(1)),
         None
     );
-    assert_eq!(NaiveDuration::months(1).partial_cmp(&NaiveDuration::days(1)), None);
     assert_eq!(
-        NaiveDuration::months(1).partial_cmp(&NaiveDuration::weeks(Weekday::Mon, 1)),
+        NaiveDuration::Weeks(Weekday::Mon, 1).partial_cmp(&NaiveDuration::Years(1)),
         None
     );
-    assert_eq!(NaiveDuration::months(1).partial_cmp(&NaiveDuration::years(1)), None);
-    assert_eq!(NaiveDuration::years(1).partial_cmp(&NaiveDuration::days(1)), None);
+    assert_eq!(NaiveDuration::Months(1).partial_cmp(&NaiveDuration::Days(1)), None);
     assert_eq!(
-        NaiveDuration::years(1).partial_cmp(&NaiveDuration::weeks(Weekday::Mon, 1)),
+        NaiveDuration::Months(1).partial_cmp(&NaiveDuration::Weeks(Weekday::Mon, 1)),
         None
     );
-    assert_eq!(NaiveDuration::years(1).partial_cmp(&NaiveDuration::months(1)), None);
+    assert_eq!(NaiveDuration::Months(1).partial_cmp(&NaiveDuration::Years(1)), None);
+    assert_eq!(NaiveDuration::Years(1).partial_cmp(&NaiveDuration::Days(1)), None);
+    assert_eq!(
+        NaiveDuration::Years(1).partial_cmp(&NaiveDuration::Weeks(Weekday::Mon, 1)),
+        None
+    );
+    assert_eq!(NaiveDuration::Years(1).partial_cmp(&NaiveDuration::Months(1)), None);
 }
 
 #[test]
 fn naive_duration_compare_days() {
     assert_eq!(
-        NaiveDuration::days(1).partial_cmp(&NaiveDuration::days(0)),
+        NaiveDuration::Days(1).partial_cmp(&NaiveDuration::Days(0)),
         Some(Ordering::Greater)
     );
     assert_eq!(
-        NaiveDuration::days(0).partial_cmp(&NaiveDuration::days(1)),
+        NaiveDuration::Days(0).partial_cmp(&NaiveDuration::Days(1)),
         Some(Ordering::Less)
     );
     assert_eq!(
-        NaiveDuration::days(0).partial_cmp(&NaiveDuration::days(0)),
+        NaiveDuration::Days(0).partial_cmp(&NaiveDuration::Days(0)),
         Some(Ordering::Equal)
     );
 }
@@ -181,15 +181,15 @@ fn naive_duration_compare_days() {
 #[test]
 fn naive_duration_compare_weeks_same_ref_day() {
     assert_eq!(
-        NaiveDuration::weeks(Weekday::Mon, 1).partial_cmp(&NaiveDuration::weeks(Weekday::Mon, 0)),
+        NaiveDuration::Weeks(Weekday::Mon, 1).partial_cmp(&NaiveDuration::Weeks(Weekday::Mon, 0)),
         Some(Ordering::Greater),
     );
     assert_eq!(
-        NaiveDuration::weeks(Weekday::Mon, 0).partial_cmp(&NaiveDuration::weeks(Weekday::Mon, 1)),
+        NaiveDuration::Weeks(Weekday::Mon, 0).partial_cmp(&NaiveDuration::Weeks(Weekday::Mon, 1)),
         Some(Ordering::Less),
     );
     assert_eq!(
-        NaiveDuration::weeks(Weekday::Mon, 0).partial_cmp(&NaiveDuration::weeks(Weekday::Mon, 0)),
+        NaiveDuration::Weeks(Weekday::Mon, 0).partial_cmp(&NaiveDuration::Weeks(Weekday::Mon, 0)),
         Some(Ordering::Equal),
     );
 }
@@ -197,15 +197,15 @@ fn naive_duration_compare_weeks_same_ref_day() {
 #[test]
 fn naive_duration_compare_weeks_different_ref_day() {
     assert_eq!(
-        NaiveDuration::weeks(Weekday::Mon, 1).partial_cmp(&NaiveDuration::weeks(Weekday::Sun, 0)),
+        NaiveDuration::Weeks(Weekday::Mon, 1).partial_cmp(&NaiveDuration::Weeks(Weekday::Sun, 0)),
         Some(Ordering::Greater),
     );
     assert_eq!(
-        NaiveDuration::weeks(Weekday::Mon, 0).partial_cmp(&NaiveDuration::weeks(Weekday::Sun, 1)),
+        NaiveDuration::Weeks(Weekday::Mon, 0).partial_cmp(&NaiveDuration::Weeks(Weekday::Sun, 1)),
         Some(Ordering::Less),
     );
     assert_eq!(
-        NaiveDuration::weeks(Weekday::Mon, 0).partial_cmp(&NaiveDuration::weeks(Weekday::Sun, 0)),
+        NaiveDuration::Weeks(Weekday::Mon, 0).partial_cmp(&NaiveDuration::Weeks(Weekday::Sun, 0)),
         Some(Ordering::Equal),
     );
 }
@@ -213,15 +213,15 @@ fn naive_duration_compare_weeks_different_ref_day() {
 #[test]
 fn naive_duration_compare_months() {
     assert_eq!(
-        NaiveDuration::months(1).partial_cmp(&NaiveDuration::months(0)),
+        NaiveDuration::Months(1).partial_cmp(&NaiveDuration::Months(0)),
         Some(Ordering::Greater)
     );
     assert_eq!(
-        NaiveDuration::months(0).partial_cmp(&NaiveDuration::months(1)),
+        NaiveDuration::Months(0).partial_cmp(&NaiveDuration::Months(1)),
         Some(Ordering::Less)
     );
     assert_eq!(
-        NaiveDuration::months(0).partial_cmp(&NaiveDuration::months(0)),
+        NaiveDuration::Months(0).partial_cmp(&NaiveDuration::Months(0)),
         Some(Ordering::Equal)
     );
 }
@@ -229,15 +229,15 @@ fn naive_duration_compare_months() {
 #[test]
 fn naive_duration_compare_years() {
     assert_eq!(
-        NaiveDuration::years(1).partial_cmp(&NaiveDuration::years(0)),
+        NaiveDuration::Years(1).partial_cmp(&NaiveDuration::Years(0)),
         Some(Ordering::Greater)
     );
     assert_eq!(
-        NaiveDuration::years(0).partial_cmp(&NaiveDuration::years(1)),
+        NaiveDuration::Years(0).partial_cmp(&NaiveDuration::Years(1)),
         Some(Ordering::Less)
     );
     assert_eq!(
-        NaiveDuration::years(0).partial_cmp(&NaiveDuration::years(0)),
+        NaiveDuration::Years(0).partial_cmp(&NaiveDuration::Years(0)),
         Some(Ordering::Equal)
     );
 }
@@ -257,7 +257,7 @@ fn checked_add_naive_duration_to_naive_date_positive_days() {
     assert_eq!(
         checked_add_naive_duration_to_naive_date(
             NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
-            NaiveDuration::days(420),
+            NaiveDuration::Days(420),
         )
         .unwrap(),
         NaiveDate::from_ymd_opt(2027, 6, 25).unwrap(),
@@ -269,7 +269,7 @@ fn checked_add_naive_duration_to_naive_date_negative_days() {
     assert_eq!(
         checked_add_naive_duration_to_naive_date(
             NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
-            NaiveDuration::days(-420),
+            NaiveDuration::Days(-420),
         )
         .unwrap(),
         NaiveDate::from_ymd_opt(2025, 3, 7).unwrap(),
@@ -283,7 +283,7 @@ fn checked_add_naive_duration_to_naive_date_zero_weeks_monday_ref() {
     assert_eq!(
         checked_add_naive_duration_to_naive_date(
             NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
-            NaiveDuration::weeks(Weekday::Mon, 0),
+            NaiveDuration::Weeks(Weekday::Mon, 0),
         )
         .unwrap(),
         NaiveDate::from_ymd_opt(2026, 4, 27).unwrap(),
@@ -295,7 +295,7 @@ fn checked_add_naive_duration_to_naive_date_zero_weeks_sunday_ref() {
     assert_eq!(
         checked_add_naive_duration_to_naive_date(
             NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
-            NaiveDuration::weeks(Weekday::Sun, 0),
+            NaiveDuration::Weeks(Weekday::Sun, 0),
         )
         .unwrap(),
         NaiveDate::from_ymd_opt(2026, 4, 26).unwrap(),
@@ -307,7 +307,7 @@ fn checked_add_naive_duration_to_naive_date_zero_weeks_monday_ref_on_sunday() {
     assert_eq!(
         checked_add_naive_duration_to_naive_date(
             NaiveDate::from_ymd_opt(2026, 2, 8).unwrap(),
-            NaiveDuration::weeks(Weekday::Mon, 0),
+            NaiveDuration::Weeks(Weekday::Mon, 0),
         )
         .unwrap(),
         NaiveDate::from_ymd_opt(2026, 2, 2).unwrap(),
@@ -319,7 +319,7 @@ fn checked_add_naive_duration_to_naive_date_zero_weeks_sunday_ref_on_sunday() {
     assert_eq!(
         checked_add_naive_duration_to_naive_date(
             NaiveDate::from_ymd_opt(2026, 2, 8).unwrap(),
-            NaiveDuration::weeks(Weekday::Sun, 0),
+            NaiveDuration::Weeks(Weekday::Sun, 0),
         )
         .unwrap(),
         NaiveDate::from_ymd_opt(2026, 2, 8).unwrap(),
@@ -331,7 +331,7 @@ fn checked_add_naive_duration_to_naive_date_positive_weeks() {
     assert_eq!(
         checked_add_naive_duration_to_naive_date(
             NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
-            NaiveDuration::weeks(Weekday::Mon, 15),
+            NaiveDuration::Weeks(Weekday::Mon, 15),
         )
         .unwrap(),
         NaiveDate::from_ymd_opt(2026, 8, 10).unwrap(),
@@ -343,7 +343,7 @@ fn checked_add_naive_duration_to_naive_date_negative_weeks() {
     assert_eq!(
         checked_add_naive_duration_to_naive_date(
             NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
-            NaiveDuration::weeks(Weekday::Mon, -10),
+            NaiveDuration::Weeks(Weekday::Mon, -10),
         )
         .unwrap(),
         NaiveDate::from_ymd_opt(2026, 2, 16).unwrap(),
@@ -357,7 +357,7 @@ fn checked_add_naive_duration_to_naive_date_zero_months() {
     assert_eq!(
         checked_add_naive_duration_to_naive_date(
             NaiveDate::from_ymd_opt(2026, 5, 20).unwrap(),
-            NaiveDuration::months(0),
+            NaiveDuration::Months(0),
         )
         .unwrap(),
         NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
@@ -369,7 +369,7 @@ fn checked_add_naive_duration_to_naive_date_positive_months_no_extra_year() {
     assert_eq!(
         checked_add_naive_duration_to_naive_date(
             NaiveDate::from_ymd_opt(2026, 5, 20).unwrap(),
-            NaiveDuration::months(30),
+            NaiveDuration::Months(30),
         )
         .unwrap(),
         NaiveDate::from_ymd_opt(2028, 11, 1).unwrap(),
@@ -381,7 +381,7 @@ fn checked_add_naive_duration_to_naive_date_positive_months_extra_year() {
     assert_eq!(
         checked_add_naive_duration_to_naive_date(
             NaiveDate::from_ymd_opt(2026, 10, 20).unwrap(),
-            NaiveDuration::months(30),
+            NaiveDuration::Months(30),
         )
         .unwrap(),
         NaiveDate::from_ymd_opt(2029, 4, 1).unwrap(),
@@ -393,7 +393,7 @@ fn checked_add_naive_duration_to_naive_date_negative_months_no_extra_year() {
     assert_eq!(
         checked_add_naive_duration_to_naive_date(
             NaiveDate::from_ymd_opt(2026, 8, 20).unwrap(),
-            NaiveDuration::months(-30),
+            NaiveDuration::Months(-30),
         )
         .unwrap(),
         NaiveDate::from_ymd_opt(2024, 2, 1).unwrap(),
@@ -405,7 +405,7 @@ fn checked_add_naive_duration_to_naive_date_negative_months_extra_year() {
     assert_eq!(
         checked_add_naive_duration_to_naive_date(
             NaiveDate::from_ymd_opt(2026, 5, 20).unwrap(),
-            NaiveDuration::months(-30),
+            NaiveDuration::Months(-30),
         )
         .unwrap(),
         NaiveDate::from_ymd_opt(2023, 11, 1).unwrap(),
@@ -419,7 +419,7 @@ fn checked_add_naive_duration_to_naive_date_zero_years() {
     assert_eq!(
         checked_add_naive_duration_to_naive_date(
             NaiveDate::from_ymd_opt(2026, 5, 20).unwrap(),
-            NaiveDuration::years(0),
+            NaiveDuration::Years(0),
         )
         .unwrap(),
         NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
@@ -431,7 +431,7 @@ fn checked_add_naive_duration_to_naive_date_positive_years() {
     assert_eq!(
         checked_add_naive_duration_to_naive_date(
             NaiveDate::from_ymd_opt(2026, 5, 20).unwrap(),
-            NaiveDuration::years(10),
+            NaiveDuration::Years(10),
         )
         .unwrap(),
         NaiveDate::from_ymd_opt(2036, 1, 1).unwrap(),
@@ -443,7 +443,7 @@ fn checked_add_naive_duration_to_naive_date_negative_years() {
     assert_eq!(
         checked_add_naive_duration_to_naive_date(
             NaiveDate::from_ymd_opt(2026, 5, 20).unwrap(),
-            NaiveDuration::years(-10),
+            NaiveDuration::Years(-10),
         )
         .unwrap(),
         NaiveDate::from_ymd_opt(2016, 1, 1).unwrap(),
@@ -465,7 +465,7 @@ fn checked_sub_naive_duration_to_naive_date_positive_days() {
     assert_eq!(
         checked_sub_naive_duration_to_naive_date(
             NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
-            NaiveDuration::days(420),
+            NaiveDuration::Days(420),
         )
         .unwrap(),
         NaiveDate::from_ymd_opt(2025, 3, 7).unwrap(),
@@ -477,7 +477,7 @@ fn checked_sub_naive_duration_to_naive_date_negative_days() {
     assert_eq!(
         checked_sub_naive_duration_to_naive_date(
             NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
-            NaiveDuration::days(-420),
+            NaiveDuration::Days(-420),
         )
         .unwrap(),
         NaiveDate::from_ymd_opt(2027, 6, 25).unwrap(),
@@ -491,7 +491,7 @@ fn checked_sub_naive_duration_to_naive_date_zero_weeks_monday_ref() {
     assert_eq!(
         checked_sub_naive_duration_to_naive_date(
             NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
-            NaiveDuration::weeks(Weekday::Mon, 0),
+            NaiveDuration::Weeks(Weekday::Mon, 0),
         )
         .unwrap(),
         NaiveDate::from_ymd_opt(2026, 4, 27).unwrap(),
@@ -503,7 +503,7 @@ fn checked_sub_naive_duration_to_naive_date_zero_weeks_sunday_ref() {
     assert_eq!(
         checked_sub_naive_duration_to_naive_date(
             NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
-            NaiveDuration::weeks(Weekday::Sun, 0),
+            NaiveDuration::Weeks(Weekday::Sun, 0),
         )
         .unwrap(),
         NaiveDate::from_ymd_opt(2026, 4, 26).unwrap(),
@@ -515,7 +515,7 @@ fn checked_sub_naive_duration_to_naive_date_zero_weeks_monday_ref_on_sunday() {
     assert_eq!(
         checked_sub_naive_duration_to_naive_date(
             NaiveDate::from_ymd_opt(2026, 2, 8).unwrap(),
-            NaiveDuration::weeks(Weekday::Mon, 0),
+            NaiveDuration::Weeks(Weekday::Mon, 0),
         )
         .unwrap(),
         NaiveDate::from_ymd_opt(2026, 2, 2).unwrap(),
@@ -527,7 +527,7 @@ fn checked_sub_naive_duration_to_naive_date_zero_weeks_sunday_ref_on_sunday() {
     assert_eq!(
         checked_sub_naive_duration_to_naive_date(
             NaiveDate::from_ymd_opt(2026, 2, 8).unwrap(),
-            NaiveDuration::weeks(Weekday::Sun, 0),
+            NaiveDuration::Weeks(Weekday::Sun, 0),
         )
         .unwrap(),
         NaiveDate::from_ymd_opt(2026, 2, 8).unwrap(),
@@ -539,7 +539,7 @@ fn checked_sub_naive_duration_to_naive_date_positive_weeks() {
     assert_eq!(
         checked_sub_naive_duration_to_naive_date(
             NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
-            NaiveDuration::weeks(Weekday::Mon, 15),
+            NaiveDuration::Weeks(Weekday::Mon, 15),
         )
         .unwrap(),
         NaiveDate::from_ymd_opt(2026, 1, 12).unwrap(),
@@ -551,7 +551,7 @@ fn checked_sub_naive_duration_to_naive_date_negative_weeks() {
     assert_eq!(
         checked_sub_naive_duration_to_naive_date(
             NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
-            NaiveDuration::weeks(Weekday::Mon, -10),
+            NaiveDuration::Weeks(Weekday::Mon, -10),
         )
         .unwrap(),
         NaiveDate::from_ymd_opt(2026, 7, 6).unwrap(),
@@ -565,7 +565,7 @@ fn checked_sub_naive_duration_to_naive_date_zero_months() {
     assert_eq!(
         checked_sub_naive_duration_to_naive_date(
             NaiveDate::from_ymd_opt(2026, 5, 20).unwrap(),
-            NaiveDuration::months(0),
+            NaiveDuration::Months(0),
         )
         .unwrap(),
         NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
@@ -577,7 +577,7 @@ fn checked_sub_naive_duration_to_naive_date_positive_months_no_extra_year() {
     assert_eq!(
         checked_sub_naive_duration_to_naive_date(
             NaiveDate::from_ymd_opt(2026, 8, 20).unwrap(),
-            NaiveDuration::months(30),
+            NaiveDuration::Months(30),
         )
         .unwrap(),
         NaiveDate::from_ymd_opt(2024, 2, 1).unwrap(),
@@ -589,7 +589,7 @@ fn checked_sub_naive_duration_to_naive_date_positive_months_extra_year() {
     assert_eq!(
         checked_sub_naive_duration_to_naive_date(
             NaiveDate::from_ymd_opt(2026, 5, 20).unwrap(),
-            NaiveDuration::months(30),
+            NaiveDuration::Months(30),
         )
         .unwrap(),
         NaiveDate::from_ymd_opt(2023, 11, 1).unwrap(),
@@ -601,7 +601,7 @@ fn checked_sub_naive_duration_to_naive_date_negative_months_no_extra_year() {
     assert_eq!(
         checked_sub_naive_duration_to_naive_date(
             NaiveDate::from_ymd_opt(2026, 10, 20).unwrap(),
-            NaiveDuration::months(-30),
+            NaiveDuration::Months(-30),
         )
         .unwrap(),
         NaiveDate::from_ymd_opt(2029, 4, 1).unwrap(),
@@ -613,7 +613,7 @@ fn checked_sub_naive_duration_to_naive_date_negative_months_extra_year() {
     assert_eq!(
         checked_sub_naive_duration_to_naive_date(
             NaiveDate::from_ymd_opt(2026, 5, 20).unwrap(),
-            NaiveDuration::months(-30),
+            NaiveDuration::Months(-30),
         )
         .unwrap(),
         NaiveDate::from_ymd_opt(2028, 11, 1).unwrap(),
@@ -627,7 +627,7 @@ fn checked_sub_naive_duration_to_naive_date_zero_years() {
     assert_eq!(
         checked_sub_naive_duration_to_naive_date(
             NaiveDate::from_ymd_opt(2026, 5, 20).unwrap(),
-            NaiveDuration::years(0),
+            NaiveDuration::Years(0),
         )
         .unwrap(),
         NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
@@ -639,7 +639,7 @@ fn checked_sub_naive_duration_to_naive_date_positive_years() {
     assert_eq!(
         checked_sub_naive_duration_to_naive_date(
             NaiveDate::from_ymd_opt(2026, 5, 20).unwrap(),
-            NaiveDuration::years(10),
+            NaiveDuration::Years(10),
         )
         .unwrap(),
         NaiveDate::from_ymd_opt(2016, 1, 1).unwrap(),
@@ -651,7 +651,7 @@ fn checked_sub_naive_duration_to_naive_date_negative_years() {
     assert_eq!(
         checked_sub_naive_duration_to_naive_date(
             NaiveDate::from_ymd_opt(2026, 5, 20).unwrap(),
-            NaiveDuration::years(-10),
+            NaiveDuration::Years(-10),
         )
         .unwrap(),
         NaiveDate::from_ymd_opt(2036, 1, 1).unwrap(),

--- a/src/time_tests.rs
+++ b/src/time_tests.rs
@@ -21,6 +21,30 @@ fn naive_month_checked_last_day() {
 }
 
 #[test]
+fn naive_month_ord() {
+    assert_eq!(
+        NaiveMonth::new(2026, Month::January).cmp(&NaiveMonth::new(2026, Month::January)),
+        Ordering::Equal,
+    );
+    assert_eq!(
+        NaiveMonth::new(2025, Month::January).cmp(&NaiveMonth::new(2027, Month::January)),
+        Ordering::Less,
+    );
+    assert_eq!(
+        NaiveMonth::new(2027, Month::January).cmp(&NaiveMonth::new(2025, Month::January)),
+        Ordering::Greater,
+    );
+    assert_eq!(
+        NaiveMonth::new(2026, Month::February).cmp(&NaiveMonth::new(2026, Month::November)),
+        Ordering::Less,
+    );
+    assert_eq!(
+        NaiveMonth::new(2026, Month::November).cmp(&NaiveMonth::new(2026, Month::February)),
+        Ordering::Greater,
+    );
+}
+
+#[test]
 fn naive_duration_days_is_zero() {
     assert!(!NaiveDuration::days(1).is_zero());
     assert!(NaiveDuration::days(0).is_zero());

--- a/src/time_tests.rs
+++ b/src/time_tests.rs
@@ -1,8 +1,24 @@
 use std::cmp::Ordering;
 
-use chrono::{NaiveDate, Weekday};
+use chrono::{Month, NaiveDate, Weekday};
 
 use super::time::*;
+
+#[test]
+fn naive_month_checked_first_day() {
+    assert_eq!(
+        NaiveMonth::new(2026, Month::April).checked_first_day().unwrap(),
+        NaiveDate::from_ymd_opt(2026, 4, 1).unwrap(),
+    );
+}
+
+#[test]
+fn naive_month_checked_last_day() {
+    assert_eq!(
+        NaiveMonth::new(2026, Month::April).checked_last_day().unwrap(),
+        NaiveDate::from_ymd_opt(2026, 4, 30).unwrap(),
+    );
+}
 
 #[test]
 fn naive_duration_days_is_zero() {


### PR DESCRIPTION
# Explanation

Since users commonly need to represent some time intervals, convenience methods were created for that purpose.

There's still convenience methods, such as splitting intervals, that should be implemented, but in order to contain the current code in `dev` in light of the `jiff` overhaul [due to `chrono` being slowly deprecated](https://github.com/chronotope/chrono/issues/1768), I thought merging now would be a good idea before continuing a new convenience methods branch.

Moreover, some logic, like getting the earliest point of a timezone'd day is not possible with `chrono`, so hopefull the overhaul will help reduce the amount of logic needed.

# Changelog

## Added

- Naive durations (days, weeks, etc.) — will probably be (partially or fully) replaced by `jiff`'s `Span`
- Convenience methods for creating absolute intervals representing naive durations relative to the current day
- Convenience methods for creating absolute intervals representing naive durations relative to a given naive date
