### PR TITLE
Improved: Linting and workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,11 +17,11 @@ jobs:
   building:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Build
         run: cargo build --verbose --all-features
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-deps-${{ hashFiles('Cargo.lock') }}
@@ -31,25 +31,35 @@ jobs:
     runs-on: ubuntu-latest
     needs: [building]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-deps-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-deps-
+      - name: Cache nightly toolchain
+        id: cache-nightly-toolchain
+        uses: actions/cache@v5
+        with:
+          path: ~/.rustup/toolchains/nightly-*
+          key: ${{ runner.os }}-rustup-nightly-toolchain-${{ hashFiles('~/.rustup/toolchains/nightly-*') }}
+          restore-keys: ${{ runner.os }}-rustup-nightly-toolchain-
+      - if: ${{ steps.cache-nightly-toolchain.outputs.cache-hit != 'true' }}
+        name: Install nightly toolchain
+        run: rustup toolchain install --no-update --no-self-update nightly
       - name: Clippy
         run: cargo clippy --verbose
       - name: Cargo fmt check
-        run: cargo fmt --check
+        run: cargo +nightly fmt --check
   testing:
     runs-on: ubuntu-latest
     needs: [building]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-deps-${{ hashFiles('Cargo.lock') }}
@@ -61,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [building]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Store active toolchain
         run: echo "ACTIVE_RUST_TOOLCHAIN=$(rustup show active-toolchain | sed 's/ .*$//')" >> $GITHUB_ENV
       - name: Store active target
@@ -69,14 +79,14 @@ jobs:
       - name: Create .local/bin
         run: mkdir -p "$HOME/.local/bin"
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-deps-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-deps-
       - name: Cache llvm-tools component
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cache-llvm-tools
         env:
           # Paths listed in ~/.rustup/toolchains/a-toolchain/lib/rustlib/manifest-llvm-tools-preview-your-target
@@ -135,7 +145,7 @@ jobs:
         name: Install llvm-tools component
         run: rustup component add llvm-tools
       - name: Cache grcov
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cache-grcov
         with:
           path: $HOME/.local/bin/grcov-*
@@ -163,7 +173,7 @@ jobs:
           --ignore-not-existing
           -o target/coverage/html
       - name: Upload code coverage report artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: code coverage report
           path: target/coverage/html/

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,9 +50,9 @@ jobs:
         name: Install nightly toolchain
         run: rustup toolchain install --no-self-update -c rustfmt nightly
       - name: Clippy
-        run: cargo clippy --verbose
+        run: cargo clippy -q
       - name: Cargo fmt check
-        run: cargo +nightly fmt --check
+        run: cargo +nightly fmt -q --check
   testing:
     runs-on: ubuntu-latest
     needs: [building]
@@ -66,7 +66,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-deps-
       - name: Run tests
-        run: cargo test --verbose --all-features --jobs 6
+        run: cargo test -q --all-features --jobs 6
   code_coverage:
     runs-on: ubuntu-latest
     needs: [building]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,7 +48,7 @@ jobs:
           restore-keys: ${{ runner.os }}-rustup-nightly-toolchain-
       - if: ${{ steps.cache-nightly-toolchain.outputs.cache-hit != 'true' }}
         name: Install nightly toolchain
-        run: rustup toolchain install --no-update --no-self-update nightly
+        run: rustup toolchain install --no-update --no-self-update -c rustfmt,cargo-fmt nightly
       - name: Clippy
         run: cargo clippy --verbose
       - name: Cargo fmt check

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,11 +48,11 @@ jobs:
           restore-keys: ${{ runner.os }}-rustup-nightly-toolchain-
       - if: ${{ steps.cache-nightly-toolchain.outputs.cache-hit != 'true' }}
         name: Install nightly toolchain
-        run: rustup toolchain install --no-self-update nightly-1.96.0
+        run: rustup toolchain install --no-self-update nightly
       - name: Clippy
         run: cargo clippy --verbose
       - name: Cargo fmt check
-        run: cargo +nightly-1.96.0 fmt --check
+        run: cargo +nightly fmt --check
   testing:
     runs-on: ubuntu-latest
     needs: [building]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,7 +48,7 @@ jobs:
           restore-keys: ${{ runner.os }}-rustup-nightly-toolchain-
       - if: ${{ steps.cache-nightly-toolchain.outputs.cache-hit != 'true' }}
         name: Install nightly toolchain
-        run: rustup toolchain install --no-self-update nightly
+        run: rustup toolchain install --no-self-update -c rustfmt nightly
       - name: Clippy
         run: cargo clippy --verbose
       - name: Cargo fmt check

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,11 +48,11 @@ jobs:
           restore-keys: ${{ runner.os }}-rustup-nightly-toolchain-
       - if: ${{ steps.cache-nightly-toolchain.outputs.cache-hit != 'true' }}
         name: Install nightly toolchain
-        run: rustup toolchain install --no-update --no-self-update -c rustfmt,cargo-fmt nightly
+        run: rustup toolchain install --no-self-update nightly-1.96.0
       - name: Clippy
         run: cargo clippy --verbose
       - name: Cargo fmt check
-        run: cargo +nightly fmt --check
+        run: cargo +nightly-1.96.0 fmt --check
   testing:
     runs-on: ubuntu-latest
     needs: [building]

--- a/CODE_FORMATTING.md
+++ b/CODE_FORMATTING.md
@@ -42,7 +42,7 @@ While 120 characters may seem like a lot, most IDEs, if fullscreen, even with a 
 are able to fit 120 characters into view, even on screens with some scaling.
 
 This line width limit should be enforced only for source code and comments. Code examples within code documentation
-must not exceed 80 characters per line, as those examples are often displayed in smaller windows/embeds,
+must not exceed 100 characters per line, as those examples are often displayed in smaller windows/embeds,
 and we want to avoid readers having to use horizontal scrolling.
 
 For [VSCode](https://code.visualstudio.com/) and its derivatives, such as [VSCodium](https://vscodium.com/), go to
@@ -53,12 +53,12 @@ In this file, change the `editor.rulers` property to the following:
 
 ```json
     "editor.rulers": [
-        80,
+        100,
         120
     ],
 ```
 
-(The 80 characters ruler is optional)
+(The 100 characters ruler is optional)
 
 ### Newline
 

--- a/CODE_FORMATTING.md
+++ b/CODE_FORMATTING.md
@@ -2,8 +2,12 @@
 
 This file defines the rules of Rust code formatting to follow in this repository.
 
-To format your code, use `cargo fmt`. This command uses the rules set by the `rustfmt.toml` file. If you are unsure
-of how one rule works or what it defines, check out [configurations for rustfmt](https://github.com/rust-lang/rustfmt/blob/master/Configurations.md).
+To format your code, use `cargo +nightly fmt`. This command uses the rules set by the `rustfmt.toml` file.
+If you are unsure of how one rule works or what it defines,
+check out [configurations for rustfmt](https://rust-lang.github.io/rustfmt).
+
+The reason the cargo command uses the nightly toolchain is that a lot of very useful formatting rules are
+unfortunately still not stabilized. To install the nightly toolchain, run `rustup toolchain install nightly`.
 
 More specific rules about how to write the code itself are defined by [Clippy](https://doc.rust-lang.org/stable/clippy/index.html), which you can run by using `cargo clippy`. Its configuration is located in the `Cargo.toml` file. If you
 are unsure of how one rule works or what it defines, check out [the interactive list of clippy lints](https://rust-lang.github.io/rust-clippy/master/index.html).
@@ -32,7 +36,14 @@ For [VSCode](https://code.visualstudio.com/) and its derivatives, such as [VSCod
 Under `imports`, check `Rust-analyzer > Imports > Granularity: Enforce` and set
 `Rust-analyzer > Imports > Granularity: Group` to `module`.
 
-### 120-characters line/ruler
+### 120-characters line width limit
+
+While 120 characters may seem like a lot, most IDEs, if fullscreen, even with a code minimap or explorer open,
+are able to fit 120 characters into view, even on screens with some scaling.
+
+This line width limit should be enforced only for source code and comments. Code examples within code documentation
+must not exceed 80 characters per line, as those examples are often displayed in smaller windows/embeds,
+and we want to avoid readers having to use horizontal scrolling.
 
 For [VSCode](https://code.visualstudio.com/) and its derivatives, such as [VSCodium](https://vscodium.com/), go to
 `Settings` (`Ctrl+,` / gear in the bottom left), and in the `Text Editor` section, no subsection, find `Rulers`, then
@@ -42,16 +53,18 @@ In this file, change the `editor.rulers` property to the following:
 
 ```json
     "editor.rulers": [
+        80,
         120
     ],
 ```
+
+(The 80 characters ruler is optional)
 
 ### Newline
 
 For [VSCode](https://code.visualstudio.com/) and its derivatives, such as [VSCodium](https://vscodium.com/), go to
 `Settings` (`Ctrl+,` / gear in the bottom left), and in the `Text Editor` section, `Files` subsection,
 find `Eol`, and set it to `\n`, then find `Insert Final Newline` and check it.
-
 
 ## Additional rules
 
@@ -76,13 +89,13 @@ can be transformed simply by adding type aliases:
 
 ```rs
 // Acronym
-type SVLTNTTS = SomeVeryLongTypeNameThatTakesSpace;
+type Svltntts = SomeVeryLongTypeNameThatTakesSpace;
 // Or abbreviation
 type LongType = SomeVeryLongTypeNameThatTakesSpace;
 
 match something {
-    SVLTNTTS::A => {},
-    SVLTNTTS::B => {},
+    Svltntts::A => {},
+    Svltntts::B => {},
     LongType::C => {},
     LongType::D => {},
 }
@@ -102,7 +115,7 @@ let mng = ...;
 
 ### Follow Rust API Guidelines
 
-See [the Rust API Guidelines Checklist](https://rust-lang.github.io/api-guidelines/checklist.html)
+See [the Rust API Guidelines Checklist](https://rust-lang.github.io/api-guidelines/checklist.html).
 
 ### File structure
 
@@ -270,3 +283,66 @@ mod shiny;
 #[cfg(test)]
 mod shiny_tests;
 ```
+
+### Unit tests should be granular
+
+The number of unit tests for a given module can rapidly grow, leading to unit tests being ordered arbitrarily.
+
+In order to avoid that, we recommend that your unit tests should be modularized in relevant smaller units.
+For example, if we want to test such a trait:
+
+```rs
+trait MyTrait {
+    fn foo() {…}
+
+    fn bar() {…}
+}
+```
+
+that is implemented on `Abc` and `Xyz`, then ideally the test suite should be split in a similar manner to:
+
+```rs
+// MyTrait test suite
+
+use your_things::*;
+
+mod foo {
+    use super::*;
+
+    mod abc {
+        use super::*;
+    }
+
+    mod xyz {
+        use super::*;
+    }
+}
+
+mod bar {
+    mod abc {
+        use super::*;
+    }
+
+    mod xyz {
+        use super::*;
+    }
+}
+```
+
+### Unit tests should not repeat tested item's name
+
+If the aforementioned rule is followed, instead of naming your test `my_trait_foo_abc_scenario_one`, it will be
+possible to identify it through the modules it is in.
+
+In this case, `my_trait_foo_abc_scenario_one` will be in a file called `my_trait_tests.rs`, within the `abc` module
+inside of the `foo` module. Then we rename the test unit to `scenario_one`
+
+When the tests are run, you will see that it will be identified as `my_trait_tests::foo::abc::scenario_one`
+instead of `my_trait_tests::my_trait_foo_abc_scenario_one`.
+
+This allows for running test suites more granularly when testing behaviors:
+running `cargo test my_trait_tests::foo::abc` instead of `cargo test my_trait_tests::my_trait_foo_abc_scenario_one`,
+which can be subject to matching unwanted tests (as the `cargo test` argument is matched as a substring, not prefix).
+
+Overall it also improves readability (no repeated information) and programmers can fold relevant modules that
+they are not touching instead of having to filter all test units.

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,8 @@ Link relevant issues and PRs here!
 
 Explain the motivation for this PR and what it does/solves
 
-# Changelog
+<details>
+<summary><h1>Changelog</h1></summary>
 
 Remove the sections that don't apply to your PR
 
@@ -31,3 +32,5 @@ Remove the sections that don't apply to your PR
 ## Security
 
 - Vulnerabilities you've fixed (add relevant CVE and any other relevant info/links)
+
+</details>

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -212,3 +212,19 @@ But there's also additional rules on coding that you should generally follow.
 
 Warnings should be considered like errors, even if it's a warning with low priority, such as warnings from the
 `pedantic` group of lints of `clippy`. Warnings shouldn't be ignored and should be resolved as much as possible.
+
+## When working on a branch
+
+Sometimes it can be hard to track all your changes on one branch, especially for when you reach the end and need
+to write a changelog and a description.
+
+Some people use AI to generate a description of their changes, but in the process you lose information about intent
+of changes, personal notes you may have, ideas, etc.
+
+In order to remediate to that problem use a "branch notes" markdown file. I recommend `branch-changelog.md`,
+but the actual name and format is left to your discretion.
+
+In this file, feel free to write and track your progress for the branch, but try to clean it once the PR is opened
+and the notes moved to the PR's description.
+
+The file can be pushed to the repository, allowing for keeping track of your notes across devices.

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -52,6 +52,7 @@ Edit your `~/.gitconfig` to include the following.
 	rs = restore
 	rb = rebase
 	p = push
+	prb = pull --rebase
 	pf = push --force-with-lease
 	pt = push --tags
     # Creates a branch and switches to it
@@ -114,11 +115,7 @@ In order to enforce that, merges from any branch into `dev` should be done by us
 following [the commit rules](#commits).
 
 When the `dev` branch has reached a stable state, usually after making sure all tests are passing, it can be merged
-into `main`.
-This merge should be squashed first so that `main` remains linear and could be extracted as its own product.
-
-To do that, use `git merge --squash --no-ff` and when committing, provide a meaningful message and description, in
-accordance to [the commit rules](#commits).
+into `main` through a detailed PR.
 
 Now, when you start working on a new thing, you should branch off `dev` and should name it by following the syntax
 `<type>/<name>`, where `<type>` is the most relevant choice out of the list below, and where `<name>` is

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,5 +1,5 @@
 comment_width = 120
-doc_comment_code_block_width = 80
+doc_comment_code_block_width = 100
 float_literal_trailing_zero = "Always"
 format_code_in_doc_comments = true
 format_macro_matchers = true

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,9 @@
+comment_width = 120
+doc_comment_code_block_width = 80
+float_literal_trailing_zero = "Always"
+format_code_in_doc_comments = true
+format_macro_matchers = true
+format_strings = true
 group_imports = "StdExternalCrate"
 imports_granularity = "Module"
 imports_layout = "HorizontalVertical"
@@ -8,6 +14,7 @@ reorder_impl_items = true
 reorder_imports = true
 reorder_modules = true
 struct_lit_single_line = false
+struct_lit_width = 0
 use_field_init_shorthand = true
 use_try_shorthand = true
 wrap_comments = true

--- a/src/intervals.rs
+++ b/src/intervals.rs
@@ -33,8 +33,7 @@
 //! When coming from an interval, they have the following invariants:
 //!
 //! 1. The start and end must be in chronological order
-//! 2. If both points are at the same position, their [bound
-//!    inclusivities](meta::BoundInclusivity) can only be
+//! 2. If both points are at the same position, their [bound inclusivities](meta::BoundInclusivity) can only be
 //!    [inclusive](meta::BoundInclusivity::Inclusive)
 //!
 //! Bounds can be modified however you want, as they don't need to conserve

--- a/src/intervals/absolute/bound.rs
+++ b/src/intervals/absolute/bound.rs
@@ -39,12 +39,8 @@ impl AbsoluteBound {
     /// let start_time = "2025-01-01 08:00:00Z".parse::<Timestamp>()?;
     /// let end_time = "2025-01-01 16:00:00Z".parse::<Timestamp>()?;
     ///
-    /// let start = AbsoluteBound::Start(
-    ///     AbsoluteFiniteBound::new(start_time).to_start_bound()
-    /// );
-    /// let end = AbsoluteBound::End(
-    ///     AbsoluteFiniteBound::new(end_time).to_end_bound()
-    /// );
+    /// let start = AbsoluteBound::Start(AbsoluteFiniteBound::new(start_time).to_start_bound());
+    /// let end = AbsoluteBound::End(AbsoluteFiniteBound::new(end_time).to_end_bound());
     ///
     /// assert!(start.is_start());
     /// assert!(!end.is_start());
@@ -66,12 +62,8 @@ impl AbsoluteBound {
     /// let start_time = "2025-01-01 08:00:00Z".parse::<Timestamp>()?;
     /// let end_time = "2025-01-01 16:00:00Z".parse::<Timestamp>()?;
     ///
-    /// let start = AbsoluteBound::Start(
-    ///     AbsoluteFiniteBound::new(start_time).to_start_bound()
-    /// );
-    /// let end = AbsoluteBound::End(
-    ///     AbsoluteFiniteBound::new(end_time).to_end_bound()
-    /// );
+    /// let start = AbsoluteBound::Start(AbsoluteFiniteBound::new(start_time).to_start_bound());
+    /// let end = AbsoluteBound::End(AbsoluteFiniteBound::new(end_time).to_end_bound());
     ///
     /// assert!(end.is_end());
     /// assert!(!start.is_end());
@@ -99,21 +91,14 @@ impl AbsoluteBound {
     /// let start_time = "2025-01-01 08:00:00Z".parse::<Timestamp>()?;
     /// let end_time = "2025-01-01 16:00:00Z".parse::<Timestamp>()?;
     ///
-    /// let start = AbsoluteBound::Start(
-    ///     AbsoluteFiniteBound::new(start_time).to_start_bound()
-    /// );
-    /// let end = AbsoluteBound::End(
-    ///     AbsoluteFiniteBound::new(end_time).to_end_bound()
-    /// );
+    /// let start = AbsoluteBound::Start(AbsoluteFiniteBound::new(start_time).to_start_bound());
+    /// let end = AbsoluteBound::End(AbsoluteFiniteBound::new(end_time).to_end_bound());
     ///
     /// assert_eq!(
     ///     start.start(),
     ///     Some(AbsoluteFiniteBound::new(start_time).to_start_bound()),
     /// );
-    /// assert_eq!(
-    ///     end.start(),
-    ///     None,
-    /// );
+    /// assert_eq!(end.start(), None,);
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
     #[must_use]
@@ -141,21 +126,14 @@ impl AbsoluteBound {
     /// let start_time = "2025-01-01 08:00:00Z".parse::<Timestamp>()?;
     /// let end_time = "2025-01-01 16:00:00Z".parse::<Timestamp>()?;
     ///
-    /// let start = AbsoluteBound::Start(
-    ///     AbsoluteFiniteBound::new(start_time).to_start_bound()
-    /// );
-    /// let end = AbsoluteBound::End(
-    ///     AbsoluteFiniteBound::new(end_time).to_end_bound()
-    /// );
+    /// let start = AbsoluteBound::Start(AbsoluteFiniteBound::new(start_time).to_start_bound());
+    /// let end = AbsoluteBound::End(AbsoluteFiniteBound::new(end_time).to_end_bound());
     ///
     /// assert_eq!(
     ///     end.end(),
     ///     Some(AbsoluteFiniteBound::new(end_time).to_end_bound()),
     /// );
-    /// assert_eq!(
-    ///     start.end(),
-    ///     None,
-    /// );
+    /// assert_eq!(start.end(), None,);
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
     #[must_use]

--- a/src/intervals/absolute/bound_pair.rs
+++ b/src/intervals/absolute/bound_pair.rs
@@ -154,10 +154,7 @@ impl AbsoluteBoundPair {
     /// );
     /// assert_eq!(
     ///     bounds.end(),
-    ///     AbsoluteFiniteBound::new_with_inclusivity(
-    ///         end,
-    ///         BoundInclusivity::Exclusive,
-    ///     ).to_end_bound(),
+    ///     AbsoluteFiniteBound::new_with_inclusivity(end, BoundInclusivity::Exclusive,).to_end_bound(),
     /// );
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```

--- a/src/intervals/absolute/bounded_interval.rs
+++ b/src/intervals/absolute/bounded_interval.rs
@@ -147,8 +147,14 @@ impl BoundedAbsoluteInterval {
     ///     BoundInclusivity::Exclusive,
     /// );
     ///
-    /// assert_eq!(bounded_interval.start_inclusivity(), BoundInclusivity::Inclusive);
-    /// assert_eq!(bounded_interval.end_inclusivity(), BoundInclusivity::Exclusive);
+    /// assert_eq!(
+    ///     bounded_interval.start_inclusivity(),
+    ///     BoundInclusivity::Inclusive
+    /// );
+    /// assert_eq!(
+    ///     bounded_interval.end_inclusivity(),
+    ///     BoundInclusivity::Exclusive
+    /// );
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
     #[must_use]
@@ -194,8 +200,14 @@ impl BoundedAbsoluteInterval {
     /// );
     ///
     /// // Therefore gets reset to inclusive for both bounds
-    /// assert_eq!(bounded_interval.start_inclusivity(), BoundInclusivity::Inclusive);
-    /// assert_eq!(bounded_interval.end_inclusivity(), BoundInclusivity::Inclusive);
+    /// assert_eq!(
+    ///     bounded_interval.start_inclusivity(),
+    ///     BoundInclusivity::Inclusive
+    /// );
+    /// assert_eq!(
+    ///     bounded_interval.end_inclusivity(),
+    ///     BoundInclusivity::Inclusive
+    /// );
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
     #[must_use]
@@ -273,7 +285,10 @@ impl BoundedAbsoluteInterval {
     ///     BoundInclusivity::Exclusive,
     /// );
     ///
-    /// assert_eq!(bounded_interval.start_inclusivity(), BoundInclusivity::Exclusive);
+    /// assert_eq!(
+    ///     bounded_interval.start_inclusivity(),
+    ///     BoundInclusivity::Exclusive
+    /// );
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
     #[must_use]
@@ -300,7 +315,10 @@ impl BoundedAbsoluteInterval {
     ///     BoundInclusivity::Exclusive,
     /// );
     ///
-    /// assert_eq!(bounded_interval.end_inclusivity(), BoundInclusivity::Exclusive);
+    /// assert_eq!(
+    ///     bounded_interval.end_inclusivity(),
+    ///     BoundInclusivity::Exclusive
+    /// );
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
     #[must_use]
@@ -479,8 +497,14 @@ impl BoundedAbsoluteInterval {
     /// bounded_interval.unchecked_set_start_inclusivity(BoundInclusivity::Exclusive);
     ///
     /// // Yet stays that way
-    /// assert_eq!(bounded_interval.start_inclusivity(), BoundInclusivity::Exclusive);
-    /// assert_eq!(bounded_interval.end_inclusivity(), BoundInclusivity::Inclusive);
+    /// assert_eq!(
+    ///     bounded_interval.start_inclusivity(),
+    ///     BoundInclusivity::Exclusive
+    /// );
+    /// assert_eq!(
+    ///     bounded_interval.end_inclusivity(),
+    ///     BoundInclusivity::Inclusive
+    /// );
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
     pub fn unchecked_set_start_inclusivity(&mut self, new_start_inclusivity: BoundInclusivity) {
@@ -504,8 +528,14 @@ impl BoundedAbsoluteInterval {
     /// bounded_interval.unchecked_set_end_inclusivity(BoundInclusivity::Exclusive);
     ///
     /// // Yet stays that way
-    /// assert_eq!(bounded_interval.start_inclusivity(), BoundInclusivity::Inclusive);
-    /// assert_eq!(bounded_interval.end_inclusivity(), BoundInclusivity::Exclusive);
+    /// assert_eq!(
+    ///     bounded_interval.start_inclusivity(),
+    ///     BoundInclusivity::Inclusive
+    /// );
+    /// assert_eq!(
+    ///     bounded_interval.end_inclusivity(),
+    ///     BoundInclusivity::Exclusive
+    /// );
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
     pub fn unchecked_set_end_inclusivity(&mut self, new_end_inclusivity: BoundInclusivity) {
@@ -534,8 +564,14 @@ impl BoundedAbsoluteInterval {
     ///
     /// bounded_interval.set_start_inclusivity(BoundInclusivity::Exclusive);
     ///
-    /// assert_eq!(bounded_interval.start_inclusivity(), BoundInclusivity::Exclusive);
-    /// assert_eq!(bounded_interval.end_inclusivity(), BoundInclusivity::Inclusive);
+    /// assert_eq!(
+    ///     bounded_interval.start_inclusivity(),
+    ///     BoundInclusivity::Exclusive
+    /// );
+    /// assert_eq!(
+    ///     bounded_interval.end_inclusivity(),
+    ///     BoundInclusivity::Inclusive
+    /// );
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
     pub fn set_start_inclusivity(
@@ -572,8 +608,14 @@ impl BoundedAbsoluteInterval {
     ///
     /// bounded_interval.set_end_inclusivity(BoundInclusivity::Exclusive);
     ///
-    /// assert_eq!(bounded_interval.start_inclusivity(), BoundInclusivity::Inclusive);
-    /// assert_eq!(bounded_interval.end_inclusivity(), BoundInclusivity::Exclusive);
+    /// assert_eq!(
+    ///     bounded_interval.start_inclusivity(),
+    ///     BoundInclusivity::Inclusive
+    /// );
+    /// assert_eq!(
+    ///     bounded_interval.end_inclusivity(),
+    ///     BoundInclusivity::Exclusive
+    /// );
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
     pub fn set_end_inclusivity(

--- a/src/intervals/absolute/end_bound.rs
+++ b/src/intervals/absolute/end_bound.rs
@@ -105,7 +105,10 @@ impl AbsoluteEndBound {
     /// let time = "2025-01-01 08:00:00Z".parse::<Timestamp>()?;
     /// let finite_end_bound = AbsoluteFiniteBound::new(time).to_end_bound();
     ///
-    /// assert_eq!(finite_end_bound.finite(), Some(AbsoluteFiniteBound::new(time)));
+    /// assert_eq!(
+    ///     finite_end_bound.finite(),
+    ///     Some(AbsoluteFiniteBound::new(time))
+    /// );
     /// assert_eq!(infinite_end_bound.finite(), None);
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
@@ -150,9 +153,7 @@ impl AbsoluteEndBound {
     /// let time = "2025-01-01 08:00:00Z".parse::<Timestamp>()?;
     ///
     /// let end_first_shift = AbsoluteFiniteBound::new(time).to_end_bound();
-    /// let break_start = end_first_shift
-    ///     .opposite()
-    ///     .ok_or(FiniteBoundExpectedError)?;
+    /// let break_start = end_first_shift.opposite().ok_or(FiniteBoundExpectedError)?;
     ///
     /// assert_eq!(
     ///     break_start.finite(),

--- a/src/intervals/absolute/finite_bound.rs
+++ b/src/intervals/absolute/finite_bound.rs
@@ -202,8 +202,8 @@ impl Display for AbsoluteFiniteBoundFromBoundError {
             Self::IsUnbounded => {
                 write!(
                     f,
-                    "The given bound was of the `Unbounded` variant, \
-                    and therefore could not be converted to an `AbsoluteFiniteBound`"
+                    "The given bound was of the `Unbounded` variant, and therefore could not be converted to an \
+                     `AbsoluteFiniteBound`"
                 )
             },
         }

--- a/src/intervals/absolute/half_bounded_interval.rs
+++ b/src/intervals/absolute/half_bounded_interval.rs
@@ -71,14 +71,18 @@ impl HalfBoundedAbsoluteInterval {
     /// # use periodical::intervals::meta::{BoundInclusivity, OpeningDirection};
     /// let ref_time = "2025-01-01 08:00:00Z".parse::<Timestamp>()?;
     ///
-    /// let half_bounded_interval = HalfBoundedAbsoluteInterval::new(
-    ///     ref_time,
-    ///     OpeningDirection::ToPast,
-    /// );
+    /// let half_bounded_interval =
+    ///     HalfBoundedAbsoluteInterval::new(ref_time, OpeningDirection::ToPast);
     ///
     /// assert_eq!(half_bounded_interval.reference(), ref_time);
-    /// assert_eq!(half_bounded_interval.reference_inclusivity(), BoundInclusivity::Inclusive);
-    /// assert_eq!(half_bounded_interval.opening_direction(), OpeningDirection::ToPast);
+    /// assert_eq!(
+    ///     half_bounded_interval.reference_inclusivity(),
+    ///     BoundInclusivity::Inclusive
+    /// );
+    /// assert_eq!(
+    ///     half_bounded_interval.opening_direction(),
+    ///     OpeningDirection::ToPast
+    /// );
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
     #[must_use]
@@ -109,8 +113,14 @@ impl HalfBoundedAbsoluteInterval {
     /// );
     ///
     /// assert_eq!(half_bounded_interval.reference(), ref_time);
-    /// assert_eq!(half_bounded_interval.reference_inclusivity(), BoundInclusivity::Exclusive);
-    /// assert_eq!(half_bounded_interval.opening_direction(), OpeningDirection::ToFuture);
+    /// assert_eq!(
+    ///     half_bounded_interval.reference_inclusivity(),
+    ///     BoundInclusivity::Exclusive
+    /// );
+    /// assert_eq!(
+    ///     half_bounded_interval.opening_direction(),
+    ///     OpeningDirection::ToFuture
+    /// );
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
     #[must_use]
@@ -137,10 +147,8 @@ impl HalfBoundedAbsoluteInterval {
     /// # use periodical::intervals::meta::OpeningDirection;
     /// let ref_time = "2025-01-01 08:00:00Z".parse::<Timestamp>()?;
     ///
-    /// let half_bounded_interval = HalfBoundedAbsoluteInterval::new(
-    ///     ref_time,
-    ///     OpeningDirection::ToPast,
-    /// );
+    /// let half_bounded_interval =
+    ///     HalfBoundedAbsoluteInterval::new(ref_time, OpeningDirection::ToPast);
     ///
     /// assert_eq!(half_bounded_interval.reference(), ref_time);
     /// # Ok::<(), Box<dyn Error>>(())
@@ -161,12 +169,13 @@ impl HalfBoundedAbsoluteInterval {
     /// # use periodical::intervals::meta::OpeningDirection;
     /// let ref_time = "2025-01-01 08:00:00Z".parse::<Timestamp>()?;
     ///
-    /// let half_bounded_interval = HalfBoundedAbsoluteInterval::new(
-    ///     ref_time,
-    ///     OpeningDirection::ToPast,
-    /// );
+    /// let half_bounded_interval =
+    ///     HalfBoundedAbsoluteInterval::new(ref_time, OpeningDirection::ToPast);
     ///
-    /// assert_eq!(half_bounded_interval.opening_direction(), OpeningDirection::ToPast);
+    /// assert_eq!(
+    ///     half_bounded_interval.opening_direction(),
+    ///     OpeningDirection::ToPast
+    /// );
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
     #[must_use]
@@ -189,7 +198,10 @@ impl HalfBoundedAbsoluteInterval {
     ///     OpeningDirection::ToFuture,
     /// );
     ///
-    /// assert_eq!(half_bounded_interval.reference_inclusivity(), BoundInclusivity::Exclusive);
+    /// assert_eq!(
+    ///     half_bounded_interval.reference_inclusivity(),
+    ///     BoundInclusivity::Exclusive
+    /// );
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
     #[must_use]
@@ -208,10 +220,8 @@ impl HalfBoundedAbsoluteInterval {
     /// # use periodical::intervals::meta::OpeningDirection;
     /// let ref_time = "2025-01-01 08:00:00Z".parse::<Timestamp>()?;
     ///
-    /// let mut half_bounded_interval = HalfBoundedAbsoluteInterval::new(
-    ///     ref_time,
-    ///     OpeningDirection::ToFuture,
-    /// );
+    /// let mut half_bounded_interval =
+    ///     HalfBoundedAbsoluteInterval::new(ref_time, OpeningDirection::ToFuture);
     ///
     /// let new_ref_time = "2025-01-01 16:00:00Z".parse::<Timestamp>()?;
     ///
@@ -235,14 +245,15 @@ impl HalfBoundedAbsoluteInterval {
     /// # use periodical::intervals::meta::{BoundInclusivity, OpeningDirection};
     /// let ref_time = "2025-01-01 08:00:00Z".parse::<Timestamp>()?;
     ///
-    /// let mut half_bounded_interval = HalfBoundedAbsoluteInterval::new(
-    ///     ref_time,
-    ///     OpeningDirection::ToFuture,
-    /// );
+    /// let mut half_bounded_interval =
+    ///     HalfBoundedAbsoluteInterval::new(ref_time, OpeningDirection::ToFuture);
     ///
     /// half_bounded_interval.set_reference_inclusivity(BoundInclusivity::Exclusive);
     ///
-    /// assert_eq!(half_bounded_interval.reference_inclusivity(), BoundInclusivity::Exclusive);
+    /// assert_eq!(
+    ///     half_bounded_interval.reference_inclusivity(),
+    ///     BoundInclusivity::Exclusive
+    /// );
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
     pub fn set_reference_inclusivity(&mut self, new_inclusivity: BoundInclusivity) {
@@ -260,14 +271,15 @@ impl HalfBoundedAbsoluteInterval {
     /// # use periodical::intervals::meta::OpeningDirection;
     /// let ref_time = "2025-01-01 08:00:00Z".parse::<Timestamp>()?;
     ///
-    /// let mut half_bounded_interval = HalfBoundedAbsoluteInterval::new(
-    ///     ref_time,
-    ///     OpeningDirection::ToFuture,
-    /// );
+    /// let mut half_bounded_interval =
+    ///     HalfBoundedAbsoluteInterval::new(ref_time, OpeningDirection::ToFuture);
     ///
     /// half_bounded_interval.set_opening_direction(OpeningDirection::ToPast);
     ///
-    /// assert_eq!(half_bounded_interval.opening_direction(), OpeningDirection::ToPast);
+    /// assert_eq!(
+    ///     half_bounded_interval.opening_direction(),
+    ///     OpeningDirection::ToPast
+    /// );
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
     pub fn set_opening_direction(&mut self, new_opening_direction: OpeningDirection) {

--- a/src/intervals/absolute/start_bound.rs
+++ b/src/intervals/absolute/start_bound.rs
@@ -106,7 +106,10 @@ impl AbsoluteStartBound {
     /// let time = "2025-01-01 08:00:00Z".parse::<Timestamp>()?;
     /// let finite_start_bound = AbsoluteFiniteBound::new(time).to_start_bound();
     ///
-    /// assert_eq!(finite_start_bound.finite(), Some(AbsoluteFiniteBound::new(time)));
+    /// assert_eq!(
+    ///     finite_start_bound.finite(),
+    ///     Some(AbsoluteFiniteBound::new(time))
+    /// );
     /// assert_eq!(infinite_start_bound.finite(), None);
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```

--- a/src/intervals/convenience/absolute/bounded_interval.rs
+++ b/src/intervals/convenience/absolute/bounded_interval.rs
@@ -48,12 +48,16 @@ impl BoundedAbsoluteInterval {
     ///
     /// assert_eq!(
     ///     interval.start(),
-    ///     "2026-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2026-01-05 00:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     /// );
     /// assert_eq!(interval.start_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(
     ///     interval.end(),
-    ///     "2026-01-06 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2026-01-06 00:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     /// );
     /// assert_eq!(interval.end_inclusivity(), BoundInclusivity::Exclusive);
     /// # Ok::<(), Box<dyn Error>>(())
@@ -116,12 +120,16 @@ impl BoundedAbsoluteInterval {
     ///
     /// assert_eq!(
     ///     interval.start(),
-    ///     "2026-05-06 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2026-05-06 00:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     /// );
     /// assert_eq!(interval.start_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(
     ///     interval.end(),
-    ///     "2026-05-07 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2026-05-07 00:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     /// );
     /// assert_eq!(interval.end_inclusivity(), BoundInclusivity::Exclusive);
     /// # Ok::<(), Box<dyn Error>>(())
@@ -176,12 +184,16 @@ impl BoundedAbsoluteInterval {
     ///
     /// assert_eq!(
     ///     interval.start(),
-    ///     "2026-04-26 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2026-04-26 00:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     /// );
     /// assert_eq!(interval.start_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(
     ///     interval.end(),
-    ///     "2026-04-27 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2026-04-27 00:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     /// );
     /// assert_eq!(interval.end_inclusivity(), BoundInclusivity::Exclusive);
     /// # Ok::<(), Box<dyn Error>>(())
@@ -356,12 +368,16 @@ impl BoundedAbsoluteInterval {
     ///
     /// assert_eq!(
     ///     interval.start(),
-    ///     "2026-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2026-01-04 00:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     /// );
     /// assert_eq!(interval.start_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(
     ///     interval.end(),
-    ///     "2026-01-11 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2026-01-11 00:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     /// );
     /// assert_eq!(interval.end_inclusivity(), BoundInclusivity::Exclusive);
     /// # Ok::<(), Box<dyn Error>>(())
@@ -426,12 +442,19 @@ impl BoundedAbsoluteInterval {
     ///
     /// assert_eq!(
     ///     week_interval.start(),
-    ///     "2026-01-26 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2026-01-26 00:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     /// );
-    /// assert_eq!(week_interval.start_inclusivity(), BoundInclusivity::Inclusive);
+    /// assert_eq!(
+    ///     week_interval.start_inclusivity(),
+    ///     BoundInclusivity::Inclusive
+    /// );
     /// assert_eq!(
     ///     week_interval.end(),
-    ///     "2026-02-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2026-02-02 00:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     /// );
     /// assert_eq!(week_interval.end_inclusivity(), BoundInclusivity::Exclusive);
     /// # Ok::<(), Box<dyn Error>>(())
@@ -491,12 +514,16 @@ impl BoundedAbsoluteInterval {
     ///
     /// assert_eq!(
     ///     interval.start(),
-    ///     "2026-03-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2026-03-01 00:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     /// );
     /// assert_eq!(interval.start_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(
     ///     interval.end(),
-    ///     "2026-04-08 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2026-04-08 00:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     /// );
     /// assert_eq!(interval.end_inclusivity(), BoundInclusivity::Exclusive);
     /// # Ok::<(), Box<dyn Error>>(())
@@ -551,12 +578,16 @@ impl BoundedAbsoluteInterval {
     ///
     /// assert_eq!(
     ///     month.start(),
-    ///     "2026-05-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2026-05-01 00:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     /// );
     /// assert_eq!(month.start_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(
     ///     month.end(),
-    ///     "2026-06-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2026-06-01 00:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     /// );
     /// assert_eq!(month.end_inclusivity(), BoundInclusivity::Exclusive);
     /// # Ok::<(), Box<dyn Error>>(())
@@ -607,12 +638,16 @@ impl BoundedAbsoluteInterval {
     ///
     /// assert_eq!(
     ///     interval.start(),
-    ///     "2026-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2026-01-01 00:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     /// );
     /// assert_eq!(interval.start_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(
     ///     interval.end(),
-    ///     "2026-06-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2026-06-01 00:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     /// );
     /// assert_eq!(interval.end_inclusivity(), BoundInclusivity::Exclusive);
     /// # Ok::<(), Box<dyn Error>>(())
@@ -674,12 +709,16 @@ impl BoundedAbsoluteInterval {
     ///
     /// assert_eq!(
     ///     interval.start(),
-    ///     "2026-03-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2026-03-01 00:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     /// );
     /// assert_eq!(interval.start_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(
     ///     interval.end(),
-    ///     "2026-04-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2026-04-01 00:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     /// );
     /// assert_eq!(interval.end_inclusivity(), BoundInclusivity::Exclusive);
     /// # Ok::<(), Box<dyn Error>>(())
@@ -740,12 +779,16 @@ impl BoundedAbsoluteInterval {
     ///
     /// assert_eq!(
     ///     interval.start(),
-    ///     "2026-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2026-02-01 00:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     /// );
     /// assert_eq!(interval.start_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(
     ///     interval.end(),
-    ///     "2026-03-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2026-03-01 00:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     /// );
     /// assert_eq!(interval.end_inclusivity(), BoundInclusivity::Exclusive);
     /// # Ok::<(), Box<dyn Error>>(())
@@ -921,12 +964,16 @@ impl BoundedAbsoluteInterval {
     ///
     /// assert_eq!(
     ///     year.start(),
-    ///     "2026-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2026-01-01 00:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     /// );
     /// assert_eq!(year.start_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(
     ///     year.end(),
-    ///     "2027-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2027-01-01 00:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     /// );
     /// assert_eq!(year.end_inclusivity(), BoundInclusivity::Exclusive);
     /// # Ok::<(), Box<dyn Error>>(())
@@ -971,12 +1018,16 @@ impl BoundedAbsoluteInterval {
     ///
     /// assert_eq!(
     ///     years.start(),
-    ///     "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2025-01-01 00:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     /// );
     /// assert_eq!(years.start_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(
     ///     years.end(),
-    ///     "2031-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2031-01-01 00:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     /// );
     /// assert_eq!(years.end_inclusivity(), BoundInclusivity::Exclusive);
     /// # Ok::<(), Box<dyn Error>>(())
@@ -1035,12 +1086,16 @@ impl BoundedAbsoluteInterval {
     ///
     /// assert_eq!(
     ///     year.start(),
-    ///     "2027-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2027-01-01 00:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     /// );
     /// assert_eq!(year.start_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(
     ///     year.end(),
-    ///     "2028-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2028-01-01 00:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     /// );
     /// assert_eq!(year.end_inclusivity(), BoundInclusivity::Exclusive);
     /// # Ok::<(), Box<dyn Error>>(())
@@ -1097,12 +1152,16 @@ impl BoundedAbsoluteInterval {
     ///
     /// assert_eq!(
     ///     year.start(),
-    ///     "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2025-01-01 00:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     /// );
     /// assert_eq!(year.start_inclusivity(), BoundInclusivity::Inclusive);
     /// assert_eq!(
     ///     year.end(),
-    ///     "2026-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2026-01-01 00:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     /// );
     /// assert_eq!(year.end_inclusivity(), BoundInclusivity::Exclusive);
     /// # Ok::<(), Box<dyn Error>>(())

--- a/src/intervals/convenience/absolute/half_bounded_interval.rs
+++ b/src/intervals/convenience/absolute/half_bounded_interval.rs
@@ -78,10 +78,18 @@ impl HalfBoundedAbsoluteInterval {
     ///
     /// assert_eq!(
     ///     from_first_of_may.reference(),
-    ///     "2026-05-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2026-05-01 00:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     /// );
-    /// assert_eq!(from_first_of_may.reference_inclusivity(), BoundInclusivity::Inclusive);
-    /// assert_eq!(from_first_of_may.opening_direction(), OpeningDirection::ToFuture);
+    /// assert_eq!(
+    ///     from_first_of_may.reference_inclusivity(),
+    ///     BoundInclusivity::Inclusive
+    /// );
+    /// assert_eq!(
+    ///     from_first_of_may.opening_direction(),
+    ///     OpeningDirection::ToFuture
+    /// );
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
     pub fn since_date(date: Date, tz: TimeZone) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError> {
@@ -120,10 +128,18 @@ impl HalfBoundedAbsoluteInterval {
     ///
     /// assert_eq!(
     ///     until_first_of_may.reference(),
-    ///     "2026-05-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2026-05-01 00:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     /// );
-    /// assert_eq!(until_first_of_may.reference_inclusivity(), BoundInclusivity::Exclusive);
-    /// assert_eq!(until_first_of_may.opening_direction(), OpeningDirection::ToPast);
+    /// assert_eq!(
+    ///     until_first_of_may.reference_inclusivity(),
+    ///     BoundInclusivity::Exclusive
+    /// );
+    /// assert_eq!(
+    ///     until_first_of_may.opening_direction(),
+    ///     OpeningDirection::ToPast
+    /// );
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
     pub fn until_date(date: Date, tz: TimeZone) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError> {
@@ -203,7 +219,8 @@ impl HalfBoundedAbsoluteInterval {
     /// # use std::error::Error;
     /// # use jiff::tz::TimeZone;
     /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
-    /// let since_tomorrow = HalfBoundedAbsoluteInterval::since_tomorrow(TimeZone::get("Europe/Oslo")?)?;
+    /// let since_tomorrow =
+    ///     HalfBoundedAbsoluteInterval::since_tomorrow(TimeZone::get("Europe/Oslo")?)?;
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
     pub fn since_tomorrow(tz: TimeZone) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError> {
@@ -242,7 +259,8 @@ impl HalfBoundedAbsoluteInterval {
     /// # use std::error::Error;
     /// # use jiff::tz::TimeZone;
     /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
-    /// let until_tomorrow = HalfBoundedAbsoluteInterval::until_tomorrow(TimeZone::get("Europe/Oslo")?)?;
+    /// let until_tomorrow =
+    ///     HalfBoundedAbsoluteInterval::until_tomorrow(TimeZone::get("Europe/Oslo")?)?;
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
     pub fn until_tomorrow(tz: TimeZone) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError> {
@@ -281,7 +299,8 @@ impl HalfBoundedAbsoluteInterval {
     /// # use std::error::Error;
     /// # use jiff::tz::TimeZone;
     /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
-    /// let since_yesterday = HalfBoundedAbsoluteInterval::since_yesterday(TimeZone::get("Europe/Oslo")?)?;
+    /// let since_yesterday =
+    ///     HalfBoundedAbsoluteInterval::since_yesterday(TimeZone::get("Europe/Oslo")?)?;
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
     pub fn since_yesterday(tz: TimeZone) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError> {
@@ -323,7 +342,8 @@ impl HalfBoundedAbsoluteInterval {
     /// # use std::error::Error;
     /// # use jiff::tz::TimeZone;
     /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
-    /// let until_yesterday = HalfBoundedAbsoluteInterval::until_yesterday(TimeZone::get("Europe/Oslo")?)?;
+    /// let until_yesterday =
+    ///     HalfBoundedAbsoluteInterval::until_yesterday(TimeZone::get("Europe/Oslo")?)?;
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
     pub fn until_yesterday(tz: TimeZone) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError> {
@@ -367,9 +387,14 @@ impl HalfBoundedAbsoluteInterval {
     ///
     /// assert_eq!(
     ///     interval.reference(),
-    ///     "2026-01-26 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2026-01-26 00:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     /// );
-    /// assert_eq!(interval.reference_inclusivity(), BoundInclusivity::Inclusive);
+    /// assert_eq!(
+    ///     interval.reference_inclusivity(),
+    ///     BoundInclusivity::Inclusive
+    /// );
     /// assert_eq!(interval.opening_direction(), OpeningDirection::ToFuture);
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
@@ -408,9 +433,14 @@ impl HalfBoundedAbsoluteInterval {
     ///
     /// assert_eq!(
     ///     interval.reference(),
-    ///     "2026-01-26 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2026-01-26 00:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     /// );
-    /// assert_eq!(interval.reference_inclusivity(), BoundInclusivity::Exclusive);
+    /// assert_eq!(
+    ///     interval.reference_inclusivity(),
+    ///     BoundInclusivity::Exclusive
+    /// );
     /// assert_eq!(interval.opening_direction(), OpeningDirection::ToPast);
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
@@ -449,9 +479,14 @@ impl HalfBoundedAbsoluteInterval {
     ///
     /// assert_eq!(
     ///     since_month.reference(),
-    ///     "2026-03-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2026-03-01 00:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     /// );
-    /// assert_eq!(since_month.reference_inclusivity(), BoundInclusivity::Inclusive);
+    /// assert_eq!(
+    ///     since_month.reference_inclusivity(),
+    ///     BoundInclusivity::Inclusive
+    /// );
     /// assert_eq!(since_month.opening_direction(), OpeningDirection::ToFuture);
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
@@ -491,9 +526,14 @@ impl HalfBoundedAbsoluteInterval {
     ///
     /// assert_eq!(
     ///     until_month.reference(),
-    ///     "2026-03-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2026-03-01 00:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     /// );
-    /// assert_eq!(until_month.reference_inclusivity(), BoundInclusivity::Exclusive);
+    /// assert_eq!(
+    ///     until_month.reference_inclusivity(),
+    ///     BoundInclusivity::Exclusive
+    /// );
     /// assert_eq!(until_month.opening_direction(), OpeningDirection::ToPast);
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
@@ -523,7 +563,8 @@ impl HalfBoundedAbsoluteInterval {
     /// # use std::error::Error;
     /// # use jiff::tz::TimeZone;
     /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
-    /// let since_this_month = HalfBoundedAbsoluteInterval::since_this_month(TimeZone::get("Europe/Oslo")?)?;
+    /// let since_this_month =
+    ///     HalfBoundedAbsoluteInterval::since_this_month(TimeZone::get("Europe/Oslo")?)?;
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
     pub fn since_this_month(tz: TimeZone) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError> {
@@ -551,7 +592,8 @@ impl HalfBoundedAbsoluteInterval {
     /// # use std::error::Error;
     /// # use jiff::tz::TimeZone;
     /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
-    /// let until_this_month = HalfBoundedAbsoluteInterval::until_this_month(TimeZone::get("Europe/Oslo")?)?;
+    /// let until_this_month =
+    ///     HalfBoundedAbsoluteInterval::until_this_month(TimeZone::get("Europe/Oslo")?)?;
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
     pub fn until_this_month(tz: TimeZone) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError> {
@@ -585,9 +627,14 @@ impl HalfBoundedAbsoluteInterval {
     ///
     /// assert_eq!(
     ///     since_year.reference(),
-    ///     "2026-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2026-01-01 00:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     /// );
-    /// assert_eq!(since_year.reference_inclusivity(), BoundInclusivity::Inclusive);
+    /// assert_eq!(
+    ///     since_year.reference_inclusivity(),
+    ///     BoundInclusivity::Inclusive
+    /// );
     /// assert_eq!(since_year.opening_direction(), OpeningDirection::ToFuture);
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
@@ -621,9 +668,14 @@ impl HalfBoundedAbsoluteInterval {
     ///
     /// assert_eq!(
     ///     until_year.reference(),
-    ///     "2026-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2026-01-01 00:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     /// );
-    /// assert_eq!(until_year.reference_inclusivity(), BoundInclusivity::Exclusive);
+    /// assert_eq!(
+    ///     until_year.reference_inclusivity(),
+    ///     BoundInclusivity::Exclusive
+    /// );
     /// assert_eq!(until_year.opening_direction(), OpeningDirection::ToPast);
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
@@ -648,7 +700,8 @@ impl HalfBoundedAbsoluteInterval {
     /// # use std::error::Error;
     /// # use jiff::tz::TimeZone;
     /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
-    /// let since_this_year = HalfBoundedAbsoluteInterval::since_this_year(TimeZone::get("Europe/Oslo")?)?;
+    /// let since_this_year =
+    ///     HalfBoundedAbsoluteInterval::since_this_year(TimeZone::get("Europe/Oslo")?)?;
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
     pub fn since_this_year(tz: TimeZone) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError> {
@@ -669,7 +722,8 @@ impl HalfBoundedAbsoluteInterval {
     /// # use std::error::Error;
     /// # use jiff::tz::TimeZone;
     /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
-    /// let until_this_year = HalfBoundedAbsoluteInterval::until_this_year(TimeZone::get("Europe/Oslo")?)?;
+    /// let until_this_year =
+    ///     HalfBoundedAbsoluteInterval::until_this_year(TimeZone::get("Europe/Oslo")?)?;
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
     pub fn until_this_year(tz: TimeZone) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError> {

--- a/src/intervals/meta.rs
+++ b/src/intervals/meta.rs
@@ -257,19 +257,23 @@ impl Epsilon {
     /// let end_epsilon_duration = std::time::Duration::from_secs(2);
     ///
     /// assert_eq!(
-    ///     Epsilon::None.interpret_as_duration_bound_specific(start_epsilon_duration, end_epsilon_duration),
+    ///     Epsilon::None
+    ///         .interpret_as_duration_bound_specific(start_epsilon_duration, end_epsilon_duration),
     ///     Ok(std::time::Duration::ZERO),
     /// );
     /// assert_eq!(
-    ///     Epsilon::Start.interpret_as_duration_bound_specific(start_epsilon_duration, end_epsilon_duration),
+    ///     Epsilon::Start
+    ///         .interpret_as_duration_bound_specific(start_epsilon_duration, end_epsilon_duration),
     ///     Ok(start_epsilon_duration),
     /// );
     /// assert_eq!(
-    ///     Epsilon::End.interpret_as_duration_bound_specific(start_epsilon_duration, end_epsilon_duration),
+    ///     Epsilon::End
+    ///         .interpret_as_duration_bound_specific(start_epsilon_duration, end_epsilon_duration),
     ///     Ok(end_epsilon_duration),
     /// );
     /// assert_eq!(
-    ///     Epsilon::Both.interpret_as_duration_bound_specific(start_epsilon_duration, end_epsilon_duration),
+    ///     Epsilon::Both
+    ///         .interpret_as_duration_bound_specific(start_epsilon_duration, end_epsilon_duration),
     ///     Ok(start_epsilon_duration + end_epsilon_duration)
     /// );
     /// ```

--- a/src/intervals/ops.rs
+++ b/src/intervals/ops.rs
@@ -3,23 +3,18 @@
 //! _Operation_ is a relatively vague term, but in this module you will find...
 //!
 //! - [how to find overlaps between intervals](overlap)
-//! - [how to check if a time is contained within an
-//!   interval](point_containment)
+//! - [how to check if a time is contained within an interval](point_containment)
 //! - [how to cut intervals](cut)
-//! - how to remove [gaps](fill_gap), [overlaps](remove_overlap), even
-//!   [both](remove_overlap_or_gap)
+//! - how to remove [gaps](fill_gap), [overlaps](remove_overlap), even [both](remove_overlap_or_gap)
 //! - [how to order bounds](bound_ord)
-//! - [how to check if a bound is contained within an
-//!   interval](bound_containment)
+//! - [how to check if a bound is contained within an interval](bound_containment)
 //! - [how to get the complement of an interval](complement)
-//! - how to adjust intervals by [growing](grow) or [shrinking](shrink) their
-//!   bounds
+//! - how to adjust intervals by [growing](grow) or [shrinking](shrink) their bounds
 //! - how to [extend] or [abridge] intervals
 //! - [how to change the precision of intervals and bounds](precision)
 //! - [how to apply set operations to intervals](set_ops)
 //! - [how to find the continuations of an interval](continuation)
-//! - [how to convert from relative to absolute and
-//!   conversely](relativity_conversion)
+//! - [how to convert from relative to absolute and conversely](relativity_conversion)
 //!
 //! And, perchance, more to come in the future!
 

--- a/src/intervals/ops/abridge.rs
+++ b/src/intervals/ops/abridge.rs
@@ -87,16 +87,24 @@ macro_rules! abridge_impl_rhs_clone {
 /// # use periodical::intervals::absolute::{AbsoluteBoundPair, AbsoluteFiniteBound};
 /// # use periodical::intervals::meta::BoundInclusivity;
 /// # use periodical::intervals::ops::abridge::Abridgable;
-/// let first_start_time = "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp();
-/// let first_end_time = "2025-01-01 11:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp();
+/// let first_start_time = "2025-01-01 08:00:00[Europe/Oslo]"
+///     .parse::<Zoned>()?
+///     .timestamp();
+/// let first_end_time = "2025-01-01 11:00:00[Europe/Oslo]"
+///     .parse::<Zoned>()?
+///     .timestamp();
 ///
 /// let first_interval = AbsoluteBoundPair::new(
 ///     AbsoluteFiniteBound::new(first_start_time).to_start_bound(),
 ///     AbsoluteFiniteBound::new(first_end_time).to_end_bound(),
 /// );
 ///
-/// let second_start_time = "2025-01-01 13:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp();
-/// let second_end_time = "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp();
+/// let second_start_time = "2025-01-01 13:00:00[Europe/Oslo]"
+///     .parse::<Zoned>()?
+///     .timestamp();
+/// let second_end_time = "2025-01-01 16:00:00[Europe/Oslo]"
+///     .parse::<Zoned>()?
+///     .timestamp();
 ///
 /// let second_interval = AbsoluteBoundPair::new(
 ///     AbsoluteFiniteBound::new(second_start_time).to_start_bound(),
@@ -110,18 +118,22 @@ macro_rules! abridge_impl_rhs_clone {
 /// // abridged interval:      (--)
 ///
 /// assert_eq!(
-///     abridged_interval.clone().bound().ok_or("Empty abridged interval")?.start(),
-///     AbsoluteFiniteBound::new_with_inclusivity(
-///         first_end_time,
-///         BoundInclusivity::Exclusive,
-///     ).to_start_bound(),
+///     abridged_interval
+///         .clone()
+///         .bound()
+///         .ok_or("Empty abridged interval")?
+///         .start(),
+///     AbsoluteFiniteBound::new_with_inclusivity(first_end_time, BoundInclusivity::Exclusive,)
+///         .to_start_bound(),
 /// );
 /// assert_eq!(
-///     abridged_interval.clone().bound().ok_or("Empty abridged interval")?.end(),
-///     AbsoluteFiniteBound::new_with_inclusivity(
-///         second_start_time,
-///         BoundInclusivity::Exclusive,
-///     ).to_end_bound(),
+///     abridged_interval
+///         .clone()
+///         .bound()
+///         .ok_or("Empty abridged interval")?
+///         .end(),
+///     AbsoluteFiniteBound::new_with_inclusivity(second_start_time, BoundInclusivity::Exclusive,)
+///         .to_end_bound(),
 /// );
 /// # Ok::<(), Box<dyn Error>>(())
 /// ```
@@ -134,16 +146,24 @@ macro_rules! abridge_impl_rhs_clone {
 /// # use periodical::intervals::absolute::{AbsoluteBoundPair, AbsoluteFiniteBound};
 /// # use periodical::intervals::meta::BoundInclusivity;
 /// # use periodical::intervals::ops::abridge::Abridgable;
-/// let first_start_time = "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp();
-/// let first_end_time = "2025-01-01 13:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp();
+/// let first_start_time = "2025-01-01 08:00:00[Europe/Oslo]"
+///     .parse::<Zoned>()?
+///     .timestamp();
+/// let first_end_time = "2025-01-01 13:00:00[Europe/Oslo]"
+///     .parse::<Zoned>()?
+///     .timestamp();
 ///
 /// let first_interval = AbsoluteBoundPair::new(
 ///     AbsoluteFiniteBound::new(first_start_time).to_start_bound(),
 ///     AbsoluteFiniteBound::new(first_end_time).to_end_bound(),
 /// );
 ///
-/// let second_start_time = "2025-01-01 11:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp();
-/// let second_end_time = "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp();
+/// let second_start_time = "2025-01-01 11:00:00[Europe/Oslo]"
+///     .parse::<Zoned>()?
+///     .timestamp();
+/// let second_end_time = "2025-01-01 16:00:00[Europe/Oslo]"
+///     .parse::<Zoned>()?
+///     .timestamp();
 ///
 /// let second_interval = AbsoluteBoundPair::new(
 ///     AbsoluteFiniteBound::new(second_start_time).to_start_bound(),
@@ -153,22 +173,26 @@ macro_rules! abridge_impl_rhs_clone {
 /// let abridged_interval = first_interval.abridge(&second_interval);
 ///
 /// // first interval:    [----]
-/// // second interval:     [----]  
+/// // second interval:     [----]
 /// // abridged interval:   [--]
 ///
 /// assert_eq!(
-///     abridged_interval.clone().bound().ok_or("Empty abridged interval")?.start(),
-///     AbsoluteFiniteBound::new_with_inclusivity(
-///         second_start_time,
-///         BoundInclusivity::Inclusive,
-///     ).to_start_bound(),
+///     abridged_interval
+///         .clone()
+///         .bound()
+///         .ok_or("Empty abridged interval")?
+///         .start(),
+///     AbsoluteFiniteBound::new_with_inclusivity(second_start_time, BoundInclusivity::Inclusive,)
+///         .to_start_bound(),
 /// );
 /// assert_eq!(
-///     abridged_interval.clone().bound().ok_or("Empty abridged interval")?.end(),
-///     AbsoluteFiniteBound::new_with_inclusivity(
-///         first_end_time,
-///         BoundInclusivity::Inclusive,
-///     ).to_end_bound(),
+///     abridged_interval
+///         .clone()
+///         .bound()
+///         .ok_or("Empty abridged interval")?
+///         .end(),
+///     AbsoluteFiniteBound::new_with_inclusivity(first_end_time, BoundInclusivity::Inclusive,)
+///         .to_end_bound(),
 /// );
 /// # Ok::<(), Box<dyn Error>>(())
 /// ```

--- a/src/intervals/ops/bound_containment.rs
+++ b/src/intervals/ops/bound_containment.rs
@@ -530,13 +530,20 @@ pub fn deny_on_bounds_containment_rule_counts_as_contained(
 /// #     CanPositionBoundContainment, DisambiguatedBoundContainmentPosition,
 /// # };
 /// let interval = BoundedAbsoluteInterval::new(
-///     "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///     "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+///     "2025-01-01 08:00:00[Europe/Oslo]"
+///         .parse::<Zoned>()?
+///         .timestamp(),
+///     "2025-01-01 16:00:00[Europe/Oslo]"
+///         .parse::<Zoned>()?
+///         .timestamp(),
 /// );
 ///
 /// let bound = AbsoluteFiniteBound::new(
-///     "2025-01-01 10:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-/// ).to_start_bound();
+///     "2025-01-01 10:00:00[Europe/Oslo]"
+///         .parse::<Zoned>()?
+///         .timestamp(),
+/// )
+/// .to_start_bound();
 ///
 /// assert!(interval.simple_contains_bound(&bound));
 /// # Ok::<(), Box<dyn Error>>(())
@@ -635,13 +642,20 @@ pub trait CanPositionBoundContainment<B> {
     /// # use periodical::intervals::meta::BoundInclusivity;
     /// # use periodical::intervals::ops::bound_containment::CanPositionBoundContainment;
     /// let interval = BoundedAbsoluteInterval::new(
-    ///     "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2025-01-01 08:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
+    ///     "2025-01-01 16:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     /// );
     ///
     /// let bound = AbsoluteFiniteBound::new(
-    ///     "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    /// ).to_start_bound();
+    ///     "2025-01-01 08:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
+    /// )
+    /// .to_start_bound();
     ///
     /// assert!(interval.simple_contains_bound(&bound));
     /// # Ok::<(), Box<dyn Error>>(())
@@ -671,19 +685,26 @@ pub trait CanPositionBoundContainment<B> {
     /// #     BoundContainmentRule, BoundContainmentRuleSet, CanPositionBoundContainment,
     /// # };
     /// let interval = BoundedAbsoluteInterval::new(
-    ///     "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2025-01-01 08:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
+    ///     "2025-01-01 16:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     /// );
     ///
     /// let bound = AbsoluteFiniteBound::new_with_inclusivity(
-    ///     "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2025-01-01 08:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     ///     BoundInclusivity::Exclusive,
-    /// ).to_start_bound();
+    /// )
+    /// .to_start_bound();
     ///
     /// let is_contained = interval.contains_bound(
     ///     &bound,
     ///     BoundContainmentRuleSet::Lenient,
-    ///     &[BoundContainmentRule::AllowOnStart]
+    ///     &[BoundContainmentRule::AllowOnStart],
     /// );
     ///
     /// assert!(is_contained);
@@ -708,18 +729,22 @@ pub trait CanPositionBoundContainment<B> {
     /// # use periodical::intervals::absolute::{AbsoluteFiniteBound, BoundedAbsoluteInterval};
     /// # use periodical::intervals::ops::bound_containment::CanPositionBoundContainment;
     /// let interval = BoundedAbsoluteInterval::new(
-    ///     "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2025-01-01 08:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
+    ///     "2025-01-01 16:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     /// );
     ///
     /// let bound = AbsoluteFiniteBound::new(
-    ///     "2025-01-01 10:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-    /// ).to_start_bound();
+    ///     "2025-01-01 10:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
+    /// )
+    /// .to_start_bound();
     ///
-    /// let is_contained = interval.contains_bound_using(
-    ///     &bound,
-    ///     |_bound| false
-    /// );
+    /// let is_contained = interval.contains_bound_using(&bound, |_bound| false);
     ///
     /// assert!(!is_contained);
     /// # Ok::<(), Box<dyn Error>>(())
@@ -745,18 +770,25 @@ pub trait CanPositionBoundContainment<B> {
     /// #     BoundContainmentRuleSet, CanPositionBoundContainment,
     /// # };
     /// let interval = BoundedAbsoluteInterval::new(
-    ///     "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2025-01-01 08:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
+    ///     "2025-01-01 16:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     /// );
     ///
     /// let bound = AbsoluteFiniteBound::new(
-    ///     "2025-01-01 10:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-    /// ).to_start_bound();
+    ///     "2025-01-01 10:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
+    /// )
+    /// .to_start_bound();
     ///
     /// let is_contained = interval.contains_bound_using_simple(
     ///     &bound,
     ///     BoundContainmentRuleSet::Lenient,
-    ///     |_disambiguated_bound| false
+    ///     |_disambiguated_bound| false,
     /// );
     ///
     /// assert!(!is_contained);

--- a/src/intervals/ops/bound_ord.rs
+++ b/src/intervals/ops/bound_ord.rs
@@ -241,11 +241,15 @@ impl BoundOrdering {
 /// # use periodical::intervals::ops::bound_ord::{BoundOrdering, PartialBoundOrd};
 /// # use periodical::intervals::ops::bound_overlap_ambiguity::BoundOverlapAmbiguity;
 /// let ref_bound = AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-///     "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+///     "2025-01-01 08:00:00[Europe/Oslo]"
+///         .parse::<Zoned>()?
+///         .timestamp(),
 /// ));
 ///
 /// let compared_bound = AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-///     "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+///     "2025-01-01 08:00:00[Europe/Oslo]"
+///         .parse::<Zoned>()?
+///         .timestamp(),
 ///     BoundInclusivity::Exclusive,
 /// ));
 ///
@@ -273,11 +277,15 @@ pub trait PartialBoundOrd<Rhs = Self> {
     /// # use periodical::intervals::ops::bound_ord::{BoundOrdering, PartialBoundOrd};
     /// # use periodical::intervals::ops::bound_overlap_ambiguity::BoundOverlapAmbiguity;
     /// let ref_bound = AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-    ///     "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2025-01-01 08:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     /// ));
     ///
     /// let compared_bound = AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-    ///     "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2025-01-01 08:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     ///     BoundInclusivity::Exclusive,
     /// ));
     ///
@@ -308,11 +316,15 @@ pub trait PartialBoundOrd<Rhs = Self> {
     /// #     BoundOverlapAmbiguity, BoundOverlapDisambiguationRuleSet,
     /// # };
     /// let ref_bound = AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-    ///     "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2025-01-01 08:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     /// ));
     ///
     /// let compared_bound = AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-    ///     "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2025-01-01 08:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     ///     BoundInclusivity::Exclusive,
     /// ));
     ///
@@ -348,11 +360,15 @@ pub trait PartialBoundOrd<Rhs = Self> {
     /// #     BoundOverlapAmbiguity, BoundOverlapDisambiguationRuleSet,
     /// # };
     /// let ref_bound = AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-    ///     "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2025-01-01 08:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     /// ));
     ///
     /// let compared_bound = AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-    ///     "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2025-01-01 08:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     ///     BoundInclusivity::Exclusive,
     /// ));
     ///
@@ -388,11 +404,15 @@ pub trait PartialBoundOrd<Rhs = Self> {
     /// #     BoundOverlapAmbiguity, BoundOverlapDisambiguationRuleSet,
     /// # };
     /// let ref_bound = AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-    ///     "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2025-01-01 08:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     /// ));
     ///
     /// let compared_bound = AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-    ///     "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2025-01-01 08:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     ///     BoundInclusivity::Exclusive,
     /// ));
     ///
@@ -428,11 +448,15 @@ pub trait PartialBoundOrd<Rhs = Self> {
     /// #     BoundOverlapAmbiguity, BoundOverlapDisambiguationRuleSet,
     /// # };
     /// let ref_bound = AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-    ///     "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2025-01-01 08:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     /// ));
     ///
     /// let compared_bound = AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-    ///     "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2025-01-01 08:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     ///     BoundInclusivity::Exclusive,
     /// ));
     ///

--- a/src/intervals/ops/continuation.rs
+++ b/src/intervals/ops/continuation.rs
@@ -20,11 +20,17 @@
 //! # use periodical::intervals::ops::continuation::Continuable;
 //! let interval = AbsoluteBoundPair::new(
 //!     AbsoluteFiniteBound::new(
-//!         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!     ).to_start_bound(),
+//!         "2025-01-01 08:00:00[Europe/Oslo]"
+//!             .parse::<Zoned>()?
+//!             .timestamp(),
+//!     )
+//!     .to_start_bound(),
 //!     AbsoluteFiniteBound::new(
-//!         "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!     ).to_end_bound(),
+//!         "2025-01-01 16:00:00[Europe/Oslo]"
+//!             .parse::<Zoned>()?
+//!             .timestamp(),
+//!     )
+//!     .to_end_bound(),
 //! );
 //!
 //! assert_eq!(
@@ -32,20 +38,28 @@
 //!     AbsoluteBoundPair::new(
 //!         AbsoluteStartBound::InfinitePast,
 //!         AbsoluteFiniteBound::new_with_inclusivity(
-//!             "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+//!             "2025-01-01 08:00:00[Europe/Oslo]"
+//!                 .parse::<Zoned>()?
+//!                 .timestamp(),
 //!             BoundInclusivity::Exclusive,
-//!         ).to_end_bound(),
-//!     ).to_emptiable(),
+//!         )
+//!         .to_end_bound(),
+//!     )
+//!     .to_emptiable(),
 //! );
 //! assert_eq!(
 //!     interval.future_continuation(),
 //!     AbsoluteBoundPair::new(
 //!         AbsoluteFiniteBound::new_with_inclusivity(
-//!             "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+//!             "2025-01-01 16:00:00[Europe/Oslo]"
+//!                 .parse::<Zoned>()?
+//!                 .timestamp(),
 //!             BoundInclusivity::Exclusive,
-//!         ).to_start_bound(),
+//!         )
+//!         .to_start_bound(),
 //!         AbsoluteEndBound::InfiniteFuture,
-//!     ).to_emptiable(),
+//!     )
+//!     .to_emptiable(),
 //! );
 //! # Ok::<(), Box<dyn Error>>(())
 //! ```
@@ -101,11 +115,17 @@ use crate::intervals::special::{EmptyInterval, UnboundedInterval};
 /// # use periodical::intervals::ops::continuation::Continuable;
 /// let interval = AbsoluteBoundPair::new(
 ///     AbsoluteFiniteBound::new(
-///         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///     ).to_start_bound(),
+///         "2025-01-01 08:00:00[Europe/Oslo]"
+///             .parse::<Zoned>()?
+///             .timestamp(),
+///     )
+///     .to_start_bound(),
 ///     AbsoluteFiniteBound::new(
-///         "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///     ).to_end_bound(),
+///         "2025-01-01 16:00:00[Europe/Oslo]"
+///             .parse::<Zoned>()?
+///             .timestamp(),
+///     )
+///     .to_end_bound(),
 /// );
 ///
 /// assert_eq!(
@@ -113,20 +133,28 @@ use crate::intervals::special::{EmptyInterval, UnboundedInterval};
 ///     AbsoluteBoundPair::new(
 ///         AbsoluteStartBound::InfinitePast,
 ///         AbsoluteFiniteBound::new_with_inclusivity(
-///             "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+///             "2025-01-01 08:00:00[Europe/Oslo]"
+///                 .parse::<Zoned>()?
+///                 .timestamp(),
 ///             BoundInclusivity::Exclusive,
-///         ).to_end_bound(),
-///     ).to_emptiable(),
+///         )
+///         .to_end_bound(),
+///     )
+///     .to_emptiable(),
 /// );
 /// assert_eq!(
 ///     interval.future_continuation(),
 ///     AbsoluteBoundPair::new(
 ///         AbsoluteFiniteBound::new_with_inclusivity(
-///             "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+///             "2025-01-01 16:00:00[Europe/Oslo]"
+///                 .parse::<Zoned>()?
+///                 .timestamp(),
 ///             BoundInclusivity::Exclusive,
-///         ).to_start_bound(),
+///         )
+///         .to_start_bound(),
 ///         AbsoluteEndBound::InfiniteFuture,
-///     ).to_emptiable(),
+///     )
+///     .to_emptiable(),
 /// );
 /// # Ok::<(), Box<dyn Error>>(())
 /// ```
@@ -148,11 +176,17 @@ pub trait Continuable {
     /// # use periodical::intervals::ops::continuation::Continuable;
     /// let interval = AbsoluteBoundPair::new(
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_start_bound(),
+    ///         "2025-01-01 08:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_start_bound(),
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_end_bound(),
+    ///         "2025-01-01 16:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_end_bound(),
     /// );
     ///
     /// assert_eq!(
@@ -160,10 +194,14 @@ pub trait Continuable {
     ///     AbsoluteBoundPair::new(
     ///         AbsoluteStartBound::InfinitePast,
     ///         AbsoluteFiniteBound::new_with_inclusivity(
-    ///             "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///             "2025-01-01 08:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
     ///             BoundInclusivity::Exclusive,
-    ///         ).to_end_bound(),
-    ///     ).to_emptiable(),
+    ///         )
+    ///         .to_end_bound(),
+    ///     )
+    ///     .to_emptiable(),
     /// );
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
@@ -184,22 +222,32 @@ pub trait Continuable {
     /// # use periodical::intervals::ops::continuation::Continuable;
     /// let interval = AbsoluteBoundPair::new(
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_start_bound(),
+    ///         "2025-01-01 08:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_start_bound(),
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_end_bound(),
+    ///         "2025-01-01 16:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_end_bound(),
     /// );
     ///
     /// assert_eq!(
     ///     interval.future_continuation(),
     ///     AbsoluteBoundPair::new(
     ///         AbsoluteFiniteBound::new_with_inclusivity(
-    ///             "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///             "2025-01-01 16:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
     ///             BoundInclusivity::Exclusive,
-    ///         ).to_start_bound(),
+    ///         )
+    ///         .to_start_bound(),
     ///         AbsoluteEndBound::InfiniteFuture,
-    ///     ).to_emptiable(),
+    ///     )
+    ///     .to_emptiable(),
     /// );
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```

--- a/src/intervals/ops/cut.rs
+++ b/src/intervals/ops/cut.rs
@@ -26,11 +26,17 @@
 //! # use periodical::intervals::ops::cut::{CutResult, Cuttable, CutType};
 //! let interval = AbsoluteBoundPair::new(
 //!     AbsoluteFiniteBound::new(
-//!         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!     ).to_start_bound(),
+//!         "2025-01-01 08:00:00[Europe/Oslo]"
+//!             .parse::<Zoned>()?
+//!             .timestamp(),
+//!     )
+//!     .to_start_bound(),
 //!     AbsoluteFiniteBound::new(
-//!         "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!     ).to_end_bound(),
+//!         "2025-01-01 16:00:00[Europe/Oslo]"
+//!             .parse::<Zoned>()?
+//!             .timestamp(),
+//!     )
+//!     .to_end_bound(),
 //! );
 //!
 //! let cut_type = CutType::new(BoundInclusivity::Exclusive, BoundInclusivity::Exclusive);
@@ -41,21 +47,33 @@
 //!     CutResult::Cut(
 //!         AbsoluteBoundPair::new(
 //!             AbsoluteFiniteBound::new(
-//!                 "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-//!             ).to_start_bound(),
+//!                 "2025-01-01 08:00:00[Europe/Oslo]"
+//!                     .parse::<Zoned>()?
+//!                     .timestamp()
+//!             )
+//!             .to_start_bound(),
 //!             AbsoluteFiniteBound::new_with_inclusivity(
-//!                 "2025-01-01 12:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+//!                 "2025-01-01 12:00:00[Europe/Oslo]"
+//!                     .parse::<Zoned>()?
+//!                     .timestamp(),
 //!                 BoundInclusivity::Exclusive,
-//!             ).to_end_bound(),
+//!             )
+//!             .to_end_bound(),
 //!         ),
 //!         AbsoluteBoundPair::new(
 //!             AbsoluteFiniteBound::new_with_inclusivity(
-//!                 "2025-01-01 12:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+//!                 "2025-01-01 12:00:00[Europe/Oslo]"
+//!                     .parse::<Zoned>()?
+//!                     .timestamp(),
 //!                 BoundInclusivity::Exclusive,
-//!             ).to_start_bound(),
+//!             )
+//!             .to_start_bound(),
 //!             AbsoluteFiniteBound::new(
-//!                 "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!             ).to_end_bound(),
+//!                 "2025-01-01 16:00:00[Europe/Oslo]"
+//!                     .parse::<Zoned>()?
+//!                     .timestamp(),
+//!             )
+//!             .to_end_bound(),
 //!         ),
 //!     ),
 //! );
@@ -72,11 +90,17 @@
 //! # use periodical::intervals::ops::cut::{CutResult, Cuttable, CutType};
 //! let interval = AbsoluteBoundPair::new(
 //!     AbsoluteFiniteBound::new(
-//!         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!     ).to_start_bound(),
+//!         "2025-01-01 08:00:00[Europe/Oslo]"
+//!             .parse::<Zoned>()?
+//!             .timestamp(),
+//!     )
+//!     .to_start_bound(),
 //!     AbsoluteFiniteBound::new(
-//!         "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!     ).to_end_bound(),
+//!         "2025-01-01 16:00:00[Europe/Oslo]"
+//!             .parse::<Zoned>()?
+//!             .timestamp(),
+//!     )
+//!     .to_end_bound(),
 //! );
 //!
 //! let cut_type = CutType::new(BoundInclusivity::Exclusive, BoundInclusivity::Inclusive);
@@ -87,20 +111,32 @@
 //!     CutResult::Cut(
 //!         AbsoluteBoundPair::new(
 //!             AbsoluteFiniteBound::new(
-//!                 "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-//!             ).to_start_bound(),
+//!                 "2025-01-01 08:00:00[Europe/Oslo]"
+//!                     .parse::<Zoned>()?
+//!                     .timestamp()
+//!             )
+//!             .to_start_bound(),
 //!             AbsoluteFiniteBound::new_with_inclusivity(
-//!                 "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+//!                 "2025-01-01 16:00:00[Europe/Oslo]"
+//!                     .parse::<Zoned>()?
+//!                     .timestamp(),
 //!                 BoundInclusivity::Exclusive,
-//!             ).to_end_bound(),
+//!             )
+//!             .to_end_bound(),
 //!         ),
 //!         AbsoluteBoundPair::new(
 //!             AbsoluteFiniteBound::new(
-//!                 "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!             ).to_start_bound(),
+//!                 "2025-01-01 16:00:00[Europe/Oslo]"
+//!                     .parse::<Zoned>()?
+//!                     .timestamp(),
+//!             )
+//!             .to_start_bound(),
 //!             AbsoluteFiniteBound::new(
-//!                 "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!             ).to_end_bound(),
+//!                 "2025-01-01 16:00:00[Europe/Oslo]"
+//!                     .parse::<Zoned>()?
+//!                     .timestamp(),
+//!             )
+//!             .to_end_bound(),
 //!         ),
 //!     ),
 //! );
@@ -117,20 +153,23 @@
 //! # use periodical::intervals::ops::cut::{CutResult, Cuttable, CutType};
 //! let interval = AbsoluteBoundPair::new(
 //!     AbsoluteFiniteBound::new(
-//!         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!     ).to_start_bound(),
+//!         "2025-01-01 08:00:00[Europe/Oslo]"
+//!             .parse::<Zoned>()?
+//!             .timestamp(),
+//!     )
+//!     .to_start_bound(),
 //!     AbsoluteFiniteBound::new(
-//!         "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!     ).to_end_bound(),
+//!         "2025-01-01 16:00:00[Europe/Oslo]"
+//!             .parse::<Zoned>()?
+//!             .timestamp(),
+//!     )
+//!     .to_end_bound(),
 //! );
 //!
 //! let cut_type = CutType::new(BoundInclusivity::Exclusive, BoundInclusivity::Exclusive);
 //! let at = "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?;
 //!
-//! assert_eq!(
-//!     interval.cut_at(at, cut_type),
-//!     CutResult::Uncut,
-//! );
+//! assert_eq!(interval.cut_at(at, cut_type), CutResult::Uncut,);
 //! # Ok::<(), Box<dyn Error>>(())
 //! ```
 
@@ -206,7 +245,10 @@ impl CutType {
     /// # use periodical::intervals::ops::cut::CutType;
     /// let cut_type = CutType::new(BoundInclusivity::Inclusive, BoundInclusivity::Exclusive);
     ///
-    /// assert_eq!(cut_type.past_bound_inclusivity(), BoundInclusivity::Inclusive);
+    /// assert_eq!(
+    ///     cut_type.past_bound_inclusivity(),
+    ///     BoundInclusivity::Inclusive
+    /// );
     /// ```
     #[must_use]
     pub fn past_bound_inclusivity(&self) -> BoundInclusivity {
@@ -222,7 +264,10 @@ impl CutType {
     /// # use periodical::intervals::ops::cut::CutType;
     /// let cut_type = CutType::new(BoundInclusivity::Inclusive, BoundInclusivity::Exclusive);
     ///
-    /// assert_eq!(cut_type.future_bound_inclusivity(), BoundInclusivity::Exclusive);
+    /// assert_eq!(
+    ///     cut_type.future_bound_inclusivity(),
+    ///     BoundInclusivity::Exclusive
+    /// );
     /// ```
     #[must_use]
     pub fn future_bound_inclusivity(&self) -> BoundInclusivity {
@@ -380,11 +425,17 @@ impl<T> CutResult<T> {
 /// # use periodical::intervals::ops::cut::{CutResult, Cuttable, CutType};
 /// let interval = AbsoluteBoundPair::new(
 ///     AbsoluteFiniteBound::new(
-///         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///     ).to_start_bound(),
+///         "2025-01-01 08:00:00[Europe/Oslo]"
+///             .parse::<Zoned>()?
+///             .timestamp(),
+///     )
+///     .to_start_bound(),
 ///     AbsoluteFiniteBound::new(
-///         "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///     ).to_end_bound(),
+///         "2025-01-01 16:00:00[Europe/Oslo]"
+///             .parse::<Zoned>()?
+///             .timestamp(),
+///     )
+///     .to_end_bound(),
 /// );
 ///
 /// let cut_type = CutType::new(BoundInclusivity::Exclusive, BoundInclusivity::Exclusive);
@@ -395,21 +446,33 @@ impl<T> CutResult<T> {
 ///     CutResult::Cut(
 ///         AbsoluteBoundPair::new(
 ///             AbsoluteFiniteBound::new(
-///                 "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-///             ).to_start_bound(),
+///                 "2025-01-01 08:00:00[Europe/Oslo]"
+///                     .parse::<Zoned>()?
+///                     .timestamp()
+///             )
+///             .to_start_bound(),
 ///             AbsoluteFiniteBound::new_with_inclusivity(
-///                 "2025-01-01 12:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+///                 "2025-01-01 12:00:00[Europe/Oslo]"
+///                     .parse::<Zoned>()?
+///                     .timestamp(),
 ///                 BoundInclusivity::Exclusive,
-///             ).to_end_bound(),
+///             )
+///             .to_end_bound(),
 ///         ),
 ///         AbsoluteBoundPair::new(
 ///             AbsoluteFiniteBound::new_with_inclusivity(
-///                 "2025-01-01 12:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+///                 "2025-01-01 12:00:00[Europe/Oslo]"
+///                     .parse::<Zoned>()?
+///                     .timestamp(),
 ///                 BoundInclusivity::Exclusive,
-///             ).to_start_bound(),
+///             )
+///             .to_start_bound(),
 ///             AbsoluteFiniteBound::new(
-///                 "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///             ).to_end_bound(),
+///                 "2025-01-01 16:00:00[Europe/Oslo]"
+///                     .parse::<Zoned>()?
+///                     .timestamp(),
+///             )
+///             .to_end_bound(),
 ///         ),
 ///     ),
 /// );
@@ -426,11 +489,17 @@ impl<T> CutResult<T> {
 /// # use periodical::intervals::ops::cut::{CutResult, Cuttable, CutType};
 /// let interval = AbsoluteBoundPair::new(
 ///     AbsoluteFiniteBound::new(
-///         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///     ).to_start_bound(),
+///         "2025-01-01 08:00:00[Europe/Oslo]"
+///             .parse::<Zoned>()?
+///             .timestamp(),
+///     )
+///     .to_start_bound(),
 ///     AbsoluteFiniteBound::new(
-///         "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///     ).to_end_bound(),
+///         "2025-01-01 16:00:00[Europe/Oslo]"
+///             .parse::<Zoned>()?
+///             .timestamp(),
+///     )
+///     .to_end_bound(),
 /// );
 ///
 /// let cut_type = CutType::new(BoundInclusivity::Exclusive, BoundInclusivity::Inclusive);
@@ -441,20 +510,32 @@ impl<T> CutResult<T> {
 ///     CutResult::Cut(
 ///         AbsoluteBoundPair::new(
 ///             AbsoluteFiniteBound::new(
-///                 "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-///             ).to_start_bound(),
+///                 "2025-01-01 08:00:00[Europe/Oslo]"
+///                     .parse::<Zoned>()?
+///                     .timestamp()
+///             )
+///             .to_start_bound(),
 ///             AbsoluteFiniteBound::new_with_inclusivity(
-///                 "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+///                 "2025-01-01 16:00:00[Europe/Oslo]"
+///                     .parse::<Zoned>()?
+///                     .timestamp(),
 ///                 BoundInclusivity::Exclusive,
-///             ).to_end_bound(),
+///             )
+///             .to_end_bound(),
 ///         ),
 ///         AbsoluteBoundPair::new(
 ///             AbsoluteFiniteBound::new(
-///                 "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///             ).to_start_bound(),
+///                 "2025-01-01 16:00:00[Europe/Oslo]"
+///                     .parse::<Zoned>()?
+///                     .timestamp(),
+///             )
+///             .to_start_bound(),
 ///             AbsoluteFiniteBound::new(
-///                 "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///             ).to_end_bound(),
+///                 "2025-01-01 16:00:00[Europe/Oslo]"
+///                     .parse::<Zoned>()?
+///                     .timestamp(),
+///             )
+///             .to_end_bound(),
 ///         ),
 ///     ),
 /// );
@@ -471,20 +552,23 @@ impl<T> CutResult<T> {
 /// # use periodical::intervals::ops::cut::{CutResult, Cuttable, CutType};
 /// let interval = AbsoluteBoundPair::new(
 ///     AbsoluteFiniteBound::new(
-///         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///     ).to_start_bound(),
+///         "2025-01-01 08:00:00[Europe/Oslo]"
+///             .parse::<Zoned>()?
+///             .timestamp(),
+///     )
+///     .to_start_bound(),
 ///     AbsoluteFiniteBound::new(
-///         "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///     ).to_end_bound(),
+///         "2025-01-01 16:00:00[Europe/Oslo]"
+///             .parse::<Zoned>()?
+///             .timestamp(),
+///     )
+///     .to_end_bound(),
 /// );
 ///
 /// let cut_type = CutType::new(BoundInclusivity::Exclusive, BoundInclusivity::Exclusive);
 /// let at = "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?;
 ///
-/// assert_eq!(
-///     interval.cut_at(at, cut_type),
-///     CutResult::Uncut,
-/// );
+/// assert_eq!(interval.cut_at(at, cut_type), CutResult::Uncut,);
 /// # Ok::<(), Box<dyn Error>>(())
 /// ```
 pub trait Cuttable<P> {
@@ -503,11 +587,17 @@ pub trait Cuttable<P> {
     /// # use periodical::intervals::ops::cut::{CutResult, Cuttable, CutType};
     /// let interval = AbsoluteBoundPair::new(
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_start_bound(),
+    ///         "2025-01-01 08:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_start_bound(),
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_end_bound(),
+    ///         "2025-01-01 16:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_end_bound(),
     /// );
     ///
     /// let cut_type = CutType::new(BoundInclusivity::Exclusive, BoundInclusivity::Exclusive);
@@ -518,21 +608,33 @@ pub trait Cuttable<P> {
     ///     CutResult::Cut(
     ///         AbsoluteBoundPair::new(
     ///             AbsoluteFiniteBound::new(
-    ///                 "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-    ///             ).to_start_bound(),
+    ///                 "2025-01-01 08:00:00[Europe/Oslo]"
+    ///                     .parse::<Zoned>()?
+    ///                     .timestamp()
+    ///             )
+    ///             .to_start_bound(),
     ///             AbsoluteFiniteBound::new_with_inclusivity(
-    ///                 "2025-01-01 12:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///                 "2025-01-01 12:00:00[Europe/Oslo]"
+    ///                     .parse::<Zoned>()?
+    ///                     .timestamp(),
     ///                 BoundInclusivity::Exclusive,
-    ///             ).to_end_bound(),
+    ///             )
+    ///             .to_end_bound(),
     ///         ),
     ///         AbsoluteBoundPair::new(
     ///             AbsoluteFiniteBound::new_with_inclusivity(
-    ///                 "2025-01-01 12:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///                 "2025-01-01 12:00:00[Europe/Oslo]"
+    ///                     .parse::<Zoned>()?
+    ///                     .timestamp(),
     ///                 BoundInclusivity::Exclusive,
-    ///             ).to_start_bound(),
+    ///             )
+    ///             .to_start_bound(),
     ///             AbsoluteFiniteBound::new(
-    ///                 "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///             ).to_end_bound(),
+    ///                 "2025-01-01 16:00:00[Europe/Oslo]"
+    ///                     .parse::<Zoned>()?
+    ///                     .timestamp(),
+    ///             )
+    ///             .to_end_bound(),
     ///         ),
     ///     ),
     /// );

--- a/src/intervals/ops/extend.rs
+++ b/src/intervals/ops/extend.rs
@@ -17,31 +17,49 @@
 //! # use periodical::intervals::ops::Extensible;
 //! let first_interval = AbsoluteBoundPair::new(
 //!     AbsoluteFiniteBound::new(
-//!         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!     ).to_start_bound(),
+//!         "2025-01-01 08:00:00[Europe/Oslo]"
+//!             .parse::<Zoned>()?
+//!             .timestamp(),
+//!     )
+//!     .to_start_bound(),
 //!     AbsoluteFiniteBound::new(
-//!         "2025-01-01 12:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!     ).to_end_bound(),
+//!         "2025-01-01 12:00:00[Europe/Oslo]"
+//!             .parse::<Zoned>()?
+//!             .timestamp(),
+//!     )
+//!     .to_end_bound(),
 //! );
 //!
 //! let second_interval = AbsoluteBoundPair::new(
 //!     AbsoluteFiniteBound::new(
-//!         "2025-01-01 14:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!     ).to_start_bound(),
+//!         "2025-01-01 14:00:00[Europe/Oslo]"
+//!             .parse::<Zoned>()?
+//!             .timestamp(),
+//!     )
+//!     .to_start_bound(),
 //!     AbsoluteFiniteBound::new(
-//!         "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!     ).to_end_bound(),
+//!         "2025-01-01 16:00:00[Europe/Oslo]"
+//!             .parse::<Zoned>()?
+//!             .timestamp(),
+//!     )
+//!     .to_end_bound(),
 //! );
 //!
 //! assert_eq!(
 //!     first_interval.extend(&second_interval),
 //!     AbsoluteBoundPair::new(
 //!         AbsoluteFiniteBound::new(
-//!             "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!         ).to_start_bound(),
+//!             "2025-01-01 08:00:00[Europe/Oslo]"
+//!                 .parse::<Zoned>()?
+//!                 .timestamp(),
+//!         )
+//!         .to_start_bound(),
 //!         AbsoluteFiniteBound::new(
-//!             "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!         ).to_end_bound(),
+//!             "2025-01-01 16:00:00[Europe/Oslo]"
+//!                 .parse::<Zoned>()?
+//!                 .timestamp(),
+//!         )
+//!         .to_end_bound(),
 //!     ),
 //! );
 //! # Ok::<(), Box<dyn Error>>(())
@@ -110,31 +128,49 @@ pub trait Extensible<Rhs = Self> {
     /// # use periodical::intervals::ops::Extensible;
     /// let first_interval = AbsoluteBoundPair::new(
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_start_bound(),
+    ///         "2025-01-01 08:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_start_bound(),
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 12:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_end_bound(),
+    ///         "2025-01-01 12:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_end_bound(),
     /// );
     ///
     /// let second_interval = AbsoluteBoundPair::new(
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 14:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_start_bound(),
+    ///         "2025-01-01 14:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_start_bound(),
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_end_bound(),
+    ///         "2025-01-01 16:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_end_bound(),
     /// );
     ///
     /// assert_eq!(
     ///     first_interval.extend(&second_interval),
     ///     AbsoluteBoundPair::new(
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_start_bound(),
+    ///             "2025-01-01 08:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_start_bound(),
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_end_bound(),
+    ///             "2025-01-01 16:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_end_bound(),
     ///     ),
     /// );
     /// # Ok::<(), Box<dyn Error>>(())

--- a/src/intervals/ops/fill_gap.rs
+++ b/src/intervals/ops/fill_gap.rs
@@ -14,32 +14,50 @@
 //! # use periodical::intervals::ops::fill_gap::GapFillable;
 //! let first_interval = AbsoluteBoundPair::new(
 //!     AbsoluteFiniteBound::new(
-//!         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!     ).to_start_bound(),
+//!         "2025-01-01 08:00:00[Europe/Oslo]"
+//!             .parse::<Zoned>()?
+//!             .timestamp(),
+//!     )
+//!     .to_start_bound(),
 //!     AbsoluteFiniteBound::new(
-//!         "2025-01-01 10:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!     ).to_end_bound(),
+//!         "2025-01-01 10:00:00[Europe/Oslo]"
+//!             .parse::<Zoned>()?
+//!             .timestamp(),
+//!     )
+//!     .to_end_bound(),
 //! );
 //!
 //! let second_interval = AbsoluteBoundPair::new(
 //!     AbsoluteFiniteBound::new(
-//!         "2025-01-01 12:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!     ).to_start_bound(),
+//!         "2025-01-01 12:00:00[Europe/Oslo]"
+//!             .parse::<Zoned>()?
+//!             .timestamp(),
+//!     )
+//!     .to_start_bound(),
 //!     AbsoluteFiniteBound::new(
-//!         "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!     ).to_end_bound(),
+//!         "2025-01-01 16:00:00[Europe/Oslo]"
+//!             .parse::<Zoned>()?
+//!             .timestamp(),
+//!     )
+//!     .to_end_bound(),
 //! );
 //!
 //! assert_eq!(
 //!     first_interval.fill_gap(&second_interval),
 //!     Ok(AbsoluteBoundPair::new(
 //!         AbsoluteFiniteBound::new(
-//!             "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!         ).to_start_bound(),
+//!             "2025-01-01 08:00:00[Europe/Oslo]"
+//!                 .parse::<Zoned>()?
+//!                 .timestamp(),
+//!         )
+//!         .to_start_bound(),
 //!         AbsoluteFiniteBound::new_with_inclusivity(
-//!             "2025-01-01 12:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+//!             "2025-01-01 12:00:00[Europe/Oslo]"
+//!                 .parse::<Zoned>()?
+//!                 .timestamp(),
 //!             BoundInclusivity::Exclusive,
-//!         ).to_end_bound(),
+//!         )
+//!         .to_end_bound(),
 //!     )),
 //! );
 //! # Ok::<(), Box<dyn Error>>(())
@@ -110,32 +128,50 @@ pub trait GapFillable<Rhs = Self> {
     /// # use periodical::intervals::ops::fill_gap::GapFillable;
     /// let first_interval = AbsoluteBoundPair::new(
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_start_bound(),
+    ///         "2025-01-01 08:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_start_bound(),
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 10:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_end_bound(),
+    ///         "2025-01-01 10:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_end_bound(),
     /// );
     ///
     /// let second_interval = AbsoluteBoundPair::new(
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 12:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_start_bound(),
+    ///         "2025-01-01 12:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_start_bound(),
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_end_bound(),
+    ///         "2025-01-01 16:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_end_bound(),
     /// );
     ///
     /// assert_eq!(
     ///     first_interval.fill_gap(&second_interval),
     ///     Ok(AbsoluteBoundPair::new(
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_start_bound(),
+    ///             "2025-01-01 08:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_start_bound(),
     ///         AbsoluteFiniteBound::new_with_inclusivity(
-    ///             "2025-01-01 12:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///             "2025-01-01 12:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
     ///             BoundInclusivity::Exclusive,
-    ///         ).to_end_bound(),
+    ///         )
+    ///         .to_end_bound(),
     ///     )),
     /// );
     /// # Ok::<(), Box<dyn Error>>(())
@@ -326,8 +362,8 @@ pub fn fill_gap_abs_bound_pair(
         Dop::OutsideBefore => {
             let AbsoluteStartBound::Finite(finite_bound) = b.abs_start() else {
                 unreachable!(
-                    "If the start of the compared bounds is `InfinitePast`, \
-                    then it is impossible that the overlap was `OutsideBefore`"
+                    "If the start of the compared bounds is `InfinitePast`, then it is impossible that the overlap \
+                     was `OutsideBefore`"
                 );
             };
 
@@ -341,8 +377,8 @@ pub fn fill_gap_abs_bound_pair(
         Dop::OutsideAfter => {
             let AbsoluteEndBound::Finite(finite_bound) = b.abs_end() else {
                 unreachable!(
-                    "If the end of the compared bounds is `InfiniteFuture`, \
-                    then it is impossible that the overlap was `OutsideAfter`"
+                    "If the end of the compared bounds is `InfiniteFuture`, then it is impossible that the overlap \
+                     was `OutsideAfter`"
                 );
             };
 
@@ -416,8 +452,8 @@ pub fn fill_gap_rel_bound_pair(
         Dop::OutsideBefore => {
             let RelativeStartBound::Finite(finite_bound) = b.rel_start() else {
                 unreachable!(
-                    "If the start of the compared bounds is `InfinitePast`, \
-                    then it is impossible that the overlap was `OutsideBefore`"
+                    "If the start of the compared bounds is `InfinitePast`, then it is impossible that the overlap \
+                     was `OutsideBefore`"
                 );
             };
 
@@ -431,8 +467,8 @@ pub fn fill_gap_rel_bound_pair(
         Dop::OutsideAfter => {
             let RelativeEndBound::Finite(finite_bound) = b.rel_end() else {
                 unreachable!(
-                    "If the end of the compared bounds is `InfiniteFuture`, \
-                    then it is impossible that the overlap was `OutsideAfter`"
+                    "If the end of the compared bounds is `InfiniteFuture`, then it is impossible that the overlap \
+                     was `OutsideAfter`"
                 );
             };
 

--- a/src/intervals/ops/grow.rs
+++ b/src/intervals/ops/grow.rs
@@ -16,27 +16,45 @@
 //! # use periodical::intervals::ops::grow::GrowableStartBound;
 //! let interval = AbsoluteBoundPair::new(
 //!     AbsoluteFiniteBound::new(
-//!         "2025-01-01 10:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!     ).to_start_bound(),
+//!         "2025-01-01 10:00:00[Europe/Oslo]"
+//!             .parse::<Zoned>()?
+//!             .timestamp(),
+//!     )
+//!     .to_start_bound(),
 //!     AbsoluteFiniteBound::new(
-//!         "2025-01-01 14:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!     ).to_end_bound(),
+//!         "2025-01-01 14:00:00[Europe/Oslo]"
+//!             .parse::<Zoned>()?
+//!             .timestamp(),
+//!     )
+//!     .to_end_bound(),
 //! );
 //!
 //! let grown_interval = interval.grow_start(
 //!     AbsoluteFiniteBound::new(
-//!         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!     ).to_start_bound()
+//!         "2025-01-01 08:00:00[Europe/Oslo]"
+//!             .parse::<Zoned>()?
+//!             .timestamp(),
+//!     )
+//!     .to_start_bound(),
 //! );
 //!
-//! assert_eq!(grown_interval, AbsoluteBoundPair::new(
-//!     AbsoluteFiniteBound::new(
-//!         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!     ).to_start_bound(),
-//!     AbsoluteFiniteBound::new(
-//!         "2025-01-01 14:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!     ).to_end_bound(),
-//! ));
+//! assert_eq!(
+//!     grown_interval,
+//!     AbsoluteBoundPair::new(
+//!         AbsoluteFiniteBound::new(
+//!             "2025-01-01 08:00:00[Europe/Oslo]"
+//!                 .parse::<Zoned>()?
+//!                 .timestamp(),
+//!         )
+//!         .to_start_bound(),
+//!         AbsoluteFiniteBound::new(
+//!             "2025-01-01 14:00:00[Europe/Oslo]"
+//!                 .parse::<Zoned>()?
+//!                 .timestamp(),
+//!         )
+//!         .to_end_bound(),
+//!     )
+//! );
 //! # Ok::<(), Box<dyn Error>>(())
 //! ```
 
@@ -90,27 +108,45 @@ pub trait GrowableStartBound<P> {
     /// # use periodical::intervals::ops::grow::GrowableStartBound;
     /// let interval = AbsoluteBoundPair::new(
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 10:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_start_bound(),
+    ///         "2025-01-01 10:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_start_bound(),
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 14:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_end_bound(),
+    ///         "2025-01-01 14:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_end_bound(),
     /// );
     ///
     /// let grown_interval = interval.grow_start(
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_start_bound()
+    ///         "2025-01-01 08:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_start_bound(),
     /// );
     ///
-    /// assert_eq!(grown_interval, AbsoluteBoundPair::new(
-    ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_start_bound(),
-    ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 14:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_end_bound(),
-    /// ));
+    /// assert_eq!(
+    ///     grown_interval,
+    ///     AbsoluteBoundPair::new(
+    ///         AbsoluteFiniteBound::new(
+    ///             "2025-01-01 08:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_start_bound(),
+    ///         AbsoluteFiniteBound::new(
+    ///             "2025-01-01 14:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_end_bound(),
+    ///     )
+    /// );
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
     fn grow_start(&self, position: P) -> Self::Output;
@@ -140,27 +176,45 @@ pub trait GrowableEndBound<P> {
     /// # use periodical::intervals::ops::grow::GrowableEndBound;
     /// let interval = AbsoluteBoundPair::new(
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 10:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_start_bound(),
+    ///         "2025-01-01 10:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_start_bound(),
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 14:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_end_bound(),
+    ///         "2025-01-01 14:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_end_bound(),
     /// );
     ///
     /// let grown_interval = interval.grow_end(
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_end_bound()
+    ///         "2025-01-01 16:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_end_bound(),
     /// );
     ///
-    /// assert_eq!(grown_interval, AbsoluteBoundPair::new(
-    ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 10:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_start_bound(),
-    ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_end_bound(),
-    /// ));
+    /// assert_eq!(
+    ///     grown_interval,
+    ///     AbsoluteBoundPair::new(
+    ///         AbsoluteFiniteBound::new(
+    ///             "2025-01-01 10:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_start_bound(),
+    ///         AbsoluteFiniteBound::new(
+    ///             "2025-01-01 16:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_end_bound(),
+    ///     )
+    /// );
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
     fn grow_end(&self, position: P) -> Self::Output;

--- a/src/intervals/ops/overlap.rs
+++ b/src/intervals/ops/overlap.rs
@@ -31,20 +31,32 @@
 //! # use periodical::intervals::ops::overlap::CanPositionOverlap;
 //! let first_interval = AbsoluteBoundPair::new(
 //!     AbsoluteFiniteBound::new(
-//!         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!     ).to_start_bound(),
+//!         "2025-01-01 08:00:00[Europe/Oslo]"
+//!             .parse::<Zoned>()?
+//!             .timestamp(),
+//!     )
+//!     .to_start_bound(),
 //!     AbsoluteFiniteBound::new(
-//!         "2025-01-01 14:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!     ).to_end_bound(),
+//!         "2025-01-01 14:00:00[Europe/Oslo]"
+//!             .parse::<Zoned>()?
+//!             .timestamp(),
+//!     )
+//!     .to_end_bound(),
 //! );
 //!
 //! let second_interval = AbsoluteBoundPair::new(
 //!     AbsoluteFiniteBound::new(
-//!         "2025-01-01 12:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!     ).to_start_bound(),
+//!         "2025-01-01 12:00:00[Europe/Oslo]"
+//!             .parse::<Zoned>()?
+//!             .timestamp(),
+//!     )
+//!     .to_start_bound(),
 //!     AbsoluteFiniteBound::new(
-//!         "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!     ).to_end_bound(),
+//!         "2025-01-01 16:00:00[Europe/Oslo]"
+//!             .parse::<Zoned>()?
+//!             .timestamp(),
+//!     )
+//!     .to_end_bound(),
 //! );
 //!
 //! assert!(first_interval.simple_overlaps(&second_interval));
@@ -558,8 +570,8 @@ pub fn overlap_position_disambiguation(
         Op::Equal(None, Some(_)) => {
             unreachable!(
                 "When there is a bound ambiguity for an equal position for comparing two half-bounded intervals, \
-                which produces a single bound ambiguity, the bound ambiguity is never stored in the second element \
-                of the `OverlapPosition::Equal` variant"
+                 which produces a single bound ambiguity, the bound ambiguity is never stored in the second element \
+                 of the `OverlapPosition::Equal` variant"
             );
         },
         Op::Equal(Some(start_ambiguity), Some(end_ambiguity)) => {
@@ -625,8 +637,8 @@ pub fn overlap_position_bound_ambiguity_disambiguation_equal_half_bounded(
         BoundOverlapAmbiguity::StartEnd(..) | BoundOverlapAmbiguity::EndStart(..) => {
             unreachable!(
                 "When there is a bound ambiguity for an equal position for comparing two half-bounded intervals, \
-                which produces a single bound ambiguity, the bound ambiguity is always either BothStarts or \
-                BothEnds, but never StartEnd nor EndStart"
+                 which produces a single bound ambiguity, the bound ambiguity is always either BothStarts or \
+                 BothEnds, but never StartEnd nor EndStart"
             );
         },
     }
@@ -1067,20 +1079,32 @@ pub trait CanPositionOverlap<Rhs = Self> {
     /// # use periodical::intervals::ops::overlap:: CanPositionOverlap;
     /// let compared_interval = AbsoluteBoundPair::new(
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_start_bound(),
+    ///         "2025-01-01 08:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_start_bound(),
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 11:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_end_bound(),
+    ///         "2025-01-01 11:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_end_bound(),
     /// );
     ///
     /// let reference_interval = AbsoluteBoundPair::new(
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 10:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_start_bound(),
+    ///         "2025-01-01 10:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_start_bound(),
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 12:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_end_bound(),
+    ///         "2025-01-01 12:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_end_bound(),
     /// );
     ///
     /// assert!(compared_interval.simple_overlaps(&reference_interval));
@@ -1190,22 +1214,34 @@ pub trait CanPositionOverlap<Rhs = Self> {
     /// # use periodical::intervals::ops::overlap::{CanPositionOverlap, OverlapPosition};
     /// let compared_interval = AbsoluteBoundPair::new(
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_start_bound(),
+    ///         "2025-01-01 08:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_start_bound(),
     ///     AbsoluteFiniteBound::new_with_inclusivity(
-    ///         "2025-01-01 10:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///         "2025-01-01 10:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
     ///         BoundInclusivity::Exclusive,
-    ///     ).to_end_bound(),
+    ///     )
+    ///     .to_end_bound(),
     /// );
     ///
     /// let reference_interval = AbsoluteBoundPair::new(
     ///     AbsoluteFiniteBound::new_with_inclusivity(
-    ///         "2025-01-01 10:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///         "2025-01-01 10:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
     ///         BoundInclusivity::Exclusive,
-    ///     ).to_start_bound(),
+    ///     )
+    ///     .to_start_bound(),
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 12:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_end_bound(),
+    ///         "2025-01-01 12:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_end_bound(),
     /// );
     ///
     /// let overlap_closure = |pos: OverlapPosition| -> bool {
@@ -1214,8 +1250,7 @@ pub trait CanPositionOverlap<Rhs = Self> {
     ///         OverlapPosition::EndsOnStart(BoundOverlapAmbiguity::EndStart(
     ///             BoundInclusivity::Exclusive,
     ///             BoundInclusivity::Exclusive,
-    ///         ))
-    ///         | OverlapPosition::StartsOnEnd(BoundOverlapAmbiguity::StartEnd(
+    ///         )) | OverlapPosition::StartsOnEnd(BoundOverlapAmbiguity::StartEnd(
     ///             BoundInclusivity::Exclusive,
     ///             BoundInclusivity::Exclusive,
     ///         )),

--- a/src/intervals/ops/point_containment.rs
+++ b/src/intervals/ops/point_containment.rs
@@ -31,11 +31,17 @@
 //! # use periodical::intervals::ops::point_containment::CanPositionPointContainment;
 //! let interval = AbsoluteBoundPair::new(
 //!     AbsoluteFiniteBound::new(
-//!         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!     ).to_start_bound(),
+//!         "2025-01-01 08:00:00[Europe/Oslo]"
+//!             .parse::<Zoned>()?
+//!             .timestamp(),
+//!     )
+//!     .to_start_bound(),
 //!     AbsoluteFiniteBound::new(
-//!         "2025-01-01 12:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!     ).to_end_bound(),
+//!         "2025-01-01 12:00:00[Europe/Oslo]"
+//!             .parse::<Zoned>()?
+//!             .timestamp(),
+//!     )
+//!     .to_end_bound(),
 //! );
 //!
 //! let point = "2025-01-01 10:00:00[Europe/Oslo]".parse::<Zoned>()?;
@@ -190,20 +196,21 @@ impl PointContainmentPosition {
     /// #     DisambiguatedPointContainmentPosition, PointContainmentPosition,
     /// # };
     /// // Weird disambiguation closure: only on start/end if exclusive
-    /// let disambiguation_closure = |pos: PointContainmentPosition| -> DisambiguatedPointContainmentPosition {
-    ///     type Pos = PointContainmentPosition;
-    ///     type DisambiguatedPos = DisambiguatedPointContainmentPosition;
-    ///     match pos {
-    ///         Pos::OutsideBefore => DisambiguatedPos::OutsideBefore,
-    ///         Pos::OutsideAfter => DisambiguatedPos::OutsideAfter,
-    ///         Pos::Outside => DisambiguatedPos::Outside,
-    ///         Pos::OnStart(BoundInclusivity::Inclusive) => DisambiguatedPos::OutsideBefore,
-    ///         Pos::OnStart(BoundInclusivity::Exclusive) => DisambiguatedPos::OnStart,
-    ///         Pos::OnEnd(BoundInclusivity::Inclusive) => DisambiguatedPos::OutsideAfter,
-    ///         Pos::OnEnd(BoundInclusivity::Exclusive) => DisambiguatedPos::OnEnd,
-    ///         Pos::Inside => DisambiguatedPos::Inside,
-    ///     }
-    /// };
+    /// let disambiguation_closure =
+    ///     |pos: PointContainmentPosition| -> DisambiguatedPointContainmentPosition {
+    ///         type Pos = PointContainmentPosition;
+    ///         type DisambiguatedPos = DisambiguatedPointContainmentPosition;
+    ///         match pos {
+    ///             Pos::OutsideBefore => DisambiguatedPos::OutsideBefore,
+    ///             Pos::OutsideAfter => DisambiguatedPos::OutsideAfter,
+    ///             Pos::Outside => DisambiguatedPos::Outside,
+    ///             Pos::OnStart(BoundInclusivity::Inclusive) => DisambiguatedPos::OutsideBefore,
+    ///             Pos::OnStart(BoundInclusivity::Exclusive) => DisambiguatedPos::OnStart,
+    ///             Pos::OnEnd(BoundInclusivity::Inclusive) => DisambiguatedPos::OutsideAfter,
+    ///             Pos::OnEnd(BoundInclusivity::Exclusive) => DisambiguatedPos::OnEnd,
+    ///             Pos::Inside => DisambiguatedPos::Inside,
+    ///         }
+    ///     };
     ///
     /// assert_eq!(
     ///     PointContainmentPosition::OnStart(BoundInclusivity::Inclusive)
@@ -574,19 +581,27 @@ pub trait CanPositionPointContainment<P> {
     /// # };
     /// let interval = AbsoluteBoundPair::new(
     ///     AbsoluteFiniteBound::new_with_inclusivity(
-    ///         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///         "2025-01-01 08:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
     ///         BoundInclusivity::Exclusive,
-    ///     ).to_start_bound(),
+    ///     )
+    ///     .to_start_bound(),
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 10:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_end_bound(),
+    ///         "2025-01-01 10:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_end_bound(),
     /// );
     ///
     /// let point = "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?;
     ///
     /// assert_eq!(
     ///     interval.point_containment_position(point),
-    ///     Ok(PointContainmentPosition::OnStart(BoundInclusivity::Exclusive)),
+    ///     Ok(PointContainmentPosition::OnStart(
+    ///         BoundInclusivity::Exclusive
+    ///     )),
     /// );
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
@@ -657,11 +672,17 @@ pub trait CanPositionPointContainment<P> {
     /// # use periodical::intervals::ops::point_containment::CanPositionPointContainment;
     /// let interval = AbsoluteBoundPair::new(
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_start_bound(),
+    ///         "2025-01-01 08:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_start_bound(),
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 10:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_end_bound(),
+    ///         "2025-01-01 10:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_end_bound(),
     /// );
     ///
     /// let point = "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?;
@@ -712,11 +733,17 @@ pub trait CanPositionPointContainment<P> {
     /// # };
     /// let interval = AbsoluteBoundPair::new(
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_start_bound(),
+    ///         "2025-01-01 08:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_start_bound(),
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 10:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_end_bound(),
+    ///         "2025-01-01 10:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_end_bound(),
     /// );
     ///
     /// let point = "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?;

--- a/src/intervals/ops/precision.rs
+++ b/src/intervals/ops/precision.rs
@@ -26,11 +26,17 @@
 //! # use periodical::intervals::ops::precision::PreciseAbsoluteInterval;
 //! let interval = AbsoluteBoundPair::new(
 //!     AbsoluteFiniteBound::new(
-//!         "2025-01-01 08:03:29.591[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!     ).to_start_bound(),
+//!         "2025-01-01 08:03:29.591[Europe/Oslo]"
+//!             .parse::<Zoned>()?
+//!             .timestamp(),
+//!     )
+//!     .to_start_bound(),
 //!     AbsoluteFiniteBound::new(
-//!         "2025-01-01 15:57:44.041[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!     ).to_end_bound(),
+//!         "2025-01-01 15:57:44.041[Europe/Oslo]"
+//!             .parse::<Zoned>()?
+//!             .timestamp(),
+//!     )
+//!     .to_end_bound(),
 //! );
 //!
 //! assert_eq!(
@@ -40,11 +46,17 @@
 //!     ),
 //!     Ok(AbsoluteBoundPair::new(
 //!         AbsoluteFiniteBound::new(
-//!             "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!         ).to_start_bound(),
+//!             "2025-01-01 08:00:00[Europe/Oslo]"
+//!                 .parse::<Zoned>()?
+//!                 .timestamp(),
+//!         )
+//!         .to_start_bound(),
 //!         AbsoluteFiniteBound::new(
-//!             "2025-01-01 15:55:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!         ).to_end_bound(),
+//!             "2025-01-01 15:55:00[Europe/Oslo]"
+//!                 .parse::<Zoned>()?
+//!                 .timestamp(),
+//!         )
+//!         .to_end_bound(),
 //!     )),
 //! );
 //! # Ok::<(), Box<dyn Error>>(())
@@ -84,11 +96,17 @@ use crate::ops::{Precision, PrecisionError};
 /// # use periodical::intervals::ops::precision::PreciseAbsoluteInterval;
 /// let interval = AbsoluteBoundPair::new(
 ///     AbsoluteFiniteBound::new(
-///         "2025-01-01 08:03:29.591[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///     ).to_start_bound(),
+///         "2025-01-01 08:03:29.591[Europe/Oslo]"
+///             .parse::<Zoned>()?
+///             .timestamp(),
+///     )
+///     .to_start_bound(),
 ///     AbsoluteFiniteBound::new(
-///         "2025-01-01 15:57:44.041[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///     ).to_end_bound(),
+///         "2025-01-01 15:57:44.041[Europe/Oslo]"
+///             .parse::<Zoned>()?
+///             .timestamp(),
+///     )
+///     .to_end_bound(),
 /// );
 ///
 /// assert_eq!(
@@ -98,11 +116,17 @@ use crate::ops::{Precision, PrecisionError};
 ///     ),
 ///     Ok(AbsoluteBoundPair::new(
 ///         AbsoluteFiniteBound::new(
-///             "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///         ).to_start_bound(),
+///             "2025-01-01 08:00:00[Europe/Oslo]"
+///                 .parse::<Zoned>()?
+///                 .timestamp(),
+///         )
+///         .to_start_bound(),
 ///         AbsoluteFiniteBound::new(
-///             "2025-01-01 15:55:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///         ).to_end_bound(),
+///             "2025-01-01 15:55:00[Europe/Oslo]"
+///                 .parse::<Zoned>()?
+///                 .timestamp(),
+///         )
+///         .to_end_bound(),
 ///     )),
 /// );
 /// # Ok::<(), Box<dyn Error>>(())
@@ -125,11 +149,17 @@ pub trait PreciseAbsoluteInterval {
     /// # use periodical::intervals::ops::precision::PreciseAbsoluteInterval;
     /// let interval = AbsoluteBoundPair::new(
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 08:03:29.591[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_start_bound(),
+    ///         "2025-01-01 08:03:29.591[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_start_bound(),
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 15:57:44.041[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_end_bound(),
+    ///         "2025-01-01 15:57:44.041[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_end_bound(),
     /// );
     ///
     /// assert_eq!(
@@ -140,11 +170,17 @@ pub trait PreciseAbsoluteInterval {
     ///     ),
     ///     Ok(AbsoluteBoundPair::new(
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_start_bound(),
+    ///             "2025-01-01 08:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_start_bound(),
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_end_bound(),
+    ///             "2025-01-01 16:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_end_bound(),
     ///     )),
     /// );
     /// # Ok::<(), Box<dyn Error>>(())
@@ -171,11 +207,17 @@ pub trait PreciseAbsoluteInterval {
     /// # use periodical::intervals::ops::precision::PreciseAbsoluteInterval;
     /// let interval = AbsoluteBoundPair::new(
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 08:03:29.591[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_start_bound(),
+    ///         "2025-01-01 08:03:29.591[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_start_bound(),
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 15:57:44.041[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_end_bound(),
+    ///         "2025-01-01 15:57:44.041[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_end_bound(),
     /// );
     ///
     /// assert_eq!(
@@ -185,11 +227,17 @@ pub trait PreciseAbsoluteInterval {
     ///     ),
     ///     Ok(AbsoluteBoundPair::new(
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_start_bound(),
+    ///             "2025-01-01 08:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_start_bound(),
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 15:55:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_end_bound(),
+    ///             "2025-01-01 15:55:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_end_bound(),
     ///     )),
     /// );
     /// # Ok::<(), Box<dyn Error>>(())
@@ -216,28 +264,44 @@ pub trait PreciseAbsoluteInterval {
     /// # use periodical::intervals::ops::precision::PreciseAbsoluteInterval;
     /// let interval = AbsoluteBoundPair::new(
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 08:11:29.591[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_start_bound(),
+    ///         "2025-01-01 08:11:29.591[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_start_bound(),
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 15:57:44.041[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_end_bound(),
+    ///         "2025-01-01 15:57:44.041[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_end_bound(),
     /// );
     ///
     /// assert_eq!(
     ///     interval.precise_interval_with_different_precisions_with_base_time(
     ///         TimeZone::get("Europe/Oslo")?,
     ///         Precision::new(Duration::from_mins(7), PrecisionMode::ToFuture)?,
-    ///         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///         "2025-01-01 08:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
     ///         Precision::new(Duration::from_mins(7), PrecisionMode::ToPast)?,
-    ///         "2025-01-01 15:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///         "2025-01-01 15:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
     ///     ),
     ///     Ok(AbsoluteBoundPair::new(
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 08:14:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_start_bound(),
+    ///             "2025-01-01 08:14:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_start_bound(),
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 15:56:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_end_bound(),
+    ///             "2025-01-01 15:56:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_end_bound(),
     ///     )),
     /// );
     /// # Ok::<(), Box<dyn Error>>(())
@@ -270,26 +334,40 @@ pub trait PreciseAbsoluteInterval {
     /// # use periodical::intervals::ops::precision::PreciseAbsoluteInterval;
     /// let interval = AbsoluteBoundPair::new(
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 08:11:29.591[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_start_bound(),
+    ///         "2025-01-01 08:11:29.591[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_start_bound(),
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 15:57:44.041[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_end_bound(),
+    ///         "2025-01-01 15:57:44.041[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_end_bound(),
     /// );
     ///
     /// assert_eq!(
     ///     interval.precise_interval_with_base_time(
     ///         TimeZone::get("Europe/Oslo")?,
     ///         Precision::new(Duration::from_mins(7), PrecisionMode::ToFuture)?,
-    ///         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///         "2025-01-01 08:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
     ///     ),
     ///     Ok(AbsoluteBoundPair::new(
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 08:14:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_start_bound(),
+    ///             "2025-01-01 08:14:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_start_bound(),
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 16:03:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_end_bound(),
+    ///             "2025-01-01 16:03:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_end_bound(),
     ///     )),
     /// );
     /// # Ok::<(), Box<dyn Error>>(())
@@ -493,9 +571,12 @@ impl PreciseAbsoluteInterval for EmptiableAbsoluteInterval {
 /// # use periodical::intervals::meta::BoundInclusivity;
 /// # use periodical::intervals::ops::precision::PreciseAbsoluteBound;
 /// let bound = AbsoluteFiniteBound::new_with_inclusivity(
-///     "2025-01-01 08:24:41[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+///     "2025-01-01 08:24:41[Europe/Oslo]"
+///         .parse::<Zoned>()?
+///         .timestamp(),
 ///     BoundInclusivity::Exclusive,
-/// ).to_start_bound();
+/// )
+/// .to_start_bound();
 ///
 /// assert_eq!(
 ///     bound.precise_bound(
@@ -503,9 +584,12 @@ impl PreciseAbsoluteInterval for EmptiableAbsoluteInterval {
 ///         Precision::new(Duration::from_mins(5), PrecisionMode::ToFuture)?,
 ///     ),
 ///     Ok(AbsoluteFiniteBound::new_with_inclusivity(
-///         "2025-01-01 08:25:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+///         "2025-01-01 08:25:00[Europe/Oslo]"
+///             .parse::<Zoned>()?
+///             .timestamp(),
 ///         BoundInclusivity::Exclusive,
-///     ).to_start_bound()),
+///     )
+///     .to_start_bound()),
 /// );
 /// # Ok::<(), Box<dyn Error>>(())
 /// ```
@@ -528,9 +612,12 @@ pub trait PreciseAbsoluteBound {
     /// # use periodical::intervals::meta::BoundInclusivity;
     /// # use periodical::intervals::ops::precision::PreciseAbsoluteBound;
     /// let bound = AbsoluteFiniteBound::new_with_inclusivity(
-    ///     "2025-01-01 08:24:41[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2025-01-01 08:24:41[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     ///     BoundInclusivity::Exclusive,
-    /// ).to_start_bound();
+    /// )
+    /// .to_start_bound();
     ///
     /// assert_eq!(
     ///     bound.precise_bound(
@@ -538,9 +625,12 @@ pub trait PreciseAbsoluteBound {
     ///         Precision::new(Duration::from_mins(5), PrecisionMode::ToFuture)?,
     ///     ),
     ///     Ok(AbsoluteFiniteBound::new_with_inclusivity(
-    ///         "2025-01-01 08:25:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///         "2025-01-01 08:25:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
     ///         BoundInclusivity::Exclusive,
-    ///     ).to_start_bound()),
+    ///     )
+    ///     .to_start_bound()),
     /// );
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
@@ -563,20 +653,28 @@ pub trait PreciseAbsoluteBound {
     /// # use periodical::intervals::meta::BoundInclusivity;
     /// # use periodical::intervals::ops::precision::PreciseAbsoluteBound;
     /// let bound = AbsoluteFiniteBound::new_with_inclusivity(
-    ///     "2025-01-01 08:24:41[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///     "2025-01-01 08:24:41[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
     ///     BoundInclusivity::Exclusive,
-    /// ).to_start_bound();
+    /// )
+    /// .to_start_bound();
     ///
     /// assert_eq!(
     ///     bound.precise_bound_with_base_time(
     ///         TimeZone::get("Europe/Oslo")?,
     ///         Precision::new(Duration::from_mins(7), PrecisionMode::ToFuture)?,
-    ///         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///         "2025-01-01 08:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
     ///     ),
     ///     Ok(AbsoluteFiniteBound::new_with_inclusivity(
-    ///         "2025-01-01 08:28:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+    ///         "2025-01-01 08:28:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
     ///         BoundInclusivity::Exclusive,
-    ///     ).to_start_bound()),
+    ///     )
+    ///     .to_start_bound()),
     /// );
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```

--- a/src/intervals/ops/relativity_conversion.rs
+++ b/src/intervals/ops/relativity_conversion.rs
@@ -81,23 +81,29 @@ macro_rules! to_relative_impl_reflective {
 /// # use periodical::intervals::ops::relativity_conversion::ToAbsolute;
 /// # use periodical::intervals::relative::{RelativeBoundPair, RelativeFiniteBound};
 /// let rel_interval = RelativeBoundPair::new(
-///     RelativeFiniteBound::new(
-///         SignedDuration::from_hours(8),
-///     ).to_start_bound(),
-///     RelativeFiniteBound::new(
-///         SignedDuration::from_hours(16),
-///     ).to_end_bound(),
+///     RelativeFiniteBound::new(SignedDuration::from_hours(8)).to_start_bound(),
+///     RelativeFiniteBound::new(SignedDuration::from_hours(16)).to_end_bound(),
 /// );
 ///
 /// assert_eq!(
-///     rel_interval.to_absolute("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()),
+///     rel_interval.to_absolute(
+///         "2025-01-01 00:00:00[Europe/Oslo]"
+///             .parse::<Zoned>()?
+///             .timestamp()
+///     ),
 ///     AbsoluteBoundPair::new(
 ///         AbsoluteFiniteBound::new(
-///             "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///         ).to_start_bound(),
+///             "2025-01-01 08:00:00[Europe/Oslo]"
+///                 .parse::<Zoned>()?
+///                 .timestamp(),
+///         )
+///         .to_start_bound(),
 ///         AbsoluteFiniteBound::new(
-///             "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///         ).to_end_bound(),
+///             "2025-01-01 16:00:00[Europe/Oslo]"
+///                 .parse::<Zoned>()?
+///                 .timestamp(),
+///         )
+///         .to_end_bound(),
 ///     ),
 /// );
 /// # Ok::<(), Box<dyn Error>>(())
@@ -116,23 +122,29 @@ pub trait ToAbsolute {
     /// # use periodical::intervals::ops::relativity_conversion::ToAbsolute;
     /// # use periodical::intervals::relative::{RelativeBoundPair, RelativeFiniteBound};
     /// let rel_interval = RelativeBoundPair::new(
-    ///     RelativeFiniteBound::new(
-    ///         SignedDuration::from_hours(8),
-    ///     ).to_start_bound(),
-    ///     RelativeFiniteBound::new(
-    ///         SignedDuration::from_hours(16),
-    ///     ).to_end_bound(),
+    ///     RelativeFiniteBound::new(SignedDuration::from_hours(8)).to_start_bound(),
+    ///     RelativeFiniteBound::new(SignedDuration::from_hours(16)).to_end_bound(),
     /// );
     ///
     /// assert_eq!(
-    ///     rel_interval.to_absolute("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()),
+    ///     rel_interval.to_absolute(
+    ///         "2025-01-01 00:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp()
+    ///     ),
     ///     AbsoluteBoundPair::new(
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_start_bound(),
+    ///             "2025-01-01 08:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_start_bound(),
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_end_bound(),
+    ///             "2025-01-01 16:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_end_bound(),
     ///     ),
     /// );
     /// # Ok::<(), Box<dyn Error>>(())
@@ -317,22 +329,28 @@ impl ToAbsolute for EmptiableRelativeInterval {
 /// # use periodical::intervals::relative::{RelativeBoundPair, RelativeFiniteBound};
 /// let abs_interval = AbsoluteBoundPair::new(
 ///     AbsoluteFiniteBound::new(
-///         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///     ).to_start_bound(),
+///         "2025-01-01 08:00:00[Europe/Oslo]"
+///             .parse::<Zoned>()?
+///             .timestamp(),
+///     )
+///     .to_start_bound(),
 ///     AbsoluteFiniteBound::new(
-///         "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///     ).to_end_bound(),
+///         "2025-01-01 16:00:00[Europe/Oslo]"
+///             .parse::<Zoned>()?
+///             .timestamp(),
+///     )
+///     .to_end_bound(),
 /// );
 ///
 /// assert_eq!(
-///     abs_interval.to_relative("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()),
+///     abs_interval.to_relative(
+///         "2025-01-01 00:00:00[Europe/Oslo]"
+///             .parse::<Zoned>()?
+///             .timestamp()
+///     ),
 ///     RelativeBoundPair::new(
-///         RelativeFiniteBound::new(
-///             SignedDuration::from_hours(8),
-///         ).to_start_bound(),
-///         RelativeFiniteBound::new(
-///             SignedDuration::from_hours(16),
-///         ).to_end_bound(),
+///         RelativeFiniteBound::new(SignedDuration::from_hours(8),).to_start_bound(),
+///         RelativeFiniteBound::new(SignedDuration::from_hours(16),).to_end_bound(),
 ///     ),
 /// );
 /// # Ok::<(), Box<dyn Error>>(())
@@ -352,22 +370,28 @@ pub trait ToRelative {
     /// # use periodical::intervals::relative::{RelativeBoundPair, RelativeFiniteBound};
     /// let abs_interval = AbsoluteBoundPair::new(
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_start_bound(),
+    ///         "2025-01-01 08:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_start_bound(),
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_end_bound(),
+    ///         "2025-01-01 16:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_end_bound(),
     /// );
     ///
     /// assert_eq!(
-    ///     abs_interval.to_relative("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()),
+    ///     abs_interval.to_relative(
+    ///         "2025-01-01 00:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp()
+    ///     ),
     ///     RelativeBoundPair::new(
-    ///         RelativeFiniteBound::new(
-    ///             SignedDuration::from_hours(8),
-    ///         ).to_start_bound(),
-    ///         RelativeFiniteBound::new(
-    ///             SignedDuration::from_hours(16),
-    ///         ).to_end_bound(),
+    ///         RelativeFiniteBound::new(SignedDuration::from_hours(8),).to_start_bound(),
+    ///         RelativeFiniteBound::new(SignedDuration::from_hours(16),).to_end_bound(),
     ///     ),
     /// );
     /// # Ok::<(), Box<dyn Error>>(())

--- a/src/intervals/ops/remove_overlap.rs
+++ b/src/intervals/ops/remove_overlap.rs
@@ -114,7 +114,10 @@ impl<T> OverlapRemovalResult<T> {
     ///
     /// ```
     /// # use periodical::intervals::ops::remove_overlap::OverlapRemovalResult;
-    /// assert_eq!(OverlapRemovalResult::<u8>::Split(10, 20).split(), Some((10, 20)));
+    /// assert_eq!(
+    ///     OverlapRemovalResult::<u8>::Split(10, 20).split(),
+    ///     Some((10, 20))
+    /// );
     /// assert_eq!(OverlapRemovalResult::<u8>::Single(10).split(), None);
     /// ```
     #[must_use]
@@ -514,8 +517,8 @@ pub fn remove_overlap_abs_bound_pair(
         Dop::EndsOnStart => {
             let AbsoluteEndBound::Finite(mut finite_bound) = a.abs_end() else {
                 unreachable!(
-                    "If the end of the reference bounds is `InfiniteFuture`, \
-                    then it is impossible that the overlap was `OnStart`"
+                    "If the end of the reference bounds is `InfiniteFuture`, then it is impossible that the overlap \
+                     was `OnStart`"
                 );
             };
 
@@ -531,8 +534,8 @@ pub fn remove_overlap_abs_bound_pair(
         Dop::StartsOnEnd => {
             let AbsoluteStartBound::Finite(mut finite_bound) = a.abs_start() else {
                 unreachable!(
-                    "If the start of the reference bounds is `InfinitePast`, \
-                    then it is impossible that the overlap was `OnEnd`"
+                    "If the start of the reference bounds is `InfinitePast`, then it is impossible that the overlap \
+                     was `OnEnd`"
                 );
             };
 
@@ -548,8 +551,8 @@ pub fn remove_overlap_abs_bound_pair(
         Dop::CrossesStart => {
             let AbsoluteStartBound::Finite(finite_bound) = b.abs_start() else {
                 unreachable!(
-                    "If the start of the compared bounds is `InfinitePast`, \
-                    then it is impossible that the overlap was `CrossesStart`"
+                    "If the start of the compared bounds is `InfinitePast`, then it is impossible that the overlap \
+                     was `CrossesStart`"
                 );
             };
 
@@ -565,8 +568,8 @@ pub fn remove_overlap_abs_bound_pair(
         Dop::CrossesEnd => {
             let AbsoluteEndBound::Finite(finite_bound) = b.abs_end() else {
                 unreachable!(
-                    "If the end of the compared bounds is `InfiniteFuture`, \
-                    then it is impossible that the overlap was `CrossesEnd`"
+                    "If the end of the compared bounds is `InfiniteFuture`, then it is impossible that the overlap \
+                     was `CrossesEnd`"
                 );
             };
 
@@ -605,8 +608,8 @@ pub fn remove_overlap_abs_bound_pair(
 pub fn remove_start_overlap_abs(a: &AbsoluteBoundPair, b: &AbsoluteBoundPair) -> AbsoluteBoundPair {
     let AbsoluteStartBound::Finite(finite_bound) = b.abs_start() else {
         unreachable!(
-            "If the start of the compared bounds is `InfiniteStart`, \
-            then it is impossible that the overlap was `ContainsAndSameEnd`"
+            "If the start of the compared bounds is `InfiniteStart`, then it is impossible that the overlap was \
+             `ContainsAndSameEnd`"
         );
     };
 
@@ -639,8 +642,8 @@ pub fn remove_start_overlap_abs(a: &AbsoluteBoundPair, b: &AbsoluteBoundPair) ->
 pub fn remove_end_overlap_abs(a: &AbsoluteBoundPair, b: &AbsoluteBoundPair) -> AbsoluteBoundPair {
     let AbsoluteEndBound::Finite(finite_bound) = b.abs_end() else {
         unreachable!(
-            "If the end of the compared bounds is `InfiniteFuture`, \
-            then it is impossible that the overlap was `ContainsAndSameStart`"
+            "If the end of the compared bounds is `InfiniteFuture`, then it is impossible that the overlap was \
+             `ContainsAndSameStart`"
         );
     };
 
@@ -730,8 +733,8 @@ pub fn remove_overlap_rel_bound_pair(
         Dop::EndsOnStart => {
             let RelativeEndBound::Finite(mut finite_bound) = a.rel_end() else {
                 unreachable!(
-                    "If the end of the reference bounds is `InfiniteFuture`, \
-                    then it is impossible that the overlap was `OnStart`"
+                    "If the end of the reference bounds is `InfiniteFuture`, then it is impossible that the overlap \
+                     was `OnStart`"
                 );
             };
 
@@ -747,8 +750,8 @@ pub fn remove_overlap_rel_bound_pair(
         Dop::StartsOnEnd => {
             let RelativeStartBound::Finite(mut finite_bound) = a.rel_start() else {
                 unreachable!(
-                    "If the start of the reference bounds is `InfinitePast`, \
-                    then it is impossible that the overlap was `OnEnd`"
+                    "If the start of the reference bounds is `InfinitePast`, then it is impossible that the overlap \
+                     was `OnEnd`"
                 );
             };
 
@@ -764,8 +767,8 @@ pub fn remove_overlap_rel_bound_pair(
         Dop::CrossesStart => {
             let RelativeStartBound::Finite(finite_bound) = b.rel_start() else {
                 unreachable!(
-                    "If the start of the compared bounds is `InfinitePast`, \
-                    then it is impossible that the overlap was `CrossesStart`"
+                    "If the start of the compared bounds is `InfinitePast`, then it is impossible that the overlap \
+                     was `CrossesStart`"
                 );
             };
 
@@ -781,8 +784,8 @@ pub fn remove_overlap_rel_bound_pair(
         Dop::CrossesEnd => {
             let RelativeEndBound::Finite(finite_bound) = b.rel_end() else {
                 unreachable!(
-                    "If the end of the compared bounds is `InfiniteFuture`, \
-                    then it is impossible that the overlap was `CrossesEnd`"
+                    "If the end of the compared bounds is `InfiniteFuture`, then it is impossible that the overlap \
+                     was `CrossesEnd`"
                 );
             };
 
@@ -821,8 +824,8 @@ pub fn remove_overlap_rel_bound_pair(
 pub fn remove_start_overlap_rel(a: &RelativeBoundPair, b: &RelativeBoundPair) -> RelativeBoundPair {
     let RelativeStartBound::Finite(finite_bound) = b.rel_start() else {
         unreachable!(
-            "If the start of the compared bounds is `InfiniteStart`, \
-            then it is impossible that the overlap was `ContainsAndSameEnd`"
+            "If the start of the compared bounds is `InfiniteStart`, then it is impossible that the overlap was \
+             `ContainsAndSameEnd`"
         );
     };
 
@@ -855,8 +858,8 @@ pub fn remove_start_overlap_rel(a: &RelativeBoundPair, b: &RelativeBoundPair) ->
 pub fn remove_end_overlap_rel(a: &RelativeBoundPair, b: &RelativeBoundPair) -> RelativeBoundPair {
     let RelativeEndBound::Finite(finite_bound) = b.rel_end() else {
         unreachable!(
-            "If the end of the compared bounds is `InfiniteFuture`, \
-            then it is impossible that the overlap was `ContainsAndSameStart`"
+            "If the end of the compared bounds is `InfiniteFuture`, then it is impossible that the overlap was \
+             `ContainsAndSameStart`"
         );
     };
 

--- a/src/intervals/ops/remove_overlap_or_gap.rs
+++ b/src/intervals/ops/remove_overlap_or_gap.rs
@@ -100,8 +100,14 @@ impl<T> OverlapOrGapRemovalResult<T> {
     ///
     /// ```
     /// # use periodical::intervals::ops::remove_overlap_or_gap::OverlapOrGapRemovalResult;
-    /// assert_eq!(OverlapOrGapRemovalResult::<u8>::Single(10).single(), Some(10));
-    /// assert_eq!(OverlapOrGapRemovalResult::<u8>::Split(10, 20).single(), None);
+    /// assert_eq!(
+    ///     OverlapOrGapRemovalResult::<u8>::Single(10).single(),
+    ///     Some(10)
+    /// );
+    /// assert_eq!(
+    ///     OverlapOrGapRemovalResult::<u8>::Split(10, 20).single(),
+    ///     None
+    /// );
     /// ```
     #[must_use]
     pub fn single(self) -> Option<T> {
@@ -123,7 +129,10 @@ impl<T> OverlapOrGapRemovalResult<T> {
     ///
     /// ```
     /// # use periodical::intervals::ops::remove_overlap_or_gap::OverlapOrGapRemovalResult;
-    /// assert_eq!(OverlapOrGapRemovalResult::<u8>::Split(10, 20).split(), Some((10, 20)));
+    /// assert_eq!(
+    ///     OverlapOrGapRemovalResult::<u8>::Split(10, 20).split(),
+    ///     Some((10, 20))
+    /// );
     /// assert_eq!(OverlapOrGapRemovalResult::<u8>::Single(10).split(), None);
     /// ```
     #[must_use]
@@ -619,8 +628,8 @@ pub fn remove_overlap_or_gap_abs_bound_pair(
         Dop::OutsideBefore => {
             let AbsoluteStartBound::Finite(finite_bound) = b.abs_start() else {
                 unreachable!(
-                    "If the start of the compared bounds is `InfinitePast`, \
-                    then it is impossible that the overlap was `OutsideBefore`"
+                    "If the start of the compared bounds is `InfinitePast`, then it is impossible that the overlap \
+                     was `OutsideBefore`"
                 );
             };
 
@@ -634,8 +643,8 @@ pub fn remove_overlap_or_gap_abs_bound_pair(
         Dop::OutsideAfter => {
             let AbsoluteEndBound::Finite(finite_bound) = b.abs_end() else {
                 unreachable!(
-                    "If the end of the compared bounds is `InfiniteFuture`, \
-                    then it is impossible that the overlap was `OutsideAfter`"
+                    "If the end of the compared bounds is `InfiniteFuture`, then it is impossible that the overlap \
+                     was `OutsideAfter`"
                 );
             };
 
@@ -649,8 +658,8 @@ pub fn remove_overlap_or_gap_abs_bound_pair(
         Dop::EndsOnStart => {
             let AbsoluteStartBound::Finite(finite_bound) = b.abs_start() else {
                 unreachable!(
-                    "If the start of the compared bounds is `InfinitePast`, \
-                    then it is impossible that the overlap was `EndsOnStart`"
+                    "If the start of the compared bounds is `InfinitePast`, then it is impossible that the overlap \
+                     was `EndsOnStart`"
                 );
             };
 
@@ -664,8 +673,8 @@ pub fn remove_overlap_or_gap_abs_bound_pair(
         Dop::StartsOnEnd => {
             let AbsoluteEndBound::Finite(finite_bound) = b.abs_end() else {
                 unreachable!(
-                    "If the end of the compared bounds is `InfiniteFuture`, \
-                    then it is impossible that the overlap was `StartsOnEnd`"
+                    "If the end of the compared bounds is `InfiniteFuture`, then it is impossible that the overlap \
+                     was `StartsOnEnd`"
                 );
             };
 
@@ -679,8 +688,8 @@ pub fn remove_overlap_or_gap_abs_bound_pair(
         Dop::CrossesStart => {
             let AbsoluteStartBound::Finite(finite_bound) = b.abs_start() else {
                 unreachable!(
-                    "If the start of the compared bounds is `InfinitePast`, \
-                    then it is impossible that the overlap was `CrossesStart`"
+                    "If the start of the compared bounds is `InfinitePast`, then it is impossible that the overlap \
+                     was `CrossesStart`"
                 );
             };
 
@@ -694,8 +703,8 @@ pub fn remove_overlap_or_gap_abs_bound_pair(
         Dop::CrossesEnd => {
             let AbsoluteEndBound::Finite(finite_bound) = b.abs_end() else {
                 unreachable!(
-                    "If the end of the compared bounds is `InfiniteFuture`, \
-                    then it is impossible that the overlap was `CrossesEnd`"
+                    "If the end of the compared bounds is `InfiniteFuture`, then it is impossible that the overlap \
+                     was `CrossesEnd`"
                 );
             };
 
@@ -772,8 +781,8 @@ pub fn remove_overlap_or_gap_rel_bound_pair(
         Dop::OutsideBefore => {
             let RelativeStartBound::Finite(finite_bound) = b.rel_start() else {
                 unreachable!(
-                    "If the start of the compared bounds is `InfinitePast`, \
-                    then it is impossible that the overlap was `OutsideBefore`"
+                    "If the start of the compared bounds is `InfinitePast`, then it is impossible that the overlap \
+                     was `OutsideBefore`"
                 );
             };
 
@@ -787,8 +796,8 @@ pub fn remove_overlap_or_gap_rel_bound_pair(
         Dop::OutsideAfter => {
             let RelativeEndBound::Finite(finite_bound) = b.rel_end() else {
                 unreachable!(
-                    "If the end of the compared bounds is `InfiniteFuture`, \
-                    then it is impossible that the overlap was `OutsideAfter`"
+                    "If the end of the compared bounds is `InfiniteFuture`, then it is impossible that the overlap \
+                     was `OutsideAfter`"
                 );
             };
 
@@ -802,8 +811,8 @@ pub fn remove_overlap_or_gap_rel_bound_pair(
         Dop::EndsOnStart => {
             let RelativeStartBound::Finite(finite_bound) = b.rel_start() else {
                 unreachable!(
-                    "If the start of the compared bounds is `InfinitePast`, \
-                    then it is impossible that the overlap was `EndsOnStart`"
+                    "If the start of the compared bounds is `InfinitePast`, then it is impossible that the overlap \
+                     was `EndsOnStart`"
                 );
             };
 
@@ -817,8 +826,8 @@ pub fn remove_overlap_or_gap_rel_bound_pair(
         Dop::StartsOnEnd => {
             let RelativeEndBound::Finite(finite_bound) = b.rel_end() else {
                 unreachable!(
-                    "If the end of the compared bounds is `InfiniteFuture`, \
-                    then it is impossible that the overlap was `StartsOnEnd`"
+                    "If the end of the compared bounds is `InfiniteFuture`, then it is impossible that the overlap \
+                     was `StartsOnEnd`"
                 );
             };
 
@@ -832,8 +841,8 @@ pub fn remove_overlap_or_gap_rel_bound_pair(
         Dop::CrossesStart => {
             let RelativeStartBound::Finite(finite_bound) = b.rel_start() else {
                 unreachable!(
-                    "If the start of the compared bounds is `InfinitePast`, \
-                    then it is impossible that the overlap was `CrossesStart`"
+                    "If the start of the compared bounds is `InfinitePast`, then it is impossible that the overlap \
+                     was `CrossesStart`"
                 );
             };
 
@@ -847,8 +856,8 @@ pub fn remove_overlap_or_gap_rel_bound_pair(
         Dop::CrossesEnd => {
             let RelativeEndBound::Finite(finite_bound) = b.rel_end() else {
                 unreachable!(
-                    "If the end of the compared bounds is `InfiniteFuture`, \
-                    then it is impossible that the overlap was `CrossesEnd`"
+                    "If the end of the compared bounds is `InfiniteFuture`, then it is impossible that the overlap \
+                     was `CrossesEnd`"
                 );
             };
 

--- a/src/intervals/ops/set_ops.rs
+++ b/src/intervals/ops/set_ops.rs
@@ -51,31 +51,49 @@ use crate::ops::{ComplementResult, DifferenceResult, IntersectionResult, Symmetr
 /// # use periodical::intervals::ops::set_ops::Unitable;
 /// let first_interval = AbsoluteBoundPair::new(
 ///     AbsoluteFiniteBound::new(
-///         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///     ).to_start_bound(),
+///         "2025-01-01 08:00:00[Europe/Oslo]"
+///             .parse::<Zoned>()?
+///             .timestamp(),
+///     )
+///     .to_start_bound(),
 ///     AbsoluteFiniteBound::new(
-///         "2025-01-01 14:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///     ).to_end_bound(),
+///         "2025-01-01 14:00:00[Europe/Oslo]"
+///             .parse::<Zoned>()?
+///             .timestamp(),
+///     )
+///     .to_end_bound(),
 /// );
 ///
 /// let second_interval = AbsoluteBoundPair::new(
 ///     AbsoluteFiniteBound::new(
-///         "2025-01-01 12:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///     ).to_start_bound(),
+///         "2025-01-01 12:00:00[Europe/Oslo]"
+///             .parse::<Zoned>()?
+///             .timestamp(),
+///     )
+///     .to_start_bound(),
 ///     AbsoluteFiniteBound::new(
-///         "2025-01-01 18:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///     ).to_end_bound(),
+///         "2025-01-01 18:00:00[Europe/Oslo]"
+///             .parse::<Zoned>()?
+///             .timestamp(),
+///     )
+///     .to_end_bound(),
 /// );
 ///
 /// assert_eq!(
 ///     first_interval.unite(&second_interval),
 ///     UnionResult::United(AbsoluteBoundPair::new(
 ///         AbsoluteFiniteBound::new(
-///             "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///         ).to_start_bound(),
+///             "2025-01-01 08:00:00[Europe/Oslo]"
+///                 .parse::<Zoned>()?
+///                 .timestamp(),
+///         )
+///         .to_start_bound(),
 ///         AbsoluteFiniteBound::new(
-///             "2025-01-01 18:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///         ).to_end_bound(),
+///             "2025-01-01 18:00:00[Europe/Oslo]"
+///                 .parse::<Zoned>()?
+///                 .timestamp(),
+///         )
+///         .to_end_bound(),
 ///     )),
 /// );
 /// # Ok::<(), Box<dyn Error>>(())
@@ -91,20 +109,32 @@ use crate::ops::{ComplementResult, DifferenceResult, IntersectionResult, Symmetr
 /// # use periodical::intervals::ops::set_ops::Unitable;
 /// let first_interval = AbsoluteBoundPair::new(
 ///     AbsoluteFiniteBound::new(
-///         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///     ).to_start_bound(),
+///         "2025-01-01 08:00:00[Europe/Oslo]"
+///             .parse::<Zoned>()?
+///             .timestamp(),
+///     )
+///     .to_start_bound(),
 ///     AbsoluteFiniteBound::new(
-///         "2025-01-01 12:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///     ).to_end_bound(),
+///         "2025-01-01 12:00:00[Europe/Oslo]"
+///             .parse::<Zoned>()?
+///             .timestamp(),
+///     )
+///     .to_end_bound(),
 /// );
 ///
 /// let second_interval = AbsoluteBoundPair::new(
 ///     AbsoluteFiniteBound::new(
-///         "2025-01-01 14:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///     ).to_start_bound(),
+///         "2025-01-01 14:00:00[Europe/Oslo]"
+///             .parse::<Zoned>()?
+///             .timestamp(),
+///     )
+///     .to_start_bound(),
 ///     AbsoluteFiniteBound::new(
-///         "2025-01-01 18:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///     ).to_end_bound(),
+///         "2025-01-01 18:00:00[Europe/Oslo]"
+///             .parse::<Zoned>()?
+///             .timestamp(),
+///     )
+///     .to_end_bound(),
 /// );
 ///
 /// assert_eq!(
@@ -129,31 +159,49 @@ pub trait Unitable<Rhs = Self> {
     /// # use periodical::intervals::ops::set_ops::Unitable;
     /// let first_interval = AbsoluteBoundPair::new(
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_start_bound(),
+    ///         "2025-01-01 08:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_start_bound(),
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 14:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_end_bound(),
+    ///         "2025-01-01 14:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_end_bound(),
     /// );
     ///
     /// let second_interval = AbsoluteBoundPair::new(
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 12:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_start_bound(),
+    ///         "2025-01-01 12:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_start_bound(),
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 18:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_end_bound(),
+    ///         "2025-01-01 18:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_end_bound(),
     /// );
     ///
     /// assert_eq!(
     ///     first_interval.unite(&second_interval),
     ///     UnionResult::United(AbsoluteBoundPair::new(
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_start_bound(),
+    ///             "2025-01-01 08:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_start_bound(),
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 18:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_end_bound(),
+    ///             "2025-01-01 18:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_end_bound(),
     ///     )),
     /// );
     /// # Ok::<(), Box<dyn Error>>(())
@@ -174,39 +222,55 @@ pub trait Unitable<Rhs = Self> {
     /// # use periodical::intervals::ops::set_ops::Unitable;
     /// let first_interval = AbsoluteBoundPair::new(
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_start_bound(),
+    ///         "2025-01-01 08:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_start_bound(),
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 12:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_end_bound(),
+    ///         "2025-01-01 12:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_end_bound(),
     /// );
     ///
     /// let second_interval = AbsoluteBoundPair::new(
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 14:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_start_bound(),
+    ///         "2025-01-01 14:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_start_bound(),
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 18:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_end_bound(),
+    ///         "2025-01-01 18:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_end_bound(),
     /// );
     ///
-    /// let union_closure = |
-    ///     a: &AbsoluteBoundPair,
-    ///     b: &AbsoluteBoundPair,
-    /// | -> UnionResult<AbsoluteBoundPair> {
-    ///     // Always unite
-    ///     UnionResult::United(a.extend(b))
-    /// };
+    /// let union_closure =
+    ///     |a: &AbsoluteBoundPair, b: &AbsoluteBoundPair| -> UnionResult<AbsoluteBoundPair> {
+    ///         // Always unite
+    ///         UnionResult::United(a.extend(b))
+    ///     };
     ///
     /// assert_eq!(
     ///     first_interval.unite_with(&second_interval, union_closure),
     ///     UnionResult::United(AbsoluteBoundPair::new(
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_start_bound(),
+    ///             "2025-01-01 08:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_start_bound(),
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 18:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_end_bound(),
+    ///             "2025-01-01 18:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_end_bound(),
     ///     )),
     /// );
     /// # Ok::<(), Box<dyn Error>>(())
@@ -493,31 +557,49 @@ pub fn unite_emptiable_rel_bound_pair(
 /// # use periodical::intervals::ops::set_ops::Intersectable;
 /// let first_interval = AbsoluteBoundPair::new(
 ///     AbsoluteFiniteBound::new(
-///         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///     ).to_start_bound(),
+///         "2025-01-01 08:00:00[Europe/Oslo]"
+///             .parse::<Zoned>()?
+///             .timestamp(),
+///     )
+///     .to_start_bound(),
 ///     AbsoluteFiniteBound::new(
-///         "2025-01-01 14:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///     ).to_end_bound(),
+///         "2025-01-01 14:00:00[Europe/Oslo]"
+///             .parse::<Zoned>()?
+///             .timestamp(),
+///     )
+///     .to_end_bound(),
 /// );
 ///
 /// let second_interval = AbsoluteBoundPair::new(
 ///     AbsoluteFiniteBound::new(
-///         "2025-01-01 12:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///     ).to_start_bound(),
+///         "2025-01-01 12:00:00[Europe/Oslo]"
+///             .parse::<Zoned>()?
+///             .timestamp(),
+///     )
+///     .to_start_bound(),
 ///     AbsoluteFiniteBound::new(
-///         "2025-01-01 18:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///     ).to_end_bound(),
+///         "2025-01-01 18:00:00[Europe/Oslo]"
+///             .parse::<Zoned>()?
+///             .timestamp(),
+///     )
+///     .to_end_bound(),
 /// );
 ///
 /// assert_eq!(
 ///     first_interval.intersect(&second_interval),
 ///     IntersectionResult::Intersected(AbsoluteBoundPair::new(
 ///         AbsoluteFiniteBound::new(
-///             "2025-01-01 12:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///         ).to_start_bound(),
+///             "2025-01-01 12:00:00[Europe/Oslo]"
+///                 .parse::<Zoned>()?
+///                 .timestamp(),
+///         )
+///         .to_start_bound(),
 ///         AbsoluteFiniteBound::new(
-///             "2025-01-01 14:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///         ).to_end_bound(),
+///             "2025-01-01 14:00:00[Europe/Oslo]"
+///                 .parse::<Zoned>()?
+///                 .timestamp(),
+///         )
+///         .to_end_bound(),
 ///     )),
 /// );
 /// # Ok::<(), Box<dyn Error>>(())
@@ -533,20 +615,32 @@ pub fn unite_emptiable_rel_bound_pair(
 /// # use periodical::intervals::ops::set_ops::Intersectable;
 /// let first_interval = AbsoluteBoundPair::new(
 ///     AbsoluteFiniteBound::new(
-///         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///     ).to_start_bound(),
+///         "2025-01-01 08:00:00[Europe/Oslo]"
+///             .parse::<Zoned>()?
+///             .timestamp(),
+///     )
+///     .to_start_bound(),
 ///     AbsoluteFiniteBound::new(
-///         "2025-01-01 12:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///     ).to_end_bound(),
+///         "2025-01-01 12:00:00[Europe/Oslo]"
+///             .parse::<Zoned>()?
+///             .timestamp(),
+///     )
+///     .to_end_bound(),
 /// );
 ///
 /// let second_interval = AbsoluteBoundPair::new(
 ///     AbsoluteFiniteBound::new(
-///         "2025-01-01 14:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///     ).to_start_bound(),
+///         "2025-01-01 14:00:00[Europe/Oslo]"
+///             .parse::<Zoned>()?
+///             .timestamp(),
+///     )
+///     .to_start_bound(),
 ///     AbsoluteFiniteBound::new(
-///         "2025-01-01 18:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///     ).to_end_bound(),
+///         "2025-01-01 18:00:00[Europe/Oslo]"
+///             .parse::<Zoned>()?
+///             .timestamp(),
+///     )
+///     .to_end_bound(),
 /// );
 ///
 /// assert_eq!(
@@ -571,31 +665,49 @@ pub trait Intersectable<Rhs = Self> {
     /// # use periodical::intervals::ops::set_ops::Intersectable;
     /// let first_interval = AbsoluteBoundPair::new(
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_start_bound(),
+    ///         "2025-01-01 08:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_start_bound(),
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 14:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_end_bound(),
+    ///         "2025-01-01 14:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_end_bound(),
     /// );
     ///
     /// let second_interval = AbsoluteBoundPair::new(
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 12:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_start_bound(),
+    ///         "2025-01-01 12:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_start_bound(),
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 18:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_end_bound(),
+    ///         "2025-01-01 18:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_end_bound(),
     /// );
     ///
     /// assert_eq!(
     ///     first_interval.intersect(&second_interval),
     ///     IntersectionResult::Intersected(AbsoluteBoundPair::new(
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 12:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_start_bound(),
+    ///             "2025-01-01 12:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_start_bound(),
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 14:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_end_bound(),
+    ///             "2025-01-01 14:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_end_bound(),
     ///     )),
     /// );
     /// # Ok::<(), Box<dyn Error>>(())
@@ -2256,8 +2368,8 @@ pub fn symmetrically_differentiate_abs_bound_pair(
         ) => SymmetricDifferenceResult::Split(split1, split2),
         (OverlapRemovalResult::Split(..), _) | (_, OverlapRemovalResult::Split(..)) => {
             unreachable!(
-                "No possible interval configuration exist where A \\ B (A diff B) returns a `Split` result, \
-                but at the same time B \\ A (B diff A) returns anything other than an empty interval"
+                "No possible interval configuration exist where A \\ B (A diff B) returns a `Split` result, but at \
+                 the same time B \\ A (B diff A) returns anything other than an empty interval"
             );
         },
     }
@@ -2347,8 +2459,8 @@ pub fn symmetrically_differentiate_rel_bound_pair(
         ) => SymmetricDifferenceResult::Split(split1, split2),
         (OverlapRemovalResult::Split(..), _) | (_, OverlapRemovalResult::Split(..)) => {
             unreachable!(
-                "No possible interval configuration exist where A \\ B (A diff B) returns a `Split` result, \
-                but at the same time B \\ A (B diff A) returns anything other than an empty interval"
+                "No possible interval configuration exist where A \\ B (A diff B) returns a `Split` result, but at \
+                 the same time B \\ A (B diff A) returns anything other than an empty interval"
             );
         },
     }

--- a/src/intervals/ops/shrink.rs
+++ b/src/intervals/ops/shrink.rs
@@ -16,27 +16,45 @@
 //! # use periodical::intervals::ops::shrink::ShrinkableStartBound;
 //! let interval = AbsoluteBoundPair::new(
 //!     AbsoluteFiniteBound::new(
-//!         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!     ).to_start_bound(),
+//!         "2025-01-01 08:00:00[Europe/Oslo]"
+//!             .parse::<Zoned>()?
+//!             .timestamp(),
+//!     )
+//!     .to_start_bound(),
 //!     AbsoluteFiniteBound::new(
-//!         "2025-01-01 14:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!     ).to_end_bound(),
+//!         "2025-01-01 14:00:00[Europe/Oslo]"
+//!             .parse::<Zoned>()?
+//!             .timestamp(),
+//!     )
+//!     .to_end_bound(),
 //! );
 //!
 //! let shrunk_interval = interval.shrink_start(
 //!     AbsoluteFiniteBound::new(
-//!         "2025-01-01 10:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!     ).to_start_bound()
+//!         "2025-01-01 10:00:00[Europe/Oslo]"
+//!             .parse::<Zoned>()?
+//!             .timestamp(),
+//!     )
+//!     .to_start_bound(),
 //! );
 //!
-//! assert_eq!(shrunk_interval, AbsoluteBoundPair::new(
-//!     AbsoluteFiniteBound::new(
-//!         "2025-01-01 10:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!     ).to_start_bound(),
-//!     AbsoluteFiniteBound::new(
-//!         "2025-01-01 14:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!     ).to_end_bound(),
-//! ));
+//! assert_eq!(
+//!     shrunk_interval,
+//!     AbsoluteBoundPair::new(
+//!         AbsoluteFiniteBound::new(
+//!             "2025-01-01 10:00:00[Europe/Oslo]"
+//!                 .parse::<Zoned>()?
+//!                 .timestamp(),
+//!         )
+//!         .to_start_bound(),
+//!         AbsoluteFiniteBound::new(
+//!             "2025-01-01 14:00:00[Europe/Oslo]"
+//!                 .parse::<Zoned>()?
+//!                 .timestamp(),
+//!         )
+//!         .to_end_bound(),
+//!     )
+//! );
 //! # Ok::<(), Box<dyn Error>>(())
 //! ```
 
@@ -92,27 +110,45 @@ pub trait ShrinkableStartBound<P> {
     /// # use periodical::intervals::ops::shrink::ShrinkableStartBound;
     /// let interval = AbsoluteBoundPair::new(
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_start_bound(),
+    ///         "2025-01-01 08:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_start_bound(),
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 14:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_end_bound(),
+    ///         "2025-01-01 14:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_end_bound(),
     /// );
     ///
     /// let shrunk_interval = interval.shrink_start(
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 10:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_start_bound()
+    ///         "2025-01-01 10:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_start_bound(),
     /// );
     ///
-    /// assert_eq!(shrunk_interval, AbsoluteBoundPair::new(
-    ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 10:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_start_bound(),
-    ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 14:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_end_bound(),
-    /// ));
+    /// assert_eq!(
+    ///     shrunk_interval,
+    ///     AbsoluteBoundPair::new(
+    ///         AbsoluteFiniteBound::new(
+    ///             "2025-01-01 10:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_start_bound(),
+    ///         AbsoluteFiniteBound::new(
+    ///             "2025-01-01 14:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_end_bound(),
+    ///     )
+    /// );
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
     fn shrink_start(&self, position: P) -> Self::Output;
@@ -142,27 +178,45 @@ pub trait ShrinkableEndBound<P> {
     /// # use periodical::intervals::ops::shrink::ShrinkableEndBound;
     /// let interval = AbsoluteBoundPair::new(
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_start_bound(),
+    ///         "2025-01-01 08:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_start_bound(),
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 14:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_end_bound(),
+    ///         "2025-01-01 14:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_end_bound(),
     /// );
     ///
     /// let shrunk_interval = interval.shrink_end(
     ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 12:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_end_bound()
+    ///         "2025-01-01 12:00:00[Europe/Oslo]"
+    ///             .parse::<Zoned>()?
+    ///             .timestamp(),
+    ///     )
+    ///     .to_end_bound(),
     /// );
     ///
-    /// assert_eq!(shrunk_interval, AbsoluteBoundPair::new(
-    ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_start_bound(),
-    ///     AbsoluteFiniteBound::new(
-    ///         "2025-01-01 12:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_end_bound(),
-    /// ));
+    /// assert_eq!(
+    ///     shrunk_interval,
+    ///     AbsoluteBoundPair::new(
+    ///         AbsoluteFiniteBound::new(
+    ///             "2025-01-01 08:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_start_bound(),
+    ///         AbsoluteFiniteBound::new(
+    ///             "2025-01-01 12:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_end_bound(),
+    ///     )
+    /// );
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
     fn shrink_end(&self, position: P) -> Self::Output;

--- a/src/intervals/relative/bound.rs
+++ b/src/intervals/relative/bound.rs
@@ -38,12 +38,8 @@ impl RelativeBound {
     /// let start_offset = SignedDuration::from_hours(8);
     /// let end_offset = SignedDuration::from_hours(16);
     ///
-    /// let start = RelativeBound::Start(
-    ///     RelativeFiniteBound::new(start_offset).to_start_bound()
-    /// );
-    /// let end = RelativeBound::End(
-    ///     RelativeFiniteBound::new(end_offset).to_end_bound()
-    /// );
+    /// let start = RelativeBound::Start(RelativeFiniteBound::new(start_offset).to_start_bound());
+    /// let end = RelativeBound::End(RelativeFiniteBound::new(end_offset).to_end_bound());
     ///
     /// assert!(start.is_start());
     /// assert!(!end.is_start());
@@ -63,12 +59,8 @@ impl RelativeBound {
     /// let start_offset = SignedDuration::from_hours(8);
     /// let end_offset = SignedDuration::from_hours(16);
     ///
-    /// let start = RelativeBound::Start(
-    ///     RelativeFiniteBound::new(start_offset).to_start_bound()
-    /// );
-    /// let end = RelativeBound::End(
-    ///     RelativeFiniteBound::new(end_offset).to_end_bound()
-    /// );
+    /// let start = RelativeBound::Start(RelativeFiniteBound::new(start_offset).to_start_bound());
+    /// let end = RelativeBound::End(RelativeFiniteBound::new(end_offset).to_end_bound());
     ///
     /// assert!(end.is_end());
     /// assert!(!start.is_end());
@@ -92,21 +84,14 @@ impl RelativeBound {
     /// let start_offset = SignedDuration::from_hours(8);
     /// let end_offset = SignedDuration::from_hours(16);
     ///
-    /// let start = RelativeBound::Start(
-    ///     RelativeFiniteBound::new(start_offset).to_start_bound()
-    /// );
-    /// let end = RelativeBound::End(
-    ///     RelativeFiniteBound::new(end_offset).to_end_bound()
-    /// );
+    /// let start = RelativeBound::Start(RelativeFiniteBound::new(start_offset).to_start_bound());
+    /// let end = RelativeBound::End(RelativeFiniteBound::new(end_offset).to_end_bound());
     ///
     /// assert_eq!(
     ///     start.start(),
     ///     Some(RelativeFiniteBound::new(start_offset).to_start_bound()),
     /// );
-    /// assert_eq!(
-    ///     end.start(),
-    ///     None,
-    /// );
+    /// assert_eq!(end.start(), None,);
     /// ```
     #[must_use]
     pub fn start(self) -> Option<RelativeStartBound> {
@@ -130,21 +115,14 @@ impl RelativeBound {
     /// let start_offset = SignedDuration::from_hours(8);
     /// let end_offset = SignedDuration::from_hours(16);
     ///
-    /// let start = RelativeBound::Start(
-    ///     RelativeFiniteBound::new(start_offset).to_start_bound()
-    /// );
-    /// let end = RelativeBound::End(
-    ///     RelativeFiniteBound::new(end_offset).to_end_bound()
-    /// );
+    /// let start = RelativeBound::Start(RelativeFiniteBound::new(start_offset).to_start_bound());
+    /// let end = RelativeBound::End(RelativeFiniteBound::new(end_offset).to_end_bound());
     ///
     /// assert_eq!(
     ///     end.end(),
     ///     Some(RelativeFiniteBound::new(end_offset).to_end_bound()),
     /// );
-    /// assert_eq!(
-    ///     start.end(),
-    ///     None,
-    /// );
+    /// assert_eq!(start.end(), None,);
     /// ```
     #[must_use]
     pub fn end(self) -> Option<RelativeEndBound> {

--- a/src/intervals/relative/bound_pair.rs
+++ b/src/intervals/relative/bound_pair.rs
@@ -149,10 +149,7 @@ impl RelativeBoundPair {
     /// );
     /// assert_eq!(
     ///     bounds.end(),
-    ///     RelativeFiniteBound::new_with_inclusivity(
-    ///         end,
-    ///         BoundInclusivity::Exclusive,
-    ///     ).to_end_bound(),
+    ///     RelativeFiniteBound::new_with_inclusivity(end, BoundInclusivity::Exclusive,).to_end_bound(),
     /// );
     /// ```
     #[must_use]

--- a/src/intervals/relative/bounded_interval.rs
+++ b/src/intervals/relative/bounded_interval.rs
@@ -181,8 +181,14 @@ impl BoundedRelativeInterval {
     ///     BoundInclusivity::Exclusive,
     /// );
     ///
-    /// assert_eq!(bounded_interval.start_inclusivity(), BoundInclusivity::Inclusive);
-    /// assert_eq!(bounded_interval.end_inclusivity(), BoundInclusivity::Exclusive);
+    /// assert_eq!(
+    ///     bounded_interval.start_inclusivity(),
+    ///     BoundInclusivity::Inclusive
+    /// );
+    /// assert_eq!(
+    ///     bounded_interval.end_inclusivity(),
+    ///     BoundInclusivity::Exclusive
+    /// );
     /// ```
     #[must_use]
     pub fn unchecked_new_with_inclusivity(
@@ -224,8 +230,14 @@ impl BoundedRelativeInterval {
     /// );
     ///
     /// // Therefore gets reset to inclusive for both bounds
-    /// assert_eq!(bounded_interval.start_inclusivity(), BoundInclusivity::Inclusive);
-    /// assert_eq!(bounded_interval.end_inclusivity(), BoundInclusivity::Inclusive);
+    /// assert_eq!(
+    ///     bounded_interval.start_inclusivity(),
+    ///     BoundInclusivity::Inclusive
+    /// );
+    /// assert_eq!(
+    ///     bounded_interval.end_inclusivity(),
+    ///     BoundInclusivity::Inclusive
+    /// );
     /// ```
     #[must_use]
     pub fn new_with_inclusivity(
@@ -267,8 +279,14 @@ impl BoundedRelativeInterval {
     ///
     /// assert_eq!(bounded_interval.start(), SignedDuration::from_hours(3));
     /// assert_eq!(bounded_interval.end(), SignedDuration::from_hours(8));
-    /// assert_eq!(bounded_interval.start_inclusivity(), BoundInclusivity::Inclusive);
-    /// assert_eq!(bounded_interval.end_inclusivity(), BoundInclusivity::Exclusive);
+    /// assert_eq!(
+    ///     bounded_interval.start_inclusivity(),
+    ///     BoundInclusivity::Inclusive
+    /// );
+    /// assert_eq!(
+    ///     bounded_interval.end_inclusivity(),
+    ///     BoundInclusivity::Exclusive
+    /// );
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
     pub fn new_with_length_and_inclusivity(
@@ -301,10 +319,8 @@ impl BoundedRelativeInterval {
     /// ```
     /// # use jiff::SignedDuration;
     /// # use periodical::intervals::relative::BoundedRelativeInterval;
-    /// let bounded_interval = BoundedRelativeInterval::new(
-    ///     SignedDuration::from_hours(1),
-    ///     SignedDuration::from_hours(5),
-    /// );
+    /// let bounded_interval =
+    ///     BoundedRelativeInterval::new(SignedDuration::from_hours(1), SignedDuration::from_hours(5));
     ///
     /// assert_eq!(bounded_interval.start(), SignedDuration::from_hours(1));
     /// ```
@@ -320,10 +336,8 @@ impl BoundedRelativeInterval {
     /// ```
     /// # use jiff::SignedDuration;
     /// # use periodical::intervals::relative::BoundedRelativeInterval;
-    /// let bounded_interval = BoundedRelativeInterval::new(
-    ///     SignedDuration::from_hours(1),
-    ///     SignedDuration::from_hours(5),
-    /// );
+    /// let bounded_interval =
+    ///     BoundedRelativeInterval::new(SignedDuration::from_hours(1), SignedDuration::from_hours(5));
     ///
     /// assert_eq!(bounded_interval.end(), SignedDuration::from_hours(5));
     /// ```
@@ -347,7 +361,10 @@ impl BoundedRelativeInterval {
     ///     BoundInclusivity::Exclusive,
     /// );
     ///
-    /// assert_eq!(bounded_interval.start_inclusivity(), BoundInclusivity::Inclusive);
+    /// assert_eq!(
+    ///     bounded_interval.start_inclusivity(),
+    ///     BoundInclusivity::Inclusive
+    /// );
     /// ```
     #[must_use]
     pub fn start_inclusivity(&self) -> BoundInclusivity {
@@ -369,7 +386,10 @@ impl BoundedRelativeInterval {
     ///     BoundInclusivity::Exclusive,
     /// );
     ///
-    /// assert_eq!(bounded_interval.end_inclusivity(), BoundInclusivity::Exclusive);
+    /// assert_eq!(
+    ///     bounded_interval.end_inclusivity(),
+    ///     BoundInclusivity::Exclusive
+    /// );
     /// ```
     #[must_use]
     pub fn end_inclusivity(&self) -> BoundInclusivity {
@@ -544,10 +564,8 @@ impl BoundedRelativeInterval {
     /// # use std::time::Duration;
     /// # use jiff::SignedDuration;
     /// # use periodical::intervals::relative::BoundedRelativeInterval;
-    /// let mut bounded_interval = BoundedRelativeInterval::new(
-    ///     SignedDuration::from_hours(2),
-    ///     SignedDuration::from_hours(5),
-    /// );
+    /// let mut bounded_interval =
+    ///     BoundedRelativeInterval::new(SignedDuration::from_hours(2), SignedDuration::from_hours(5));
     ///
     /// bounded_interval.set_length_from_start(Duration::from_hours(10))?;
     ///
@@ -594,10 +612,8 @@ impl BoundedRelativeInterval {
     /// # use std::time::Duration;
     /// # use jiff::SignedDuration;
     /// # use periodical::intervals::relative::BoundedRelativeInterval;
-    /// let mut bounded_interval = BoundedRelativeInterval::new(
-    ///     SignedDuration::from_hours(2),
-    ///     SignedDuration::from_hours(5),
-    /// );
+    /// let mut bounded_interval =
+    ///     BoundedRelativeInterval::new(SignedDuration::from_hours(2), SignedDuration::from_hours(5));
     ///
     /// bounded_interval.set_length_from_end(Duration::from_hours(10))?;
     ///
@@ -635,17 +651,21 @@ impl BoundedRelativeInterval {
     /// # use jiff::SignedDuration;
     /// # use periodical::intervals::relative::BoundedRelativeInterval;
     /// # use periodical::intervals::meta::BoundInclusivity;
-    /// let mut bounded_interval = BoundedRelativeInterval::new(
-    ///     SignedDuration::from_hours(5),
-    ///     SignedDuration::from_hours(5),
-    /// );
+    /// let mut bounded_interval =
+    ///     BoundedRelativeInterval::new(SignedDuration::from_hours(5), SignedDuration::from_hours(5));
     ///
     /// // Violates the same time doubly inclusive invariant
     /// bounded_interval.unchecked_set_start_inclusivity(BoundInclusivity::Exclusive);
     ///
     /// // Yet stays this way
-    /// assert_eq!(bounded_interval.start_inclusivity(), BoundInclusivity::Exclusive);
-    /// assert_eq!(bounded_interval.end_inclusivity(), BoundInclusivity::Inclusive);
+    /// assert_eq!(
+    ///     bounded_interval.start_inclusivity(),
+    ///     BoundInclusivity::Exclusive
+    /// );
+    /// assert_eq!(
+    ///     bounded_interval.end_inclusivity(),
+    ///     BoundInclusivity::Inclusive
+    /// );
     /// ```
     pub fn unchecked_set_start_inclusivity(&mut self, new_inclusivity: BoundInclusivity) {
         self.start_inclusivity = new_inclusivity;
@@ -660,17 +680,21 @@ impl BoundedRelativeInterval {
     /// # use jiff::SignedDuration;
     /// # use periodical::intervals::relative::BoundedRelativeInterval;
     /// # use periodical::intervals::meta::BoundInclusivity;
-    /// let mut bounded_interval = BoundedRelativeInterval::new(
-    ///     SignedDuration::from_hours(5),
-    ///     SignedDuration::from_hours(5),
-    /// );
+    /// let mut bounded_interval =
+    ///     BoundedRelativeInterval::new(SignedDuration::from_hours(5), SignedDuration::from_hours(5));
     ///
     /// // Violates the same time doubly inclusive invariant
     /// bounded_interval.unchecked_set_end_inclusivity(BoundInclusivity::Exclusive);
     ///
     /// // Yet stays this way
-    /// assert_eq!(bounded_interval.start_inclusivity(), BoundInclusivity::Inclusive);
-    /// assert_eq!(bounded_interval.end_inclusivity(), BoundInclusivity::Exclusive);
+    /// assert_eq!(
+    ///     bounded_interval.start_inclusivity(),
+    ///     BoundInclusivity::Inclusive
+    /// );
+    /// assert_eq!(
+    ///     bounded_interval.end_inclusivity(),
+    ///     BoundInclusivity::Exclusive
+    /// );
     /// ```
     pub fn unchecked_set_end_inclusivity(&mut self, new_inclusivity: BoundInclusivity) {
         self.end_inclusivity = new_inclusivity;
@@ -698,8 +722,14 @@ impl BoundedRelativeInterval {
     ///
     /// bounded_interval.set_start_inclusivity(BoundInclusivity::Exclusive);
     ///
-    /// assert_eq!(bounded_interval.start_inclusivity(), BoundInclusivity::Exclusive);
-    /// assert_eq!(bounded_interval.end_inclusivity(), BoundInclusivity::Inclusive);
+    /// assert_eq!(
+    ///     bounded_interval.start_inclusivity(),
+    ///     BoundInclusivity::Exclusive
+    /// );
+    /// assert_eq!(
+    ///     bounded_interval.end_inclusivity(),
+    ///     BoundInclusivity::Inclusive
+    /// );
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
     pub fn set_start_inclusivity(
@@ -736,8 +766,14 @@ impl BoundedRelativeInterval {
     ///
     /// bounded_interval.set_end_inclusivity(BoundInclusivity::Exclusive);
     ///
-    /// assert_eq!(bounded_interval.start_inclusivity(), BoundInclusivity::Inclusive);
-    /// assert_eq!(bounded_interval.end_inclusivity(), BoundInclusivity::Exclusive);
+    /// assert_eq!(
+    ///     bounded_interval.start_inclusivity(),
+    ///     BoundInclusivity::Inclusive
+    /// );
+    /// assert_eq!(
+    ///     bounded_interval.end_inclusivity(),
+    ///     BoundInclusivity::Exclusive
+    /// );
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
     pub fn set_end_inclusivity(

--- a/src/intervals/relative/end_bound.rs
+++ b/src/intervals/relative/end_bound.rs
@@ -55,9 +55,8 @@ impl RelativeEndBound {
     /// # use jiff::SignedDuration;
     /// # use periodical::intervals::relative::{RelativeEndBound, RelativeFiniteBound};
     /// let infinite_end_bound = RelativeEndBound::InfiniteFuture;
-    /// let finite_end_bound = RelativeEndBound::Finite(
-    ///     RelativeFiniteBound::new(SignedDuration::from_hours(1))
-    /// );
+    /// let finite_end_bound =
+    ///     RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1)));
     ///
     /// assert!(finite_end_bound.is_finite());
     /// assert!(!infinite_end_bound.is_finite());
@@ -76,9 +75,8 @@ impl RelativeEndBound {
     /// # use jiff::SignedDuration;
     /// # use periodical::intervals::relative::{RelativeEndBound, RelativeFiniteBound};
     /// let infinite_end_bound = RelativeEndBound::InfiniteFuture;
-    /// let finite_end_bound = RelativeEndBound::Finite(
-    ///     RelativeFiniteBound::new(SignedDuration::from_hours(1))
-    /// );
+    /// let finite_end_bound =
+    ///     RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1)));
     ///
     /// assert!(infinite_end_bound.is_infinite_future());
     /// assert!(!finite_end_bound.is_infinite_future());
@@ -100,9 +98,8 @@ impl RelativeEndBound {
     /// # use jiff::SignedDuration;
     /// # use periodical::intervals::relative::{RelativeEndBound, RelativeFiniteBound};
     /// let infinite_end_bound = RelativeEndBound::InfiniteFuture;
-    /// let finite_end_bound = RelativeEndBound::Finite(
-    ///     RelativeFiniteBound::new(SignedDuration::from_hours(1))
-    /// );
+    /// let finite_end_bound =
+    ///     RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1)));
     ///
     /// assert_eq!(
     ///     finite_end_bound.finite(),
@@ -148,12 +145,9 @@ impl RelativeEndBound {
     /// # }
     /// #
     /// # impl Error for FiniteBoundExpectedError {}
-    /// let end_first_shift = RelativeEndBound::Finite(
-    ///     RelativeFiniteBound::new(SignedDuration::from_hours(1))
-    /// );
-    /// let break_start = end_first_shift
-    ///     .opposite()
-    ///     .ok_or(FiniteBoundExpectedError)?;
+    /// let end_first_shift =
+    ///     RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1)));
+    /// let break_start = end_first_shift.opposite().ok_or(FiniteBoundExpectedError)?;
     ///
     /// assert_eq!(
     ///     break_start.finite(),

--- a/src/intervals/relative/finite_bound.rs
+++ b/src/intervals/relative/finite_bound.rs
@@ -186,8 +186,8 @@ impl Display for RelativeFiniteBoundFromBoundError {
             Self::IsUnbounded => {
                 write!(
                     f,
-                    "The given bound was of the `Unbounded` variant, \
-                    and therefore could not be converted to an `RelativeFiniteBound`"
+                    "The given bound was of the `Unbounded` variant, and therefore could not be converted to an \
+                     `RelativeFiniteBound`"
                 )
             },
         }

--- a/src/intervals/relative/half_bounded_interval.rs
+++ b/src/intervals/relative/half_bounded_interval.rs
@@ -68,14 +68,21 @@ impl HalfBoundedRelativeInterval {
     /// # use jiff::SignedDuration;
     /// # use periodical::intervals::meta::{BoundInclusivity, OpeningDirection};
     /// # use periodical::intervals::relative::HalfBoundedRelativeInterval;
-    /// let half_bounded_interval = HalfBoundedRelativeInterval::new(
-    ///     SignedDuration::from_hours(8),
-    ///     OpeningDirection::ToPast,
-    /// );
+    /// let half_bounded_interval =
+    ///     HalfBoundedRelativeInterval::new(SignedDuration::from_hours(8), OpeningDirection::ToPast);
     ///
-    /// assert_eq!(half_bounded_interval.reference(), SignedDuration::from_hours(8));
-    /// assert_eq!(half_bounded_interval.reference_inclusivity(), BoundInclusivity::Inclusive);
-    /// assert_eq!(half_bounded_interval.opening_direction(), OpeningDirection::ToPast);
+    /// assert_eq!(
+    ///     half_bounded_interval.reference(),
+    ///     SignedDuration::from_hours(8)
+    /// );
+    /// assert_eq!(
+    ///     half_bounded_interval.reference_inclusivity(),
+    ///     BoundInclusivity::Inclusive
+    /// );
+    /// assert_eq!(
+    ///     half_bounded_interval.opening_direction(),
+    ///     OpeningDirection::ToPast
+    /// );
     /// ```
     #[must_use]
     pub fn new(reference: SignedDuration, opening_direction: OpeningDirection) -> Self {
@@ -101,9 +108,18 @@ impl HalfBoundedRelativeInterval {
     ///     OpeningDirection::ToPast,
     /// );
     ///
-    /// assert_eq!(half_bounded_interval.reference(), SignedDuration::from_hours(8));
-    /// assert_eq!(half_bounded_interval.reference_inclusivity(), BoundInclusivity::Exclusive);
-    /// assert_eq!(half_bounded_interval.opening_direction(), OpeningDirection::ToPast);
+    /// assert_eq!(
+    ///     half_bounded_interval.reference(),
+    ///     SignedDuration::from_hours(8)
+    /// );
+    /// assert_eq!(
+    ///     half_bounded_interval.reference_inclusivity(),
+    ///     BoundInclusivity::Exclusive
+    /// );
+    /// assert_eq!(
+    ///     half_bounded_interval.opening_direction(),
+    ///     OpeningDirection::ToPast
+    /// );
     /// ```
     #[must_use]
     pub fn new_with_inclusivity(
@@ -126,12 +142,13 @@ impl HalfBoundedRelativeInterval {
     /// # use jiff::SignedDuration;
     /// # use periodical::intervals::meta::OpeningDirection;
     /// # use periodical::intervals::relative::HalfBoundedRelativeInterval;
-    /// let half_bounded_interval = HalfBoundedRelativeInterval::new(
-    ///     SignedDuration::from_hours(8),
-    ///     OpeningDirection::ToPast,
-    /// );
+    /// let half_bounded_interval =
+    ///     HalfBoundedRelativeInterval::new(SignedDuration::from_hours(8), OpeningDirection::ToPast);
     ///
-    /// assert_eq!(half_bounded_interval.reference(), SignedDuration::from_hours(8));
+    /// assert_eq!(
+    ///     half_bounded_interval.reference(),
+    ///     SignedDuration::from_hours(8)
+    /// );
     /// ```
     #[must_use]
     pub fn reference(&self) -> SignedDuration {
@@ -146,12 +163,13 @@ impl HalfBoundedRelativeInterval {
     /// # use jiff::SignedDuration;
     /// # use periodical::intervals::meta::OpeningDirection;
     /// # use periodical::intervals::relative::HalfBoundedRelativeInterval;
-    /// let half_bounded_interval = HalfBoundedRelativeInterval::new(
-    ///     SignedDuration::from_hours(8),
-    ///     OpeningDirection::ToPast,
-    /// );
+    /// let half_bounded_interval =
+    ///     HalfBoundedRelativeInterval::new(SignedDuration::from_hours(8), OpeningDirection::ToPast);
     ///
-    /// assert_eq!(half_bounded_interval.opening_direction(), OpeningDirection::ToPast);
+    /// assert_eq!(
+    ///     half_bounded_interval.opening_direction(),
+    ///     OpeningDirection::ToPast
+    /// );
     /// ```
     #[must_use]
     pub fn opening_direction(&self) -> OpeningDirection {
@@ -172,7 +190,10 @@ impl HalfBoundedRelativeInterval {
     ///     OpeningDirection::ToPast,
     /// );
     ///
-    /// assert_eq!(half_bounded_interval.reference_inclusivity(), BoundInclusivity::Exclusive);
+    /// assert_eq!(
+    ///     half_bounded_interval.reference_inclusivity(),
+    ///     BoundInclusivity::Exclusive
+    /// );
     /// ```
     #[must_use]
     pub fn reference_inclusivity(&self) -> BoundInclusivity {
@@ -187,14 +208,15 @@ impl HalfBoundedRelativeInterval {
     /// # use jiff::SignedDuration;
     /// # use periodical::intervals::meta::OpeningDirection;
     /// # use periodical::intervals::relative::HalfBoundedRelativeInterval;
-    /// let mut half_bounded_interval = HalfBoundedRelativeInterval::new(
-    ///     SignedDuration::from_hours(8),
-    ///     OpeningDirection::ToPast,
-    /// );
+    /// let mut half_bounded_interval =
+    ///     HalfBoundedRelativeInterval::new(SignedDuration::from_hours(8), OpeningDirection::ToPast);
     ///
     /// half_bounded_interval.set_reference(SignedDuration::from_hours(1));
     ///
-    /// assert_eq!(half_bounded_interval.reference(), SignedDuration::from_hours(1));
+    /// assert_eq!(
+    ///     half_bounded_interval.reference(),
+    ///     SignedDuration::from_hours(1)
+    /// );
     /// ```
     pub fn set_reference(&mut self, new_reference: SignedDuration) {
         self.reference = new_reference;
@@ -216,7 +238,10 @@ impl HalfBoundedRelativeInterval {
     ///
     /// half_bounded_interval.set_reference_inclusivity(BoundInclusivity::Inclusive);
     ///
-    /// assert_eq!(half_bounded_interval.reference_inclusivity(), BoundInclusivity::Inclusive);
+    /// assert_eq!(
+    ///     half_bounded_interval.reference_inclusivity(),
+    ///     BoundInclusivity::Inclusive
+    /// );
     /// ```
     pub fn set_reference_inclusivity(&mut self, new_inclusivity: BoundInclusivity) {
         self.reference_inclusivity = new_inclusivity;
@@ -230,14 +255,15 @@ impl HalfBoundedRelativeInterval {
     /// # use jiff::SignedDuration;
     /// # use periodical::intervals::meta::OpeningDirection;
     /// # use periodical::intervals::relative::HalfBoundedRelativeInterval;
-    /// let mut half_bounded_interval = HalfBoundedRelativeInterval::new(
-    ///     SignedDuration::from_hours(8),
-    ///     OpeningDirection::ToPast,
-    /// );
+    /// let mut half_bounded_interval =
+    ///     HalfBoundedRelativeInterval::new(SignedDuration::from_hours(8), OpeningDirection::ToPast);
     ///
     /// half_bounded_interval.set_opening_direction(OpeningDirection::ToFuture);
     ///
-    /// assert_eq!(half_bounded_interval.opening_direction(), OpeningDirection::ToFuture);
+    /// assert_eq!(
+    ///     half_bounded_interval.opening_direction(),
+    ///     OpeningDirection::ToFuture
+    /// );
     /// ```
     pub fn set_opening_direction(&mut self, new_opening_direction: OpeningDirection) {
         self.opening_direction = new_opening_direction;

--- a/src/intervals/relative/start_bound.rs
+++ b/src/intervals/relative/start_bound.rs
@@ -55,9 +55,8 @@ impl RelativeStartBound {
     /// # use jiff::SignedDuration;
     /// # use periodical::intervals::relative::{RelativeFiniteBound, RelativeStartBound};
     /// let infinite_start_bound = RelativeStartBound::InfinitePast;
-    /// let finite_start_bound = RelativeStartBound::Finite(
-    ///     RelativeFiniteBound::new(SignedDuration::from_hours(1))
-    /// );
+    /// let finite_start_bound =
+    ///     RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1)));
     ///
     /// assert!(finite_start_bound.is_finite());
     /// assert!(!infinite_start_bound.is_finite());
@@ -76,9 +75,8 @@ impl RelativeStartBound {
     /// # use jiff::SignedDuration;
     /// # use periodical::intervals::relative::{RelativeFiniteBound, RelativeStartBound};
     /// let infinite_start_bound = RelativeStartBound::InfinitePast;
-    /// let finite_start_bound = RelativeStartBound::Finite(
-    ///     RelativeFiniteBound::new(SignedDuration::from_hours(1))
-    /// );
+    /// let finite_start_bound =
+    ///     RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1)));
     ///
     /// assert!(infinite_start_bound.is_infinite_past());
     /// assert!(!finite_start_bound.is_infinite_past());
@@ -101,9 +99,8 @@ impl RelativeStartBound {
     /// # use jiff::SignedDuration;
     /// # use periodical::intervals::relative::{RelativeFiniteBound, RelativeStartBound};
     /// let infinite_start_bound = RelativeStartBound::InfinitePast;
-    /// let finite_start_bound = RelativeStartBound::Finite(
-    ///     RelativeFiniteBound::new(SignedDuration::from_hours(1))
-    /// );
+    /// let finite_start_bound =
+    ///     RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1)));
     ///
     /// assert_eq!(
     ///     finite_start_bound.finite(),
@@ -148,9 +145,8 @@ impl RelativeStartBound {
     /// # }
     /// #
     /// # impl Error for FiniteBoundExpectedError {}
-    /// let start_second_part_my_shift = RelativeStartBound::Finite(
-    ///     RelativeFiniteBound::new(SignedDuration::from_hours(3))
-    /// );
+    /// let start_second_part_my_shift =
+    ///     RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(3)));
     /// let break_end_before_shift = start_second_part_my_shift
     ///     .opposite()
     ///     .ok_or(FiniteBoundExpectedError)?;

--- a/src/iter/intervals/bounds.rs
+++ b/src/iter/intervals/bounds.rs
@@ -16,19 +16,31 @@
 //! let intervals = [
 //!     AbsoluteBoundPair::new(
 //!         AbsoluteFiniteBound::new(
-//!             "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!         ).to_start_bound(),
+//!             "2025-01-01 08:00:00[Europe/Oslo]"
+//!                 .parse::<Zoned>()?
+//!                 .timestamp(),
+//!         )
+//!         .to_start_bound(),
 //!         AbsoluteFiniteBound::new(
-//!             "2025-01-01 11:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!         ).to_end_bound(),
+//!             "2025-01-01 11:00:00[Europe/Oslo]"
+//!                 .parse::<Zoned>()?
+//!                 .timestamp(),
+//!         )
+//!         .to_end_bound(),
 //!     ),
 //!     AbsoluteBoundPair::new(
 //!         AbsoluteFiniteBound::new(
-//!             "2025-01-01 12:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!         ).to_start_bound(),
+//!             "2025-01-01 12:00:00[Europe/Oslo]"
+//!                 .parse::<Zoned>()?
+//!                 .timestamp(),
+//!         )
+//!         .to_start_bound(),
 //!         AbsoluteFiniteBound::new(
-//!             "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!         ).to_end_bound(),
+//!             "2025-01-01 16:00:00[Europe/Oslo]"
+//!                 .parse::<Zoned>()?
+//!                 .timestamp(),
+//!         )
+//!         .to_end_bound(),
 //!     ),
 //! ];
 //!
@@ -36,17 +48,33 @@
 //!     intervals.abs_bounds_iter().collect::<Vec<_>>(),
 //!     vec![
 //!         AbsoluteFiniteBound::new(
-//!             "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!         ).to_start_bound().to_bound(),
+//!             "2025-01-01 08:00:00[Europe/Oslo]"
+//!                 .parse::<Zoned>()?
+//!                 .timestamp(),
+//!         )
+//!         .to_start_bound()
+//!         .to_bound(),
 //!         AbsoluteFiniteBound::new(
-//!             "2025-01-01 11:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!         ).to_end_bound().to_bound(),
+//!             "2025-01-01 11:00:00[Europe/Oslo]"
+//!                 .parse::<Zoned>()?
+//!                 .timestamp(),
+//!         )
+//!         .to_end_bound()
+//!         .to_bound(),
 //!         AbsoluteFiniteBound::new(
-//!             "2025-01-01 12:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!         ).to_start_bound().to_bound(),
+//!             "2025-01-01 12:00:00[Europe/Oslo]"
+//!                 .parse::<Zoned>()?
+//!                 .timestamp(),
+//!         )
+//!         .to_start_bound()
+//!         .to_bound(),
 //!         AbsoluteFiniteBound::new(
-//!             "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!         ).to_end_bound().to_bound(),
+//!             "2025-01-01 16:00:00[Europe/Oslo]"
+//!                 .parse::<Zoned>()?
+//!                 .timestamp(),
+//!         )
+//!         .to_end_bound()
+//!         .to_bound(),
 //!     ],
 //! );
 //! # Ok::<(), Box<dyn Error>>(())
@@ -103,31 +131,54 @@ impl AbsoluteBoundsIter {
     /// let intervals = [
     ///     AbsoluteBoundPair::new(
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_start_bound(),
+    ///             "2025-01-01 08:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_start_bound(),
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 14:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_end_bound(),
+    ///             "2025-01-01 14:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_end_bound(),
     ///     ),
     ///     AbsoluteBoundPair::new(
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 12:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_start_bound(),
+    ///             "2025-01-01 12:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_start_bound(),
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_end_bound(),
+    ///             "2025-01-01 16:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_end_bound(),
     ///     ),
     /// ];
     ///
     /// assert_eq!(
-    ///     intervals.abs_bounds_iter().unite_bounds().collect::<Vec<_>>(),
+    ///     intervals
+    ///         .abs_bounds_iter()
+    ///         .unite_bounds()
+    ///         .collect::<Vec<_>>(),
     ///     vec![
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_start_bound().to_bound(),
+    ///             "2025-01-01 08:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_start_bound()
+    ///         .to_bound(),
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_end_bound().to_bound(),
+    ///             "2025-01-01 16:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_end_bound()
+    ///         .to_bound(),
     ///     ],
     /// );
     /// # Ok::<(), Box<dyn Error>>(())
@@ -170,38 +221,62 @@ impl AbsoluteBoundsIter {
     /// let first_layer_intervals = [
     ///     AbsoluteBoundPair::new(
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_start_bound(),
+    ///             "2025-01-01 08:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_start_bound(),
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 12:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_end_bound(),
+    ///             "2025-01-01 12:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_end_bound(),
     ///     ),
     ///     AbsoluteBoundPair::new(
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 13:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_start_bound(),
+    ///             "2025-01-01 13:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_start_bound(),
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_end_bound(),
+    ///             "2025-01-01 16:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_end_bound(),
     ///     ),
     /// ];
     ///
     /// let second_layer_intervals = [
     ///     AbsoluteBoundPair::new(
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 07:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_start_bound(),
+    ///             "2025-01-01 07:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_start_bound(),
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 11:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_end_bound(),
+    ///             "2025-01-01 11:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_end_bound(),
     ///     ),
     ///     AbsoluteBoundPair::new(
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 14:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_start_bound(),
+    ///             "2025-01-01 14:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_start_bound(),
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 18:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_end_bound(),
+    ///             "2025-01-01 18:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_end_bound(),
     ///     ),
     /// ];
     ///
@@ -316,32 +391,27 @@ impl RelativeBoundsIter {
     /// # use periodical::iter::intervals::bounds::RelativeBoundsIteratorDispatcher;
     /// let intervals = [
     ///     RelativeBoundPair::new(
-    ///         RelativeFiniteBound::new(
-    ///             SignedDuration::from_hours(8),
-    ///         ).to_start_bound(),
-    ///         RelativeFiniteBound::new(
-    ///             SignedDuration::from_hours(14),
-    ///         ).to_end_bound(),
+    ///         RelativeFiniteBound::new(SignedDuration::from_hours(8)).to_start_bound(),
+    ///         RelativeFiniteBound::new(SignedDuration::from_hours(14)).to_end_bound(),
     ///     ),
     ///     RelativeBoundPair::new(
-    ///         RelativeFiniteBound::new(
-    ///             SignedDuration::from_hours(12),
-    ///         ).to_start_bound(),
-    ///         RelativeFiniteBound::new(
-    ///             SignedDuration::from_hours(16),
-    ///         ).to_end_bound(),
+    ///         RelativeFiniteBound::new(SignedDuration::from_hours(12)).to_start_bound(),
+    ///         RelativeFiniteBound::new(SignedDuration::from_hours(16)).to_end_bound(),
     ///     ),
     /// ];
     ///
     /// assert_eq!(
-    ///     intervals.rel_bounds_iter().unite_bounds().collect::<Vec<_>>(),
+    ///     intervals
+    ///         .rel_bounds_iter()
+    ///         .unite_bounds()
+    ///         .collect::<Vec<_>>(),
     ///     vec![
-    ///         RelativeFiniteBound::new(
-    ///             SignedDuration::from_hours(8),
-    ///         ).to_start_bound().to_bound(),
-    ///         RelativeFiniteBound::new(
-    ///             SignedDuration::from_hours(16),
-    ///         ).to_end_bound().to_bound(),
+    ///         RelativeFiniteBound::new(SignedDuration::from_hours(8),)
+    ///             .to_start_bound()
+    ///             .to_bound(),
+    ///         RelativeFiniteBound::new(SignedDuration::from_hours(16),)
+    ///             .to_end_bound()
+    ///             .to_bound(),
     ///     ],
     /// );
     /// ```
@@ -381,39 +451,23 @@ impl RelativeBoundsIter {
     /// # use periodical::iter::intervals::bounds::RelativeBoundsIteratorDispatcher;
     /// let first_layer_intervals = [
     ///     RelativeBoundPair::new(
-    ///         RelativeFiniteBound::new(
-    ///             SignedDuration::from_hours(8),
-    ///         ).to_start_bound(),
-    ///         RelativeFiniteBound::new(
-    ///             SignedDuration::from_hours(12),
-    ///         ).to_end_bound(),
+    ///         RelativeFiniteBound::new(SignedDuration::from_hours(8)).to_start_bound(),
+    ///         RelativeFiniteBound::new(SignedDuration::from_hours(12)).to_end_bound(),
     ///     ),
     ///     RelativeBoundPair::new(
-    ///         RelativeFiniteBound::new(
-    ///             SignedDuration::from_hours(13),
-    ///         ).to_start_bound(),
-    ///         RelativeFiniteBound::new(
-    ///             SignedDuration::from_hours(16),
-    ///         ).to_end_bound(),
+    ///         RelativeFiniteBound::new(SignedDuration::from_hours(13)).to_start_bound(),
+    ///         RelativeFiniteBound::new(SignedDuration::from_hours(16)).to_end_bound(),
     ///     ),
     /// ];
     ///
     /// let second_layer_intervals = [
     ///     RelativeBoundPair::new(
-    ///         RelativeFiniteBound::new(
-    ///             SignedDuration::from_hours(7),
-    ///         ).to_start_bound(),
-    ///         RelativeFiniteBound::new(
-    ///             SignedDuration::from_hours(11),
-    ///         ).to_end_bound(),
+    ///         RelativeFiniteBound::new(SignedDuration::from_hours(7)).to_start_bound(),
+    ///         RelativeFiniteBound::new(SignedDuration::from_hours(11)).to_end_bound(),
     ///     ),
     ///     RelativeBoundPair::new(
-    ///         RelativeFiniteBound::new(
-    ///             SignedDuration::from_hours(14),
-    ///         ).to_start_bound(),
-    ///         RelativeFiniteBound::new(
-    ///             SignedDuration::from_hours(18),
-    ///         ).to_end_bound(),
+    ///         RelativeFiniteBound::new(SignedDuration::from_hours(14)).to_start_bound(),
+    ///         RelativeFiniteBound::new(SignedDuration::from_hours(18)).to_end_bound(),
     ///     ),
     /// ];
     ///

--- a/src/iter/intervals/complement.rs
+++ b/src/iter/intervals/complement.rs
@@ -20,19 +20,31 @@
 //! let intervals = [
 //!     AbsoluteBoundPair::new(
 //!         AbsoluteFiniteBound::new(
-//!             "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!         ).to_start_bound(),
+//!             "2025-01-01 08:00:00[Europe/Oslo]"
+//!                 .parse::<Zoned>()?
+//!                 .timestamp(),
+//!         )
+//!         .to_start_bound(),
 //!         AbsoluteFiniteBound::new(
-//!             "2025-01-01 11:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!         ).to_end_bound(),
+//!             "2025-01-01 11:00:00[Europe/Oslo]"
+//!                 .parse::<Zoned>()?
+//!                 .timestamp(),
+//!         )
+//!         .to_end_bound(),
 //!     ),
 //!     AbsoluteBoundPair::new(
 //!         AbsoluteFiniteBound::new(
-//!             "2025-01-01 12:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!         ).to_start_bound(),
+//!             "2025-01-01 12:00:00[Europe/Oslo]"
+//!                 .parse::<Zoned>()?
+//!                 .timestamp(),
+//!         )
+//!         .to_start_bound(),
 //!         AbsoluteFiniteBound::new(
-//!             "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!         ).to_end_bound(),
+//!             "2025-01-01 16:00:00[Europe/Oslo]"
+//!                 .parse::<Zoned>()?
+//!                 .timestamp(),
+//!         )
+//!         .to_end_bound(),
 //!     ),
 //! ];
 //!
@@ -43,33 +55,49 @@
 //!             AbsoluteBoundPair::new(
 //!                 AbsoluteStartBound::InfinitePast,
 //!                 AbsoluteFiniteBound::new_with_inclusivity(
-//!                     "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+//!                     "2025-01-01 08:00:00[Europe/Oslo]"
+//!                         .parse::<Zoned>()?
+//!                         .timestamp(),
 //!                     BoundInclusivity::Exclusive,
-//!                 ).to_end_bound(),
-//!             ).to_emptiable(),
+//!                 )
+//!                 .to_end_bound(),
+//!             )
+//!             .to_emptiable(),
 //!             AbsoluteBoundPair::new(
 //!                 AbsoluteFiniteBound::new_with_inclusivity(
-//!                     "2025-01-01 11:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+//!                     "2025-01-01 11:00:00[Europe/Oslo]"
+//!                         .parse::<Zoned>()?
+//!                         .timestamp(),
 //!                     BoundInclusivity::Exclusive,
-//!                 ).to_start_bound(),
+//!                 )
+//!                 .to_start_bound(),
 //!                 AbsoluteEndBound::InfiniteFuture,
-//!             ).to_emptiable(),
+//!             )
+//!             .to_emptiable(),
 //!         ),
 //!         ComplementResult::Split(
 //!             AbsoluteBoundPair::new(
 //!                 AbsoluteStartBound::InfinitePast,
 //!                 AbsoluteFiniteBound::new_with_inclusivity(
-//!                     "2025-01-01 12:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+//!                     "2025-01-01 12:00:00[Europe/Oslo]"
+//!                         .parse::<Zoned>()?
+//!                         .timestamp(),
 //!                     BoundInclusivity::Exclusive,
-//!                 ).to_end_bound(),
-//!             ).to_emptiable(),
+//!                 )
+//!                 .to_end_bound(),
+//!             )
+//!             .to_emptiable(),
 //!             AbsoluteBoundPair::new(
 //!                 AbsoluteFiniteBound::new_with_inclusivity(
-//!                     "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+//!                     "2025-01-01 16:00:00[Europe/Oslo]"
+//!                         .parse::<Zoned>()?
+//!                         .timestamp(),
 //!                     BoundInclusivity::Exclusive,
-//!                 ).to_start_bound(),
+//!                 )
+//!                 .to_start_bound(),
 //!                 AbsoluteEndBound::InfiniteFuture,
-//!             ).to_emptiable(),
+//!             )
+//!             .to_emptiable(),
 //!         ),
 //!     ],
 //! );

--- a/src/iter/intervals/layered_bounds.rs
+++ b/src/iter/intervals/layered_bounds.rs
@@ -24,38 +24,62 @@
 //! let first_layer_intervals = [
 //!     AbsoluteBoundPair::new(
 //!         AbsoluteFiniteBound::new(
-//!             "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!         ).to_start_bound(),
+//!             "2025-01-01 08:00:00[Europe/Oslo]"
+//!                 .parse::<Zoned>()?
+//!                 .timestamp(),
+//!         )
+//!         .to_start_bound(),
 //!         AbsoluteFiniteBound::new(
-//!             "2025-01-01 12:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!         ).to_end_bound(),
+//!             "2025-01-01 12:00:00[Europe/Oslo]"
+//!                 .parse::<Zoned>()?
+//!                 .timestamp(),
+//!         )
+//!         .to_end_bound(),
 //!     ),
 //!     AbsoluteBoundPair::new(
 //!         AbsoluteFiniteBound::new(
-//!             "2025-01-01 13:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!         ).to_start_bound(),
+//!             "2025-01-01 13:00:00[Europe/Oslo]"
+//!                 .parse::<Zoned>()?
+//!                 .timestamp(),
+//!         )
+//!         .to_start_bound(),
 //!         AbsoluteFiniteBound::new(
-//!             "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!         ).to_end_bound(),
+//!             "2025-01-01 16:00:00[Europe/Oslo]"
+//!                 .parse::<Zoned>()?
+//!                 .timestamp(),
+//!         )
+//!         .to_end_bound(),
 //!     ),
 //! ];
 //!
 //! let second_layer_intervals = [
 //!     AbsoluteBoundPair::new(
 //!         AbsoluteFiniteBound::new(
-//!             "2025-01-01 07:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!         ).to_start_bound(),
+//!             "2025-01-01 07:00:00[Europe/Oslo]"
+//!                 .parse::<Zoned>()?
+//!                 .timestamp(),
+//!         )
+//!         .to_start_bound(),
 //!         AbsoluteFiniteBound::new(
-//!             "2025-01-01 11:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!         ).to_end_bound(),
+//!             "2025-01-01 11:00:00[Europe/Oslo]"
+//!                 .parse::<Zoned>()?
+//!                 .timestamp(),
+//!         )
+//!         .to_end_bound(),
 //!     ),
 //!     AbsoluteBoundPair::new(
 //!         AbsoluteFiniteBound::new(
-//!             "2025-01-01 14:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!         ).to_start_bound(),
+//!             "2025-01-01 14:00:00[Europe/Oslo]"
+//!                 .parse::<Zoned>()?
+//!                 .timestamp(),
+//!         )
+//!         .to_start_bound(),
 //!         AbsoluteFiniteBound::new(
-//!             "2025-01-01 18:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!         ).to_end_bound(),
+//!             "2025-01-01 18:00:00[Europe/Oslo]"
+//!                 .parse::<Zoned>()?
+//!                 .timestamp(),
+//!         )
+//!         .to_end_bound(),
 //!     ),
 //! ];
 //!
@@ -69,90 +93,170 @@
 //!         LayeredBoundsStateChangeAtAbsoluteBound::new(
 //!             LayeredBoundsState::NoLayers,
 //!             LayeredBoundsState::SecondLayer,
-//!             Some(AbsoluteFiniteBound::new_with_inclusivity(
-//!                 "2025-01-01 07:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!                 BoundInclusivity::Exclusive,
-//!             ).to_end_bound()),
-//!             Some(AbsoluteFiniteBound::new(
-//!                 "2025-01-01 07:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!             ).to_start_bound()),
+//!             Some(
+//!                 AbsoluteFiniteBound::new_with_inclusivity(
+//!                     "2025-01-01 07:00:00[Europe/Oslo]"
+//!                         .parse::<Zoned>()?
+//!                         .timestamp(),
+//!                     BoundInclusivity::Exclusive,
+//!                 )
+//!                 .to_end_bound()
+//!             ),
+//!             Some(
+//!                 AbsoluteFiniteBound::new(
+//!                     "2025-01-01 07:00:00[Europe/Oslo]"
+//!                         .parse::<Zoned>()?
+//!                         .timestamp(),
+//!                 )
+//!                 .to_start_bound()
+//!             ),
 //!         ),
 //!         LayeredBoundsStateChangeAtAbsoluteBound::new(
 //!             LayeredBoundsState::SecondLayer,
 //!             LayeredBoundsState::BothLayers,
-//!             Some(AbsoluteFiniteBound::new_with_inclusivity(
-//!                 "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!                 BoundInclusivity::Exclusive,
-//!             ).to_end_bound()),
-//!             Some(AbsoluteFiniteBound::new(
-//!                 "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!             ).to_start_bound()),
+//!             Some(
+//!                 AbsoluteFiniteBound::new_with_inclusivity(
+//!                     "2025-01-01 08:00:00[Europe/Oslo]"
+//!                         .parse::<Zoned>()?
+//!                         .timestamp(),
+//!                     BoundInclusivity::Exclusive,
+//!                 )
+//!                 .to_end_bound()
+//!             ),
+//!             Some(
+//!                 AbsoluteFiniteBound::new(
+//!                     "2025-01-01 08:00:00[Europe/Oslo]"
+//!                         .parse::<Zoned>()?
+//!                         .timestamp(),
+//!                 )
+//!                 .to_start_bound()
+//!             ),
 //!         ),
 //!         LayeredBoundsStateChangeAtAbsoluteBound::new(
 //!             LayeredBoundsState::BothLayers,
 //!             LayeredBoundsState::FirstLayer,
-//!             Some(AbsoluteFiniteBound::new(
-//!                 "2025-01-01 11:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!             ).to_end_bound()),
-//!             Some(AbsoluteFiniteBound::new_with_inclusivity(
-//!                 "2025-01-01 11:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!                 BoundInclusivity::Exclusive,
-//!             ).to_start_bound()),
+//!             Some(
+//!                 AbsoluteFiniteBound::new(
+//!                     "2025-01-01 11:00:00[Europe/Oslo]"
+//!                         .parse::<Zoned>()?
+//!                         .timestamp(),
+//!                 )
+//!                 .to_end_bound()
+//!             ),
+//!             Some(
+//!                 AbsoluteFiniteBound::new_with_inclusivity(
+//!                     "2025-01-01 11:00:00[Europe/Oslo]"
+//!                         .parse::<Zoned>()?
+//!                         .timestamp(),
+//!                     BoundInclusivity::Exclusive,
+//!                 )
+//!                 .to_start_bound()
+//!             ),
 //!         ),
 //!         LayeredBoundsStateChangeAtAbsoluteBound::new(
 //!             LayeredBoundsState::FirstLayer,
 //!             LayeredBoundsState::NoLayers,
-//!             Some(AbsoluteFiniteBound::new(
-//!                 "2025-01-01 12:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!             ).to_end_bound()),
-//!             Some(AbsoluteFiniteBound::new_with_inclusivity(
-//!                 "2025-01-01 12:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!                 BoundInclusivity::Exclusive,
-//!             ).to_start_bound()),
+//!             Some(
+//!                 AbsoluteFiniteBound::new(
+//!                     "2025-01-01 12:00:00[Europe/Oslo]"
+//!                         .parse::<Zoned>()?
+//!                         .timestamp(),
+//!                 )
+//!                 .to_end_bound()
+//!             ),
+//!             Some(
+//!                 AbsoluteFiniteBound::new_with_inclusivity(
+//!                     "2025-01-01 12:00:00[Europe/Oslo]"
+//!                         .parse::<Zoned>()?
+//!                         .timestamp(),
+//!                     BoundInclusivity::Exclusive,
+//!                 )
+//!                 .to_start_bound()
+//!             ),
 //!         ),
 //!         LayeredBoundsStateChangeAtAbsoluteBound::new(
 //!             LayeredBoundsState::NoLayers,
 //!             LayeredBoundsState::FirstLayer,
-//!             Some(AbsoluteFiniteBound::new_with_inclusivity(
-//!                 "2025-01-01 13:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!                 BoundInclusivity::Exclusive,
-//!             ).to_end_bound()),
-//!             Some(AbsoluteFiniteBound::new(
-//!                 "2025-01-01 13:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!             ).to_start_bound()),
+//!             Some(
+//!                 AbsoluteFiniteBound::new_with_inclusivity(
+//!                     "2025-01-01 13:00:00[Europe/Oslo]"
+//!                         .parse::<Zoned>()?
+//!                         .timestamp(),
+//!                     BoundInclusivity::Exclusive,
+//!                 )
+//!                 .to_end_bound()
+//!             ),
+//!             Some(
+//!                 AbsoluteFiniteBound::new(
+//!                     "2025-01-01 13:00:00[Europe/Oslo]"
+//!                         .parse::<Zoned>()?
+//!                         .timestamp(),
+//!                 )
+//!                 .to_start_bound()
+//!             ),
 //!         ),
 //!         LayeredBoundsStateChangeAtAbsoluteBound::new(
 //!             LayeredBoundsState::FirstLayer,
 //!             LayeredBoundsState::BothLayers,
-//!             Some(AbsoluteFiniteBound::new_with_inclusivity(
-//!                 "2025-01-01 14:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!                 BoundInclusivity::Exclusive,
-//!             ).to_end_bound()),
-//!             Some(AbsoluteFiniteBound::new(
-//!                 "2025-01-01 14:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!             ).to_start_bound()),
+//!             Some(
+//!                 AbsoluteFiniteBound::new_with_inclusivity(
+//!                     "2025-01-01 14:00:00[Europe/Oslo]"
+//!                         .parse::<Zoned>()?
+//!                         .timestamp(),
+//!                     BoundInclusivity::Exclusive,
+//!                 )
+//!                 .to_end_bound()
+//!             ),
+//!             Some(
+//!                 AbsoluteFiniteBound::new(
+//!                     "2025-01-01 14:00:00[Europe/Oslo]"
+//!                         .parse::<Zoned>()?
+//!                         .timestamp(),
+//!                 )
+//!                 .to_start_bound()
+//!             ),
 //!         ),
 //!         LayeredBoundsStateChangeAtAbsoluteBound::new(
 //!             LayeredBoundsState::BothLayers,
 //!             LayeredBoundsState::SecondLayer,
-//!             Some(AbsoluteFiniteBound::new(
-//!                 "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!             ).to_end_bound()),
-//!             Some(AbsoluteFiniteBound::new_with_inclusivity(
-//!                 "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!                 BoundInclusivity::Exclusive,
-//!             ).to_start_bound()),
+//!             Some(
+//!                 AbsoluteFiniteBound::new(
+//!                     "2025-01-01 16:00:00[Europe/Oslo]"
+//!                         .parse::<Zoned>()?
+//!                         .timestamp(),
+//!                 )
+//!                 .to_end_bound()
+//!             ),
+//!             Some(
+//!                 AbsoluteFiniteBound::new_with_inclusivity(
+//!                     "2025-01-01 16:00:00[Europe/Oslo]"
+//!                         .parse::<Zoned>()?
+//!                         .timestamp(),
+//!                     BoundInclusivity::Exclusive,
+//!                 )
+//!                 .to_start_bound()
+//!             ),
 //!         ),
 //!         LayeredBoundsStateChangeAtAbsoluteBound::new(
 //!             LayeredBoundsState::SecondLayer,
 //!             LayeredBoundsState::NoLayers,
-//!             Some(AbsoluteFiniteBound::new(
-//!                 "2025-01-01 18:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!             ).to_end_bound()),
-//!             Some(AbsoluteFiniteBound::new_with_inclusivity(
-//!                 "2025-01-01 18:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!                 BoundInclusivity::Exclusive,
-//!             ).to_start_bound()),
+//!             Some(
+//!                 AbsoluteFiniteBound::new(
+//!                     "2025-01-01 18:00:00[Europe/Oslo]"
+//!                         .parse::<Zoned>()?
+//!                         .timestamp(),
+//!                 )
+//!                 .to_end_bound()
+//!             ),
+//!             Some(
+//!                 AbsoluteFiniteBound::new_with_inclusivity(
+//!                     "2025-01-01 18:00:00[Europe/Oslo]"
+//!                         .parse::<Zoned>()?
+//!                         .timestamp(),
+//!                     BoundInclusivity::Exclusive,
+//!                 )
+//!                 .to_start_bound()
+//!             ),
 //!         ),
 //!     ],
 //! );
@@ -309,13 +413,23 @@ impl LayeredBoundsStateChangeAtAbsoluteBound {
     /// let change = LayeredBoundsStateChangeAtAbsoluteBound::new(
     ///     LayeredBoundsState::NoLayers,
     ///     LayeredBoundsState::FirstLayer,
-    ///     Some(AbsoluteFiniteBound::new(
-    ///         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_end_bound()),
-    ///     Some(AbsoluteFiniteBound::new_with_inclusivity(
-    ///         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         BoundInclusivity::Exclusive,
-    ///     ).to_start_bound()),
+    ///     Some(
+    ///         AbsoluteFiniteBound::new(
+    ///             "2025-01-01 08:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_end_bound(),
+    ///     ),
+    ///     Some(
+    ///         AbsoluteFiniteBound::new_with_inclusivity(
+    ///             "2025-01-01 08:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///             BoundInclusivity::Exclusive,
+    ///         )
+    ///         .to_start_bound(),
+    ///     ),
     /// );
     ///
     /// assert_eq!(change.old_state(), LayeredBoundsState::NoLayers);
@@ -341,13 +455,23 @@ impl LayeredBoundsStateChangeAtAbsoluteBound {
     /// let change = LayeredBoundsStateChangeAtAbsoluteBound::new(
     ///     LayeredBoundsState::NoLayers,
     ///     LayeredBoundsState::FirstLayer,
-    ///     Some(AbsoluteFiniteBound::new(
-    ///         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_end_bound()),
-    ///     Some(AbsoluteFiniteBound::new_with_inclusivity(
-    ///         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         BoundInclusivity::Exclusive,
-    ///     ).to_start_bound()),
+    ///     Some(
+    ///         AbsoluteFiniteBound::new(
+    ///             "2025-01-01 08:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_end_bound(),
+    ///     ),
+    ///     Some(
+    ///         AbsoluteFiniteBound::new_with_inclusivity(
+    ///             "2025-01-01 08:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///             BoundInclusivity::Exclusive,
+    ///         )
+    ///         .to_start_bound(),
+    ///     ),
     /// );
     ///
     /// assert_eq!(change.new_state(), LayeredBoundsState::FirstLayer);
@@ -380,20 +504,35 @@ impl LayeredBoundsStateChangeAtAbsoluteBound {
     /// let change = LayeredBoundsStateChangeAtAbsoluteBound::new(
     ///     LayeredBoundsState::NoLayers,
     ///     LayeredBoundsState::FirstLayer,
-    ///     Some(AbsoluteFiniteBound::new(
-    ///         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_end_bound()),
-    ///     Some(AbsoluteFiniteBound::new_with_inclusivity(
-    ///         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         BoundInclusivity::Exclusive,
-    ///     ).to_start_bound()),
+    ///     Some(
+    ///         AbsoluteFiniteBound::new(
+    ///             "2025-01-01 08:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_end_bound(),
+    ///     ),
+    ///     Some(
+    ///         AbsoluteFiniteBound::new_with_inclusivity(
+    ///             "2025-01-01 08:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///             BoundInclusivity::Exclusive,
+    ///         )
+    ///         .to_start_bound(),
+    ///     ),
     /// );
     ///
     /// assert_eq!(
     ///     change.old_state_end(),
-    ///     Some(AbsoluteFiniteBound::new(
-    ///         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_end_bound()),
+    ///     Some(
+    ///         AbsoluteFiniteBound::new(
+    ///             "2025-01-01 08:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_end_bound()
+    ///     ),
     /// );
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
@@ -424,21 +563,36 @@ impl LayeredBoundsStateChangeAtAbsoluteBound {
     /// let change = LayeredBoundsStateChangeAtAbsoluteBound::new(
     ///     LayeredBoundsState::NoLayers,
     ///     LayeredBoundsState::FirstLayer,
-    ///     Some(AbsoluteFiniteBound::new(
-    ///         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///     ).to_end_bound()),
-    ///     Some(AbsoluteFiniteBound::new_with_inclusivity(
-    ///         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         BoundInclusivity::Exclusive,
-    ///     ).to_start_bound()),
+    ///     Some(
+    ///         AbsoluteFiniteBound::new(
+    ///             "2025-01-01 08:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_end_bound(),
+    ///     ),
+    ///     Some(
+    ///         AbsoluteFiniteBound::new_with_inclusivity(
+    ///             "2025-01-01 08:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///             BoundInclusivity::Exclusive,
+    ///         )
+    ///         .to_start_bound(),
+    ///     ),
     /// );
     ///
     /// assert_eq!(
     ///     change.new_state_start(),
-    ///     Some(AbsoluteFiniteBound::new_with_inclusivity(
-    ///         "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         BoundInclusivity::Exclusive,
-    ///     ).to_start_bound()),
+    ///     Some(
+    ///         AbsoluteFiniteBound::new_with_inclusivity(
+    ///             "2025-01-01 08:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///             BoundInclusivity::Exclusive,
+    ///         )
+    ///         .to_start_bound()
+    ///     ),
     /// );
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
@@ -500,13 +654,14 @@ impl LayeredBoundsStateChangeAtRelativeBound {
     /// let change = LayeredBoundsStateChangeAtRelativeBound::new(
     ///     LayeredBoundsState::NoLayers,
     ///     LayeredBoundsState::FirstLayer,
-    ///     Some(RelativeFiniteBound::new(
-    ///         SignedDuration::from_hours(8),
-    ///     ).to_end_bound()),
-    ///     Some(RelativeFiniteBound::new_with_inclusivity(
-    ///         SignedDuration::from_hours(8),
-    ///         BoundInclusivity::Exclusive,
-    ///     ).to_start_bound()),
+    ///     Some(RelativeFiniteBound::new(SignedDuration::from_hours(8)).to_end_bound()),
+    ///     Some(
+    ///         RelativeFiniteBound::new_with_inclusivity(
+    ///             SignedDuration::from_hours(8),
+    ///             BoundInclusivity::Exclusive,
+    ///         )
+    ///         .to_start_bound(),
+    ///     ),
     /// );
     ///
     /// assert_eq!(change.old_state(), LayeredBoundsState::NoLayers);
@@ -530,13 +685,14 @@ impl LayeredBoundsStateChangeAtRelativeBound {
     /// let change = LayeredBoundsStateChangeAtRelativeBound::new(
     ///     LayeredBoundsState::NoLayers,
     ///     LayeredBoundsState::FirstLayer,
-    ///     Some(RelativeFiniteBound::new(
-    ///         SignedDuration::from_hours(8),
-    ///     ).to_end_bound()),
-    ///     Some(RelativeFiniteBound::new_with_inclusivity(
-    ///         SignedDuration::from_hours(8),
-    ///         BoundInclusivity::Exclusive,
-    ///     ).to_start_bound()),
+    ///     Some(RelativeFiniteBound::new(SignedDuration::from_hours(8)).to_end_bound()),
+    ///     Some(
+    ///         RelativeFiniteBound::new_with_inclusivity(
+    ///             SignedDuration::from_hours(8),
+    ///             BoundInclusivity::Exclusive,
+    ///         )
+    ///         .to_start_bound(),
+    ///     ),
     /// );
     ///
     /// assert_eq!(change.new_state(), LayeredBoundsState::FirstLayer);
@@ -567,20 +723,19 @@ impl LayeredBoundsStateChangeAtRelativeBound {
     /// let change = LayeredBoundsStateChangeAtRelativeBound::new(
     ///     LayeredBoundsState::NoLayers,
     ///     LayeredBoundsState::FirstLayer,
-    ///     Some(RelativeFiniteBound::new(
-    ///         SignedDuration::from_hours(8),
-    ///     ).to_end_bound()),
-    ///     Some(RelativeFiniteBound::new_with_inclusivity(
-    ///         SignedDuration::from_hours(8),
-    ///         BoundInclusivity::Exclusive,
-    ///     ).to_start_bound()),
+    ///     Some(RelativeFiniteBound::new(SignedDuration::from_hours(8)).to_end_bound()),
+    ///     Some(
+    ///         RelativeFiniteBound::new_with_inclusivity(
+    ///             SignedDuration::from_hours(8),
+    ///             BoundInclusivity::Exclusive,
+    ///         )
+    ///         .to_start_bound(),
+    ///     ),
     /// );
     ///
     /// assert_eq!(
     ///     change.old_state_end(),
-    ///     Some(RelativeFiniteBound::new(
-    ///         SignedDuration::from_hours(8),
-    ///     ).to_end_bound()),
+    ///     Some(RelativeFiniteBound::new(SignedDuration::from_hours(8),).to_end_bound()),
     /// );
     /// ```
     #[must_use]
@@ -609,21 +764,25 @@ impl LayeredBoundsStateChangeAtRelativeBound {
     /// let change = LayeredBoundsStateChangeAtRelativeBound::new(
     ///     LayeredBoundsState::NoLayers,
     ///     LayeredBoundsState::FirstLayer,
-    ///     Some(RelativeFiniteBound::new(
-    ///         SignedDuration::from_hours(8),
-    ///     ).to_end_bound()),
-    ///     Some(RelativeFiniteBound::new_with_inclusivity(
-    ///         SignedDuration::from_hours(8),
-    ///         BoundInclusivity::Exclusive,
-    ///     ).to_start_bound()),
+    ///     Some(RelativeFiniteBound::new(SignedDuration::from_hours(8)).to_end_bound()),
+    ///     Some(
+    ///         RelativeFiniteBound::new_with_inclusivity(
+    ///             SignedDuration::from_hours(8),
+    ///             BoundInclusivity::Exclusive,
+    ///         )
+    ///         .to_start_bound(),
+    ///     ),
     /// );
     ///
     /// assert_eq!(
     ///     change.new_state_start(),
-    ///     Some(RelativeFiniteBound::new_with_inclusivity(
-    ///         SignedDuration::from_hours(8),
-    ///         BoundInclusivity::Exclusive,
-    ///     ).to_start_bound()),
+    ///     Some(
+    ///         RelativeFiniteBound::new_with_inclusivity(
+    ///             SignedDuration::from_hours(8),
+    ///             BoundInclusivity::Exclusive,
+    ///         )
+    ///         .to_start_bound()
+    ///     ),
     /// );
     /// ```
     #[must_use]
@@ -651,38 +810,62 @@ impl LayeredBoundsStateChangeAtRelativeBound {
 /// let first_layer_intervals = [
 ///     AbsoluteBoundPair::new(
 ///         AbsoluteFiniteBound::new(
-///             "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///         ).to_start_bound(),
+///             "2025-01-01 08:00:00[Europe/Oslo]"
+///                 .parse::<Zoned>()?
+///                 .timestamp(),
+///         )
+///         .to_start_bound(),
 ///         AbsoluteFiniteBound::new(
-///             "2025-01-01 12:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///         ).to_end_bound(),
+///             "2025-01-01 12:00:00[Europe/Oslo]"
+///                 .parse::<Zoned>()?
+///                 .timestamp(),
+///         )
+///         .to_end_bound(),
 ///     ),
 ///     AbsoluteBoundPair::new(
 ///         AbsoluteFiniteBound::new(
-///             "2025-01-01 13:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///         ).to_start_bound(),
+///             "2025-01-01 13:00:00[Europe/Oslo]"
+///                 .parse::<Zoned>()?
+///                 .timestamp(),
+///         )
+///         .to_start_bound(),
 ///         AbsoluteFiniteBound::new(
-///             "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///         ).to_end_bound(),
+///             "2025-01-01 16:00:00[Europe/Oslo]"
+///                 .parse::<Zoned>()?
+///                 .timestamp(),
+///         )
+///         .to_end_bound(),
 ///     ),
 /// ];
 ///
 /// let second_layer_intervals = [
 ///     AbsoluteBoundPair::new(
 ///         AbsoluteFiniteBound::new(
-///             "2025-01-01 07:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///         ).to_start_bound(),
+///             "2025-01-01 07:00:00[Europe/Oslo]"
+///                 .parse::<Zoned>()?
+///                 .timestamp(),
+///         )
+///         .to_start_bound(),
 ///         AbsoluteFiniteBound::new(
-///             "2025-01-01 11:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///         ).to_end_bound(),
+///             "2025-01-01 11:00:00[Europe/Oslo]"
+///                 .parse::<Zoned>()?
+///                 .timestamp(),
+///         )
+///         .to_end_bound(),
 ///     ),
 ///     AbsoluteBoundPair::new(
 ///         AbsoluteFiniteBound::new(
-///             "2025-01-01 14:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///         ).to_start_bound(),
+///             "2025-01-01 14:00:00[Europe/Oslo]"
+///                 .parse::<Zoned>()?
+///                 .timestamp(),
+///         )
+///         .to_start_bound(),
 ///         AbsoluteFiniteBound::new(
-///             "2025-01-01 18:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///         ).to_end_bound(),
+///             "2025-01-01 18:00:00[Europe/Oslo]"
+///                 .parse::<Zoned>()?
+///                 .timestamp(),
+///         )
+///         .to_end_bound(),
 ///     ),
 /// ];
 ///
@@ -696,90 +879,170 @@ impl LayeredBoundsStateChangeAtRelativeBound {
 ///         LayeredBoundsStateChangeAtAbsoluteBound::new(
 ///             LayeredBoundsState::NoLayers,
 ///             LayeredBoundsState::SecondLayer,
-///             Some(AbsoluteFiniteBound::new_with_inclusivity(
-///                 "2025-01-01 07:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///                 BoundInclusivity::Exclusive,
-///             ).to_end_bound()),
-///             Some(AbsoluteFiniteBound::new(
-///                 "2025-01-01 07:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///             ).to_start_bound()),
+///             Some(
+///                 AbsoluteFiniteBound::new_with_inclusivity(
+///                     "2025-01-01 07:00:00[Europe/Oslo]"
+///                         .parse::<Zoned>()?
+///                         .timestamp(),
+///                     BoundInclusivity::Exclusive,
+///                 )
+///                 .to_end_bound()
+///             ),
+///             Some(
+///                 AbsoluteFiniteBound::new(
+///                     "2025-01-01 07:00:00[Europe/Oslo]"
+///                         .parse::<Zoned>()?
+///                         .timestamp(),
+///                 )
+///                 .to_start_bound()
+///             ),
 ///         ),
 ///         LayeredBoundsStateChangeAtAbsoluteBound::new(
 ///             LayeredBoundsState::SecondLayer,
 ///             LayeredBoundsState::BothLayers,
-///             Some(AbsoluteFiniteBound::new_with_inclusivity(
-///                 "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///                 BoundInclusivity::Exclusive,
-///             ).to_end_bound()),
-///             Some(AbsoluteFiniteBound::new(
-///                 "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///             ).to_start_bound()),
+///             Some(
+///                 AbsoluteFiniteBound::new_with_inclusivity(
+///                     "2025-01-01 08:00:00[Europe/Oslo]"
+///                         .parse::<Zoned>()?
+///                         .timestamp(),
+///                     BoundInclusivity::Exclusive,
+///                 )
+///                 .to_end_bound()
+///             ),
+///             Some(
+///                 AbsoluteFiniteBound::new(
+///                     "2025-01-01 08:00:00[Europe/Oslo]"
+///                         .parse::<Zoned>()?
+///                         .timestamp(),
+///                 )
+///                 .to_start_bound()
+///             ),
 ///         ),
 ///         LayeredBoundsStateChangeAtAbsoluteBound::new(
 ///             LayeredBoundsState::BothLayers,
 ///             LayeredBoundsState::FirstLayer,
-///             Some(AbsoluteFiniteBound::new(
-///                 "2025-01-01 11:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///             ).to_end_bound()),
-///             Some(AbsoluteFiniteBound::new_with_inclusivity(
-///                 "2025-01-01 11:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///                 BoundInclusivity::Exclusive,
-///             ).to_start_bound()),
+///             Some(
+///                 AbsoluteFiniteBound::new(
+///                     "2025-01-01 11:00:00[Europe/Oslo]"
+///                         .parse::<Zoned>()?
+///                         .timestamp(),
+///                 )
+///                 .to_end_bound()
+///             ),
+///             Some(
+///                 AbsoluteFiniteBound::new_with_inclusivity(
+///                     "2025-01-01 11:00:00[Europe/Oslo]"
+///                         .parse::<Zoned>()?
+///                         .timestamp(),
+///                     BoundInclusivity::Exclusive,
+///                 )
+///                 .to_start_bound()
+///             ),
 ///         ),
 ///         LayeredBoundsStateChangeAtAbsoluteBound::new(
 ///             LayeredBoundsState::FirstLayer,
 ///             LayeredBoundsState::NoLayers,
-///             Some(AbsoluteFiniteBound::new(
-///                 "2025-01-01 12:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///             ).to_end_bound()),
-///             Some(AbsoluteFiniteBound::new_with_inclusivity(
-///                 "2025-01-01 12:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///                 BoundInclusivity::Exclusive,
-///             ).to_start_bound()),
+///             Some(
+///                 AbsoluteFiniteBound::new(
+///                     "2025-01-01 12:00:00[Europe/Oslo]"
+///                         .parse::<Zoned>()?
+///                         .timestamp(),
+///                 )
+///                 .to_end_bound()
+///             ),
+///             Some(
+///                 AbsoluteFiniteBound::new_with_inclusivity(
+///                     "2025-01-01 12:00:00[Europe/Oslo]"
+///                         .parse::<Zoned>()?
+///                         .timestamp(),
+///                     BoundInclusivity::Exclusive,
+///                 )
+///                 .to_start_bound()
+///             ),
 ///         ),
 ///         LayeredBoundsStateChangeAtAbsoluteBound::new(
 ///             LayeredBoundsState::NoLayers,
 ///             LayeredBoundsState::FirstLayer,
-///             Some(AbsoluteFiniteBound::new_with_inclusivity(
-///                 "2025-01-01 13:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///                 BoundInclusivity::Exclusive,
-///             ).to_end_bound()),
-///             Some(AbsoluteFiniteBound::new(
-///                 "2025-01-01 13:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///             ).to_start_bound()),
+///             Some(
+///                 AbsoluteFiniteBound::new_with_inclusivity(
+///                     "2025-01-01 13:00:00[Europe/Oslo]"
+///                         .parse::<Zoned>()?
+///                         .timestamp(),
+///                     BoundInclusivity::Exclusive,
+///                 )
+///                 .to_end_bound()
+///             ),
+///             Some(
+///                 AbsoluteFiniteBound::new(
+///                     "2025-01-01 13:00:00[Europe/Oslo]"
+///                         .parse::<Zoned>()?
+///                         .timestamp(),
+///                 )
+///                 .to_start_bound()
+///             ),
 ///         ),
 ///         LayeredBoundsStateChangeAtAbsoluteBound::new(
 ///             LayeredBoundsState::FirstLayer,
 ///             LayeredBoundsState::BothLayers,
-///             Some(AbsoluteFiniteBound::new_with_inclusivity(
-///                 "2025-01-01 14:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///                 BoundInclusivity::Exclusive,
-///             ).to_end_bound()),
-///             Some(AbsoluteFiniteBound::new(
-///                 "2025-01-01 14:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///             ).to_start_bound()),
+///             Some(
+///                 AbsoluteFiniteBound::new_with_inclusivity(
+///                     "2025-01-01 14:00:00[Europe/Oslo]"
+///                         .parse::<Zoned>()?
+///                         .timestamp(),
+///                     BoundInclusivity::Exclusive,
+///                 )
+///                 .to_end_bound()
+///             ),
+///             Some(
+///                 AbsoluteFiniteBound::new(
+///                     "2025-01-01 14:00:00[Europe/Oslo]"
+///                         .parse::<Zoned>()?
+///                         .timestamp(),
+///                 )
+///                 .to_start_bound()
+///             ),
 ///         ),
 ///         LayeredBoundsStateChangeAtAbsoluteBound::new(
 ///             LayeredBoundsState::BothLayers,
 ///             LayeredBoundsState::SecondLayer,
-///             Some(AbsoluteFiniteBound::new(
-///                 "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///             ).to_end_bound()),
-///             Some(AbsoluteFiniteBound::new_with_inclusivity(
-///                 "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///                 BoundInclusivity::Exclusive,
-///             ).to_start_bound()),
+///             Some(
+///                 AbsoluteFiniteBound::new(
+///                     "2025-01-01 16:00:00[Europe/Oslo]"
+///                         .parse::<Zoned>()?
+///                         .timestamp(),
+///                 )
+///                 .to_end_bound()
+///             ),
+///             Some(
+///                 AbsoluteFiniteBound::new_with_inclusivity(
+///                     "2025-01-01 16:00:00[Europe/Oslo]"
+///                         .parse::<Zoned>()?
+///                         .timestamp(),
+///                     BoundInclusivity::Exclusive,
+///                 )
+///                 .to_start_bound()
+///             ),
 ///         ),
 ///         LayeredBoundsStateChangeAtAbsoluteBound::new(
 ///             LayeredBoundsState::SecondLayer,
 ///             LayeredBoundsState::NoLayers,
-///             Some(AbsoluteFiniteBound::new(
-///                 "2025-01-01 18:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///             ).to_end_bound()),
-///             Some(AbsoluteFiniteBound::new_with_inclusivity(
-///                 "2025-01-01 18:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-///                 BoundInclusivity::Exclusive,
-///             ).to_start_bound()),
+///             Some(
+///                 AbsoluteFiniteBound::new(
+///                     "2025-01-01 18:00:00[Europe/Oslo]"
+///                         .parse::<Zoned>()?
+///                         .timestamp(),
+///                 )
+///                 .to_end_bound()
+///             ),
+///             Some(
+///                 AbsoluteFiniteBound::new_with_inclusivity(
+///                     "2025-01-01 18:00:00[Europe/Oslo]"
+///                         .parse::<Zoned>()?
+///                         .timestamp(),
+///                     BoundInclusivity::Exclusive,
+///                 )
+///                 .to_start_bound()
+///             ),
 ///         ),
 ///     ],
 /// );
@@ -812,38 +1075,62 @@ impl<I1, I2> LayeredAbsoluteBounds<I1, I2> {
     /// let first_layer_intervals = [
     ///     AbsoluteBoundPair::new(
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_start_bound(),
+    ///             "2025-01-01 08:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_start_bound(),
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 12:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_end_bound(),
+    ///             "2025-01-01 12:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_end_bound(),
     ///     ),
     ///     AbsoluteBoundPair::new(
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 13:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_start_bound(),
+    ///             "2025-01-01 13:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_start_bound(),
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_end_bound(),
+    ///             "2025-01-01 16:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_end_bound(),
     ///     ),
     /// ];
     ///
     /// let second_layer_intervals = [
     ///     AbsoluteBoundPair::new(
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 07:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_start_bound(),
+    ///             "2025-01-01 07:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_start_bound(),
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 11:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_end_bound(),
+    ///             "2025-01-01 11:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_end_bound(),
     ///     ),
     ///     AbsoluteBoundPair::new(
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 14:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_start_bound(),
+    ///             "2025-01-01 14:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_start_bound(),
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 18:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_end_bound(),
+    ///             "2025-01-01 18:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_end_bound(),
     ///     ),
     /// ];
     ///
@@ -874,9 +1161,8 @@ where
     ///
     /// 1. The bounds in each layer iterator **must be sorted chronologically**
     /// 2. The bounds in each layer iterator **must not be overlapping**
-    /// 3. The bounds in each layer iterator **must be paired**, that means
-    ///    there should be an equal amount of [`Start`](AbsoluteBound::Start)s
-    ///    and [`End`](AbsoluteBound::End)s.
+    /// 3. The bounds in each layer iterator **must be paired**, that means there should be an equal amount of
+    ///    [`Start`](AbsoluteBound::Start)s and [`End`](AbsoluteBound::End)s.
     ///
     /// The responsibility of verifying those requirements are left to the
     /// caller in order to prevent double-processing.
@@ -1028,10 +1314,8 @@ where
 ///
 /// Shouldn't panic but could if one of the following is true:
 ///
-/// 1. The peeked start bound of the first layer didn't equal the value returned
-///    by `next()` on the first layer
-/// 2. The value returned by `next()` on the first layer wasn't of the
-///    [`Start`](AbsoluteBound::Start) variant
+/// 1. The peeked start bound of the first layer didn't equal the value returned by `next()` on the first layer
+/// 2. The value returned by `next()` on the first layer wasn't of the [`Start`](AbsoluteBound::Start) variant
 #[must_use]
 pub fn layered_abs_bounds_change_start_first_layer(
     old_state: LayeredBoundsState,
@@ -1065,10 +1349,8 @@ pub fn layered_abs_bounds_change_start_first_layer(
 ///
 /// Shouldn't panic but could if one of the following is true:
 ///
-/// 1. The peeked end bound of the first layer didn't equal the value returned
-///    by `next()` on the first layer
-/// 2. The value returned by `next()` on the first layer wasn't of the
-///    [`End`](AbsoluteBound::End) variant
+/// 1. The peeked end bound of the first layer didn't equal the value returned by `next()` on the first layer
+/// 2. The value returned by `next()` on the first layer wasn't of the [`End`](AbsoluteBound::End) variant
 #[must_use]
 pub fn layered_abs_bounds_change_end_first_layer(
     old_state: LayeredBoundsState,
@@ -1097,10 +1379,8 @@ pub fn layered_abs_bounds_change_end_first_layer(
 ///
 /// Shouldn't panic but could if one of the following is true:
 ///
-/// 1. The peeked start bound of the second layer didn't equal the value
-///    returned by `next()` on the second layer
-/// 2. The value returned by `next()` on the second layer wasn't of the
-///    [`Start`](AbsoluteBound::Start) variant
+/// 1. The peeked start bound of the second layer didn't equal the value returned by `next()` on the second layer
+/// 2. The value returned by `next()` on the second layer wasn't of the [`Start`](AbsoluteBound::Start) variant
 #[must_use]
 pub fn layered_abs_bounds_change_start_second_layer(
     old_state: LayeredBoundsState,
@@ -1134,10 +1414,8 @@ pub fn layered_abs_bounds_change_start_second_layer(
 ///
 /// Shouldn't panic but could if one of the following is true:
 ///
-/// 1. The peeked end bound of the second layer didn't equal the value returned
-///    by `next()` on the second layer
-/// 2. The value returned by `next()` on the second layer wasn't of the
-///    [`End`](AbsoluteBound::End) variant
+/// 1. The peeked end bound of the second layer didn't equal the value returned by `next()` on the second layer
+/// 2. The value returned by `next()` on the second layer wasn't of the [`End`](AbsoluteBound::End) variant
 #[must_use]
 pub fn layered_abs_bounds_change_end_second_layer(
     old_state: LayeredBoundsState,
@@ -1171,10 +1449,8 @@ pub fn layered_abs_bounds_change_end_second_layer(
 ///
 /// Shouldn't panic but could if one of the following is true:
 ///
-/// 1. The peeked value of a layer wasn't equal to the value returned by calling
-///    `next()` on that layer
-/// 2. The value returned by `next()` on the layer wasn't of the expected
-///    variant
+/// 1. The peeked value of a layer wasn't equal to the value returned by calling `next()` on that layer
+/// 2. The value returned by `next()` on the layer wasn't of the expected variant
 #[must_use]
 pub fn layered_abs_bounds_change_start_start(
     old_state: LayeredBoundsState,
@@ -1253,12 +1529,9 @@ pub fn layered_abs_bounds_change_start_start(
 ///
 /// Shouldn't panic but could if one of the following is true:
 ///
-/// 1. The peeked value of a layer wasn't equal to the value returned by calling
-///    `next()` on that layer
-/// 2. The value returned by `next()` on the layer wasn't of the expected
-///    variant
-/// 3. The comparison between [`AbsoluteStartBound`] and [`AbsoluteEndBound`]
-///    returned [`None`]
+/// 1. The peeked value of a layer wasn't equal to the value returned by calling `next()` on that layer
+/// 2. The value returned by `next()` on the layer wasn't of the expected variant
+/// 3. The comparison between [`AbsoluteStartBound`] and [`AbsoluteEndBound`] returned [`None`]
 #[must_use]
 pub fn layered_abs_bounds_change_start_end(
     old_state: LayeredBoundsState,
@@ -1375,12 +1648,9 @@ pub fn layered_abs_bounds_change_start_end(
 ///
 /// Shouldn't panic but could if one of the following is true:
 ///
-/// 1. The peeked value of a layer wasn't equal to the value returned by calling
-///    `next()` on that layer
-/// 2. The value returned by `next()` on the layer wasn't of the expected
-///    variant
-/// 3. The comparison between [`AbsoluteEndBound`] and [`AbsoluteStartBound`]
-///    returned [`None`]
+/// 1. The peeked value of a layer wasn't equal to the value returned by calling `next()` on that layer
+/// 2. The value returned by `next()` on the layer wasn't of the expected variant
+/// 3. The comparison between [`AbsoluteEndBound`] and [`AbsoluteStartBound`] returned [`None`]
 #[must_use]
 pub fn layered_abs_bounds_change_end_start(
     old_state: LayeredBoundsState,
@@ -1491,10 +1761,8 @@ pub fn layered_abs_bounds_change_end_start(
 ///
 /// Shouldn't panic but could if one of the following is true:
 ///
-/// 1. The peeked value of a layer wasn't equal to the value returned by calling
-///    `next()` on that layer
-/// 2. The value returned by `next()` on the layer wasn't of the expected
-///    variant
+/// 1. The peeked value of a layer wasn't equal to the value returned by calling `next()` on that layer
+/// 2. The value returned by `next()` on the layer wasn't of the expected variant
 #[must_use]
 pub fn layered_abs_bounds_change_end_end(
     old_state: LayeredBoundsState,
@@ -1567,39 +1835,23 @@ pub fn layered_abs_bounds_change_end_end(
 /// # };
 /// let first_layer_intervals = [
 ///     RelativeBoundPair::new(
-///         RelativeFiniteBound::new(
-///             SignedDuration::from_hours(8),
-///         ).to_start_bound(),
-///         RelativeFiniteBound::new(
-///             SignedDuration::from_hours(12),
-///         ).to_end_bound(),
+///         RelativeFiniteBound::new(SignedDuration::from_hours(8)).to_start_bound(),
+///         RelativeFiniteBound::new(SignedDuration::from_hours(12)).to_end_bound(),
 ///     ),
 ///     RelativeBoundPair::new(
-///         RelativeFiniteBound::new(
-///             SignedDuration::from_hours(13),
-///         ).to_start_bound(),
-///         RelativeFiniteBound::new(
-///             SignedDuration::from_hours(16),
-///         ).to_end_bound(),
+///         RelativeFiniteBound::new(SignedDuration::from_hours(13)).to_start_bound(),
+///         RelativeFiniteBound::new(SignedDuration::from_hours(16)).to_end_bound(),
 ///     ),
 /// ];
 ///
 /// let second_layer_intervals = [
 ///     RelativeBoundPair::new(
-///         RelativeFiniteBound::new(
-///             SignedDuration::from_hours(7),
-///         ).to_start_bound(),
-///         RelativeFiniteBound::new(
-///             SignedDuration::from_hours(11),
-///         ).to_end_bound(),
+///         RelativeFiniteBound::new(SignedDuration::from_hours(7)).to_start_bound(),
+///         RelativeFiniteBound::new(SignedDuration::from_hours(11)).to_end_bound(),
 ///     ),
 ///     RelativeBoundPair::new(
-///         RelativeFiniteBound::new(
-///             SignedDuration::from_hours(14),
-///         ).to_start_bound(),
-///         RelativeFiniteBound::new(
-///             SignedDuration::from_hours(18),
-///         ).to_end_bound(),
+///         RelativeFiniteBound::new(SignedDuration::from_hours(14)).to_start_bound(),
+///         RelativeFiniteBound::new(SignedDuration::from_hours(18)).to_end_bound(),
 ///     ),
 /// ];
 ///
@@ -1613,90 +1865,98 @@ pub fn layered_abs_bounds_change_end_end(
 ///         LayeredBoundsStateChangeAtRelativeBound::new(
 ///             LayeredBoundsState::NoLayers,
 ///             LayeredBoundsState::SecondLayer,
-///             Some(RelativeFiniteBound::new_with_inclusivity(
-///                 SignedDuration::from_hours(7),
-///                 BoundInclusivity::Exclusive,
-///             ).to_end_bound()),
-///             Some(RelativeFiniteBound::new(
-///                 SignedDuration::from_hours(7),
-///             ).to_start_bound()),
+///             Some(
+///                 RelativeFiniteBound::new_with_inclusivity(
+///                     SignedDuration::from_hours(7),
+///                     BoundInclusivity::Exclusive,
+///                 )
+///                 .to_end_bound()
+///             ),
+///             Some(RelativeFiniteBound::new(SignedDuration::from_hours(7),).to_start_bound()),
 ///         ),
 ///         LayeredBoundsStateChangeAtRelativeBound::new(
 ///             LayeredBoundsState::SecondLayer,
 ///             LayeredBoundsState::BothLayers,
-///             Some(RelativeFiniteBound::new_with_inclusivity(
-///                 SignedDuration::from_hours(8),
-///                 BoundInclusivity::Exclusive,
-///             ).to_end_bound()),
-///             Some(RelativeFiniteBound::new(
-///                 SignedDuration::from_hours(8),
-///             ).to_start_bound()),
+///             Some(
+///                 RelativeFiniteBound::new_with_inclusivity(
+///                     SignedDuration::from_hours(8),
+///                     BoundInclusivity::Exclusive,
+///                 )
+///                 .to_end_bound()
+///             ),
+///             Some(RelativeFiniteBound::new(SignedDuration::from_hours(8),).to_start_bound()),
 ///         ),
 ///         LayeredBoundsStateChangeAtRelativeBound::new(
 ///             LayeredBoundsState::BothLayers,
 ///             LayeredBoundsState::FirstLayer,
-///             Some(RelativeFiniteBound::new(
-///                 SignedDuration::from_hours(11),
-///             ).to_end_bound()),
-///             Some(RelativeFiniteBound::new_with_inclusivity(
-///                 SignedDuration::from_hours(11),
-///                 BoundInclusivity::Exclusive,
-///             ).to_start_bound()),
+///             Some(RelativeFiniteBound::new(SignedDuration::from_hours(11),).to_end_bound()),
+///             Some(
+///                 RelativeFiniteBound::new_with_inclusivity(
+///                     SignedDuration::from_hours(11),
+///                     BoundInclusivity::Exclusive,
+///                 )
+///                 .to_start_bound()
+///             ),
 ///         ),
 ///         LayeredBoundsStateChangeAtRelativeBound::new(
 ///             LayeredBoundsState::FirstLayer,
 ///             LayeredBoundsState::NoLayers,
-///             Some(RelativeFiniteBound::new(
-///                 SignedDuration::from_hours(12),
-///             ).to_end_bound()),
-///             Some(RelativeFiniteBound::new_with_inclusivity(
-///                 SignedDuration::from_hours(12),
-///                 BoundInclusivity::Exclusive,
-///             ).to_start_bound()),
+///             Some(RelativeFiniteBound::new(SignedDuration::from_hours(12),).to_end_bound()),
+///             Some(
+///                 RelativeFiniteBound::new_with_inclusivity(
+///                     SignedDuration::from_hours(12),
+///                     BoundInclusivity::Exclusive,
+///                 )
+///                 .to_start_bound()
+///             ),
 ///         ),
 ///         LayeredBoundsStateChangeAtRelativeBound::new(
 ///             LayeredBoundsState::NoLayers,
 ///             LayeredBoundsState::FirstLayer,
-///             Some(RelativeFiniteBound::new_with_inclusivity(
-///                 SignedDuration::from_hours(13),
-///                 BoundInclusivity::Exclusive,
-///             ).to_end_bound()),
-///             Some(RelativeFiniteBound::new(
-///                 SignedDuration::from_hours(13),
-///             ).to_start_bound()),
+///             Some(
+///                 RelativeFiniteBound::new_with_inclusivity(
+///                     SignedDuration::from_hours(13),
+///                     BoundInclusivity::Exclusive,
+///                 )
+///                 .to_end_bound()
+///             ),
+///             Some(RelativeFiniteBound::new(SignedDuration::from_hours(13),).to_start_bound()),
 ///         ),
 ///         LayeredBoundsStateChangeAtRelativeBound::new(
 ///             LayeredBoundsState::FirstLayer,
 ///             LayeredBoundsState::BothLayers,
-///             Some(RelativeFiniteBound::new_with_inclusivity(
-///                 SignedDuration::from_hours(14),
-///                 BoundInclusivity::Exclusive,
-///             ).to_end_bound()),
-///             Some(RelativeFiniteBound::new(
-///                 SignedDuration::from_hours(14),
-///             ).to_start_bound()),
+///             Some(
+///                 RelativeFiniteBound::new_with_inclusivity(
+///                     SignedDuration::from_hours(14),
+///                     BoundInclusivity::Exclusive,
+///                 )
+///                 .to_end_bound()
+///             ),
+///             Some(RelativeFiniteBound::new(SignedDuration::from_hours(14),).to_start_bound()),
 ///         ),
 ///         LayeredBoundsStateChangeAtRelativeBound::new(
 ///             LayeredBoundsState::BothLayers,
 ///             LayeredBoundsState::SecondLayer,
-///             Some(RelativeFiniteBound::new(
-///                 SignedDuration::from_hours(16),
-///             ).to_end_bound()),
-///             Some(RelativeFiniteBound::new_with_inclusivity(
-///                 SignedDuration::from_hours(16),
-///                 BoundInclusivity::Exclusive,
-///             ).to_start_bound()),
+///             Some(RelativeFiniteBound::new(SignedDuration::from_hours(16),).to_end_bound()),
+///             Some(
+///                 RelativeFiniteBound::new_with_inclusivity(
+///                     SignedDuration::from_hours(16),
+///                     BoundInclusivity::Exclusive,
+///                 )
+///                 .to_start_bound()
+///             ),
 ///         ),
 ///         LayeredBoundsStateChangeAtRelativeBound::new(
 ///             LayeredBoundsState::SecondLayer,
 ///             LayeredBoundsState::NoLayers,
-///             Some(RelativeFiniteBound::new(
-///                 SignedDuration::from_hours(18),
-///             ).to_end_bound()),
-///             Some(RelativeFiniteBound::new_with_inclusivity(
-///                 SignedDuration::from_hours(18),
-///                 BoundInclusivity::Exclusive,
-///             ).to_start_bound()),
+///             Some(RelativeFiniteBound::new(SignedDuration::from_hours(18),).to_end_bound()),
+///             Some(
+///                 RelativeFiniteBound::new_with_inclusivity(
+///                     SignedDuration::from_hours(18),
+///                     BoundInclusivity::Exclusive,
+///                 )
+///                 .to_start_bound()
+///             ),
 ///         ),
 ///     ],
 /// );
@@ -1726,39 +1986,23 @@ impl<I1, I2> LayeredRelativeBounds<I1, I2> {
     /// # };
     /// let first_layer_intervals = [
     ///     RelativeBoundPair::new(
-    ///         RelativeFiniteBound::new(
-    ///             SignedDuration::from_hours(8),
-    ///         ).to_start_bound(),
-    ///         RelativeFiniteBound::new(
-    ///             SignedDuration::from_hours(12),
-    ///         ).to_end_bound(),
+    ///         RelativeFiniteBound::new(SignedDuration::from_hours(8)).to_start_bound(),
+    ///         RelativeFiniteBound::new(SignedDuration::from_hours(12)).to_end_bound(),
     ///     ),
     ///     RelativeBoundPair::new(
-    ///         RelativeFiniteBound::new(
-    ///             SignedDuration::from_hours(13),
-    ///         ).to_start_bound(),
-    ///         RelativeFiniteBound::new(
-    ///             SignedDuration::from_hours(16),
-    ///         ).to_end_bound(),
+    ///         RelativeFiniteBound::new(SignedDuration::from_hours(13)).to_start_bound(),
+    ///         RelativeFiniteBound::new(SignedDuration::from_hours(16)).to_end_bound(),
     ///     ),
     /// ];
     ///
     /// let second_layer_intervals = [
     ///     RelativeBoundPair::new(
-    ///         RelativeFiniteBound::new(
-    ///             SignedDuration::from_hours(7),
-    ///         ).to_start_bound(),
-    ///         RelativeFiniteBound::new(
-    ///             SignedDuration::from_hours(11),
-    ///         ).to_end_bound(),
+    ///         RelativeFiniteBound::new(SignedDuration::from_hours(7)).to_start_bound(),
+    ///         RelativeFiniteBound::new(SignedDuration::from_hours(11)).to_end_bound(),
     ///     ),
     ///     RelativeBoundPair::new(
-    ///         RelativeFiniteBound::new(
-    ///             SignedDuration::from_hours(14),
-    ///         ).to_start_bound(),
-    ///         RelativeFiniteBound::new(
-    ///             SignedDuration::from_hours(18),
-    ///         ).to_end_bound(),
+    ///         RelativeFiniteBound::new(SignedDuration::from_hours(14)).to_start_bound(),
+    ///         RelativeFiniteBound::new(SignedDuration::from_hours(18)).to_end_bound(),
     ///     ),
     /// ];
     ///
@@ -1788,9 +2032,8 @@ where
     ///
     /// 1. The bounds in each layer iterator **must be sorted chronologically**
     /// 2. The bounds in each layer iterator **must not be overlapping**
-    /// 3. The bounds in each layer iterator **must be paired**, that means
-    ///    there should be an equal amount of [`Start`](RelativeBound::Start)s
-    ///    and [`End`](RelativeBound::End)s.
+    /// 3. The bounds in each layer iterator **must be paired**, that means there should be an equal amount of
+    ///    [`Start`](RelativeBound::Start)s and [`End`](RelativeBound::End)s.
     ///
     /// The responsibility of verifying those requirements are left to the
     /// caller in order to prevent double-processing.
@@ -1942,10 +2185,8 @@ where
 ///
 /// Shouldn't panic but could if one of the following is true:
 ///
-/// 1. The peeked start bound of the first layer didn't equal the value returned
-///    by `next()` on the first layer
-/// 2. The value returned by `next()` on the first layer wasn't of the
-///    [`Start`](RelativeBound::Start) variant
+/// 1. The peeked start bound of the first layer didn't equal the value returned by `next()` on the first layer
+/// 2. The value returned by `next()` on the first layer wasn't of the [`Start`](RelativeBound::Start) variant
 #[must_use]
 pub fn layered_rel_bounds_change_start_first_layer(
     old_state: LayeredBoundsState,
@@ -1979,10 +2220,8 @@ pub fn layered_rel_bounds_change_start_first_layer(
 ///
 /// Shouldn't panic but could if one of the following is true:
 ///
-/// 1. The peeked end bound of the first layer didn't equal the value returned
-///    by `next()` on the first layer
-/// 2. The value returned by `next()` on the first layer wasn't of the
-///    [`End`](RelativeBound::End) variant
+/// 1. The peeked end bound of the first layer didn't equal the value returned by `next()` on the first layer
+/// 2. The value returned by `next()` on the first layer wasn't of the [`End`](RelativeBound::End) variant
 #[must_use]
 pub fn layered_rel_bounds_change_end_first_layer(
     old_state: LayeredBoundsState,
@@ -2011,10 +2250,8 @@ pub fn layered_rel_bounds_change_end_first_layer(
 ///
 /// Shouldn't panic but could if one of the following is true:
 ///
-/// 1. The peeked start bound of the second layer didn't equal the value
-///    returned by `next()` on the second layer
-/// 2. The value returned by `next()` on the second layer wasn't of the
-///    [`Start`](RelativeBound::Start) variant
+/// 1. The peeked start bound of the second layer didn't equal the value returned by `next()` on the second layer
+/// 2. The value returned by `next()` on the second layer wasn't of the [`Start`](RelativeBound::Start) variant
 #[must_use]
 pub fn layered_rel_bounds_change_start_second_layer(
     old_state: LayeredBoundsState,
@@ -2048,10 +2285,8 @@ pub fn layered_rel_bounds_change_start_second_layer(
 ///
 /// Shouldn't panic but could if one of the following is true:
 ///
-/// 1. The peeked end bound of the second layer didn't equal the value returned
-///    by `next()` on the second layer
-/// 2. The value returned by `next()` on the second layer wasn't of the
-///    [`End`](RelativeBound::End) variant
+/// 1. The peeked end bound of the second layer didn't equal the value returned by `next()` on the second layer
+/// 2. The value returned by `next()` on the second layer wasn't of the [`End`](RelativeBound::End) variant
 #[must_use]
 pub fn layered_rel_bounds_change_end_second_layer(
     old_state: LayeredBoundsState,
@@ -2085,10 +2320,8 @@ pub fn layered_rel_bounds_change_end_second_layer(
 ///
 /// Shouldn't panic but could if one of the following is true:
 ///
-/// 1. The peeked value of a layer wasn't equal to the value returned by calling
-///    `next()` on that layer
-/// 2. The value returned by `next()` on the layer wasn't of the expected
-///    variant
+/// 1. The peeked value of a layer wasn't equal to the value returned by calling `next()` on that layer
+/// 2. The value returned by `next()` on the layer wasn't of the expected variant
 #[must_use]
 pub fn layered_rel_bounds_change_start_start(
     old_state: LayeredBoundsState,
@@ -2167,12 +2400,9 @@ pub fn layered_rel_bounds_change_start_start(
 ///
 /// Shouldn't panic but could if one of the following is true:
 ///
-/// 1. The peeked value of a layer wasn't equal to the value returned by calling
-///    `next()` on that layer
-/// 2. The value returned by `next()` on the layer wasn't of the expected
-///    variant
-/// 3. The comparison between [`RelativeStartBound`] and [`RelativeEndBound`]
-///    returned [`None`]
+/// 1. The peeked value of a layer wasn't equal to the value returned by calling `next()` on that layer
+/// 2. The value returned by `next()` on the layer wasn't of the expected variant
+/// 3. The comparison between [`RelativeStartBound`] and [`RelativeEndBound`] returned [`None`]
 #[must_use]
 pub fn layered_rel_bounds_change_start_end(
     old_state: LayeredBoundsState,
@@ -2289,12 +2519,9 @@ pub fn layered_rel_bounds_change_start_end(
 ///
 /// Shouldn't panic but could if one of the following is true:
 ///
-/// 1. The peeked value of a layer wasn't equal to the value returned by calling
-///    `next()` on that layer
-/// 2. The value returned by `next()` on the layer wasn't of the expected
-///    variant
-/// 3. The comparison between [`RelativeEndBound`] and [`RelativeStartBound`]
-///    returned [`None`]
+/// 1. The peeked value of a layer wasn't equal to the value returned by calling `next()` on that layer
+/// 2. The value returned by `next()` on the layer wasn't of the expected variant
+/// 3. The comparison between [`RelativeEndBound`] and [`RelativeStartBound`] returned [`None`]
 #[must_use]
 pub fn layered_rel_bounds_change_end_start(
     old_state: LayeredBoundsState,
@@ -2405,10 +2632,8 @@ pub fn layered_rel_bounds_change_end_start(
 ///
 /// Shouldn't panic but could if one of the following is true:
 ///
-/// 1. The peeked value of a layer wasn't equal to the value returned by calling
-///    `next()` on that layer
-/// 2. The value returned by `next()` on the layer wasn't of the expected
-///    variant
+/// 1. The peeked value of a layer wasn't equal to the value returned by calling `next()` on that layer
+/// 2. The value returned by `next()` on the layer wasn't of the expected variant
 #[must_use]
 pub fn layered_rel_bounds_change_end_end(
     old_state: LayeredBoundsState,

--- a/src/iter/intervals/layered_bounds_set_ops/diff.rs
+++ b/src/iter/intervals/layered_bounds_set_ops/diff.rs
@@ -122,8 +122,7 @@ where
     ///
     /// # Input requirements
     ///
-    /// 1. The iterator **must return continuous [state
-    ///    changes](LayeredBoundsStateChangeAtAbsoluteBound)**
+    /// 1. The iterator **must return continuous [state changes](LayeredBoundsStateChangeAtAbsoluteBound)**
     /// 2. The state changes **must be in chronological order**
     ///
     /// For more precision about requirement 1, _continuous state changes_ means
@@ -174,16 +173,16 @@ where
 
             let Some(next) = self.iter.next() else {
                 unreachable!(
-                    "The input requirements guarantee that the given iterator \
-                    cannot end on an active state such as `FirstLayer`"
+                    "The input requirements guarantee that the given iterator cannot end on an active state such as \
+                     `FirstLayer`"
                 );
             };
 
             let Some(end) = next.old_state_end() else {
                 unreachable!(
                     "We can infer the guarantee that the state change following one that transitions to `FirstLayer` \
-                    must contain an end to the old state, given that the input requirements guarantee \
-                    that the given iterator cannot end on an active state such as `FirstLayer`"
+                     must contain an end to the old state, given that the input requirements guarantee that the given \
+                     iterator cannot end on an active state such as `FirstLayer`"
                 );
             };
 
@@ -243,8 +242,7 @@ where
     ///
     /// # Input requirements
     ///
-    /// 1. The iterator **must return continuous [state
-    ///    changes](LayeredBoundsStateChangeAtRelativeBound)**
+    /// 1. The iterator **must return continuous [state changes](LayeredBoundsStateChangeAtRelativeBound)**
     /// 2. The state changes **must be in chronological order**
     ///
     /// For more precision about requirement 1, _continuous state changes_ means
@@ -295,16 +293,16 @@ where
 
             let Some(next) = self.iter.next() else {
                 unreachable!(
-                    "The input requirements guarantee that the given iterator \
-                    cannot end on an active state such as `FirstLayer`"
+                    "The input requirements guarantee that the given iterator cannot end on an active state such as \
+                     `FirstLayer`"
                 );
             };
 
             let Some(end) = next.old_state_end() else {
                 unreachable!(
                     "We can infer the guarantee that the state change following one that transitions to `FirstLayer` \
-                    must contain an end to the old state, given that the input requirements guarantee \
-                    that the given iterator cannot end on an active state such as `FirstLayer`"
+                     must contain an end to the old state, given that the input requirements guarantee that the given \
+                     iterator cannot end on an active state such as `FirstLayer`"
                 );
             };
 

--- a/src/iter/intervals/layered_bounds_set_ops/intersect.rs
+++ b/src/iter/intervals/layered_bounds_set_ops/intersect.rs
@@ -111,8 +111,7 @@ where
     ///
     /// # Input requirements
     ///
-    /// 1. The iterator **must return continuous [state
-    ///    changes](LayeredBoundsStateChangeAtAbsoluteBound)**
+    /// 1. The iterator **must return continuous [state changes](LayeredBoundsStateChangeAtAbsoluteBound)**
     /// 2. The state changes **must be in chronological order**
     ///
     /// For more precision about requirement 1, _continuous state changes_ means
@@ -163,16 +162,16 @@ where
 
             let Some(next) = self.iter.next() else {
                 unreachable!(
-                    "The input requirements guarantee that the given iterator \
-                    cannot end on an active state such as `BothLayers`"
+                    "The input requirements guarantee that the given iterator cannot end on an active state such as \
+                     `BothLayers`"
                 );
             };
 
             let Some(end) = next.old_state_end() else {
                 unreachable!(
                     "We can infer the guarantee that the state change following one that transitions to `BothLayers` \
-                    must contain an end to the old state, given that the input requirements guarantee \
-                    that the given iterator cannot end on an active state such as `BothLayers`"
+                     must contain an end to the old state, given that the input requirements guarantee that the given \
+                     iterator cannot end on an active state such as `BothLayers`"
                 );
             };
 
@@ -228,8 +227,7 @@ where
     ///
     /// # Input requirements
     ///
-    /// 1. The iterator **must return continuous [state
-    ///    changes](LayeredBoundsStateChangeAtRelativeBound)**
+    /// 1. The iterator **must return continuous [state changes](LayeredBoundsStateChangeAtRelativeBound)**
     /// 2. The state changes **must be in chronological order**
     ///
     /// For more precision about requirement 1, _continuous state changes_ means
@@ -280,16 +278,16 @@ where
 
             let Some(next) = self.iter.next() else {
                 unreachable!(
-                    "The input requirements guarantee that the given iterator \
-                    cannot end on an active state such as `BothLayers`"
+                    "The input requirements guarantee that the given iterator cannot end on an active state such as \
+                     `BothLayers`"
                 );
             };
 
             let Some(end) = next.old_state_end() else {
                 unreachable!(
                     "We can infer the guarantee that the state change following one that transitions to `BothLayers` \
-                    must contain an end to the old state, given that the input requirements guarantee \
-                    that the given iterator cannot end on an active state such as `BothLayers`"
+                     must contain an end to the old state, given that the input requirements guarantee that the given \
+                     iterator cannot end on an active state such as `BothLayers`"
                 );
             };
 

--- a/src/iter/intervals/layered_bounds_set_ops/sym_diff.rs
+++ b/src/iter/intervals/layered_bounds_set_ops/sym_diff.rs
@@ -23,38 +23,62 @@
 //! let first_layer_intervals = [
 //!     AbsoluteBoundPair::new(
 //!         AbsoluteFiniteBound::new(
-//!             "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!         ).to_start_bound(),
+//!             "2025-01-01 08:00:00[Europe/Oslo]"
+//!                 .parse::<Zoned>()?
+//!                 .timestamp(),
+//!         )
+//!         .to_start_bound(),
 //!         AbsoluteFiniteBound::new(
-//!             "2025-01-01 12:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!         ).to_end_bound(),
+//!             "2025-01-01 12:00:00[Europe/Oslo]"
+//!                 .parse::<Zoned>()?
+//!                 .timestamp(),
+//!         )
+//!         .to_end_bound(),
 //!     ),
 //!     AbsoluteBoundPair::new(
 //!         AbsoluteFiniteBound::new(
-//!             "2025-01-01 13:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!         ).to_start_bound(),
+//!             "2025-01-01 13:00:00[Europe/Oslo]"
+//!                 .parse::<Zoned>()?
+//!                 .timestamp(),
+//!         )
+//!         .to_start_bound(),
 //!         AbsoluteFiniteBound::new(
-//!             "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!         ).to_end_bound(),
+//!             "2025-01-01 16:00:00[Europe/Oslo]"
+//!                 .parse::<Zoned>()?
+//!                 .timestamp(),
+//!         )
+//!         .to_end_bound(),
 //!     ),
 //! ];
 //!
 //! let second_layer_intervals = [
 //!     AbsoluteBoundPair::new(
 //!         AbsoluteFiniteBound::new(
-//!             "2025-01-01 07:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!         ).to_start_bound(),
+//!             "2025-01-01 07:00:00[Europe/Oslo]"
+//!                 .parse::<Zoned>()?
+//!                 .timestamp(),
+//!         )
+//!         .to_start_bound(),
 //!         AbsoluteFiniteBound::new(
-//!             "2025-01-01 11:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!         ).to_end_bound(),
+//!             "2025-01-01 11:00:00[Europe/Oslo]"
+//!                 .parse::<Zoned>()?
+//!                 .timestamp(),
+//!         )
+//!         .to_end_bound(),
 //!     ),
 //!     AbsoluteBoundPair::new(
 //!         AbsoluteFiniteBound::new(
-//!             "2025-01-01 14:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!         ).to_start_bound(),
+//!             "2025-01-01 14:00:00[Europe/Oslo]"
+//!                 .parse::<Zoned>()?
+//!                 .timestamp(),
+//!         )
+//!         .to_start_bound(),
 //!         AbsoluteFiniteBound::new(
-//!             "2025-01-01 18:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!         ).to_end_bound(),
+//!             "2025-01-01 18:00:00[Europe/Oslo]"
+//!                 .parse::<Zoned>()?
+//!                 .timestamp(),
+//!         )
+//!         .to_end_bound(),
 //!     ),
 //! ];
 //!
@@ -68,39 +92,63 @@
 //!     vec![
 //!         AbsoluteBoundPair::new(
 //!             AbsoluteFiniteBound::new(
-//!                 "2025-01-01 07:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!             ).to_start_bound(),
+//!                 "2025-01-01 07:00:00[Europe/Oslo]"
+//!                     .parse::<Zoned>()?
+//!                     .timestamp(),
+//!             )
+//!             .to_start_bound(),
 //!             AbsoluteFiniteBound::new_with_inclusivity(
-//!                 "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+//!                 "2025-01-01 08:00:00[Europe/Oslo]"
+//!                     .parse::<Zoned>()?
+//!                     .timestamp(),
 //!                 BoundInclusivity::Exclusive,
-//!             ).to_end_bound(),
+//!             )
+//!             .to_end_bound(),
 //!         ),
 //!         AbsoluteBoundPair::new(
 //!             AbsoluteFiniteBound::new_with_inclusivity(
-//!                 "2025-01-01 11:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+//!                 "2025-01-01 11:00:00[Europe/Oslo]"
+//!                     .parse::<Zoned>()?
+//!                     .timestamp(),
 //!                 BoundInclusivity::Exclusive
-//!             ).to_start_bound(),
+//!             )
+//!             .to_start_bound(),
 //!             AbsoluteFiniteBound::new(
-//!                 "2025-01-01 12:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!             ).to_end_bound(),
+//!                 "2025-01-01 12:00:00[Europe/Oslo]"
+//!                     .parse::<Zoned>()?
+//!                     .timestamp(),
+//!             )
+//!             .to_end_bound(),
 //!         ),
 //!         AbsoluteBoundPair::new(
 //!             AbsoluteFiniteBound::new(
-//!                 "2025-01-01 13:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!             ).to_start_bound(),
+//!                 "2025-01-01 13:00:00[Europe/Oslo]"
+//!                     .parse::<Zoned>()?
+//!                     .timestamp(),
+//!             )
+//!             .to_start_bound(),
 //!             AbsoluteFiniteBound::new_with_inclusivity(
-//!                 "2025-01-01 14:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+//!                 "2025-01-01 14:00:00[Europe/Oslo]"
+//!                     .parse::<Zoned>()?
+//!                     .timestamp(),
 //!                 BoundInclusivity::Exclusive,
-//!             ).to_end_bound(),
+//!             )
+//!             .to_end_bound(),
 //!         ),
 //!         AbsoluteBoundPair::new(
 //!             AbsoluteFiniteBound::new_with_inclusivity(
-//!                 "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+//!                 "2025-01-01 16:00:00[Europe/Oslo]"
+//!                     .parse::<Zoned>()?
+//!                     .timestamp(),
 //!                 BoundInclusivity::Exclusive
-//!             ).to_start_bound(),
+//!             )
+//!             .to_start_bound(),
 //!             AbsoluteFiniteBound::new(
-//!                 "2025-01-01 18:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!             ).to_end_bound(),
+//!                 "2025-01-01 18:00:00[Europe/Oslo]"
+//!                     .parse::<Zoned>()?
+//!                     .timestamp(),
+//!             )
+//!             .to_end_bound(),
 //!         ),
 //!     ],
 //! );
@@ -133,8 +181,7 @@ where
     ///
     /// # Input requirements
     ///
-    /// 1. The iterator **must return continuous [state
-    ///    changes](LayeredBoundsStateChangeAtAbsoluteBound)**
+    /// 1. The iterator **must return continuous [state changes](LayeredBoundsStateChangeAtAbsoluteBound)**
     /// 2. The state changes **must be in chronological order**
     ///
     /// For more precision about requirement 1, _continuous state changes_ means
@@ -189,8 +236,8 @@ where
             loop {
                 let Some(next) = self.iter.next() else {
                     unreachable!(
-                        "The input requirements guarantee that the given iterator \
-                        cannot end on an active state such as `FirstLayer` or `SecondLayer`"
+                        "The input requirements guarantee that the given iterator cannot end on an active state such \
+                         as `FirstLayer` or `SecondLayer`"
                     );
                 };
 
@@ -205,10 +252,10 @@ where
 
                 let Some(end) = next.old_state_end() else {
                     unreachable!(
-                        "We can infer the guarantee that the state change following one that transitions \
-                        to `FirstLayer` or `SecondLayer` must contain an end to the old state, \
-                        given that the input requirements guarantee that the given iterator cannot end \
-                        on an active state such as `FirstLayer` or `SecondLayer`"
+                        "We can infer the guarantee that the state change following one that transitions to \
+                         `FirstLayer` or `SecondLayer` must contain an end to the old state, given that the input \
+                         requirements guarantee that the given iterator cannot end on an active state such as \
+                         `FirstLayer` or `SecondLayer`"
                     );
                 };
 
@@ -265,8 +312,7 @@ where
     ///
     /// # Input requirements
     ///
-    /// 1. The iterator **must return continuous [state
-    ///    changes](LayeredBoundsStateChangeAtRelativeBound)**
+    /// 1. The iterator **must return continuous [state changes](LayeredBoundsStateChangeAtRelativeBound)**
     /// 2. The state changes **must be in chronological order**
     ///
     /// For more precision about requirement 1, _continuous state changes_ means
@@ -321,8 +367,8 @@ where
             loop {
                 let Some(next) = self.iter.next() else {
                     unreachable!(
-                        "The input requirements guarantee that the given iterator \
-                        cannot end on an active state such as `FirstLayer` or `SecondLayer`"
+                        "The input requirements guarantee that the given iterator cannot end on an active state such \
+                         as `FirstLayer` or `SecondLayer`"
                     );
                 };
 
@@ -337,10 +383,10 @@ where
 
                 let Some(end) = next.old_state_end() else {
                     unreachable!(
-                        "We can infer the guarantee that the state change following one that transitions \
-                        to `FirstLayer` or `SecondLayer` must contain an end to the old state, \
-                        given that the input requirements guarantee that the given iterator cannot end \
-                        on an active state such as `FirstLayer` or `SecondLayer`"
+                        "We can infer the guarantee that the state change following one that transitions to \
+                         `FirstLayer` or `SecondLayer` must contain an end to the old state, given that the input \
+                         requirements guarantee that the given iterator cannot end on an active state such as \
+                         `FirstLayer` or `SecondLayer`"
                     );
                 };
 

--- a/src/iter/intervals/layered_bounds_set_ops/unite.rs
+++ b/src/iter/intervals/layered_bounds_set_ops/unite.rs
@@ -110,8 +110,7 @@ where
     ///
     /// # Input requirements
     ///
-    /// 1. The iterator **must return continuous [state
-    ///    changes](LayeredBoundsStateChangeAtAbsoluteBound)**
+    /// 1. The iterator **must return continuous [state changes](LayeredBoundsStateChangeAtAbsoluteBound)**
     /// 2. The state changes **must be in chronological order**
     ///
     /// For more precision about requirement 1, _continuous state changes_ means
@@ -163,9 +162,9 @@ where
             loop {
                 let Some(next) = self.iter.next() else {
                     unreachable!(
-                        "Since the input requirements state that the state changes need to be continuous, \
-                        and since we already stopped at a state that is not `NoLayers`, we can expect \
-                        the next elements to exist until a state change that transitions to `NoLayers` is returned"
+                        "Since the input requirements state that the state changes need to be continuous, and since \
+                         we already stopped at a state that is not `NoLayers`, we can expect the next elements to \
+                         exist until a state change that transitions to `NoLayers` is returned"
                     );
                 };
 
@@ -175,9 +174,9 @@ where
 
                 let Some(end) = next.old_state_end() else {
                     unreachable!(
-                        "Since the input requirements state that the state changes need to be continuous, \
-                        we can expect the next state change which transitions to `NoLayers` to contain \
-                        the change's old state's end"
+                        "Since the input requirements state that the state changes need to be continuous, we can \
+                         expect the next state change which transitions to `NoLayers` to contain the change's old \
+                         state's end"
                     );
                 };
 
@@ -237,8 +236,7 @@ where
     ///
     /// # Input requirements
     ///
-    /// 1. The iterator **must return continuous [state
-    ///    changes](LayeredBoundsStateChangeAtRelativeBound)**
+    /// 1. The iterator **must return continuous [state changes](LayeredBoundsStateChangeAtRelativeBound)**
     /// 2. The state changes **must be in chronological order**
     ///
     /// For more precision about requirement 1, _continuous state changes_ means
@@ -290,9 +288,9 @@ where
             loop {
                 let Some(next) = self.iter.next() else {
                     unreachable!(
-                        "Since the input requirements state that the state changes need to be continuous, \
-                        and since we already stopped at a state that is not `NoLayers`, we can expect \
-                        the next elements to exist until a state change that transitions to `NoLayers` is returned"
+                        "Since the input requirements state that the state changes need to be continuous, and since \
+                         we already stopped at a state that is not `NoLayers`, we can expect the next elements to \
+                         exist until a state change that transitions to `NoLayers` is returned"
                     );
                 };
 
@@ -302,9 +300,9 @@ where
 
                 let Some(end) = next.old_state_end() else {
                     unreachable!(
-                        "Since the input requirements state that the state changes need to be continuous, \
-                        we can expect the next state change which transitions to `NoLayers` to contain \
-                        the change's old state's end"
+                        "Since the input requirements state that the state changes need to be continuous, we can \
+                         expect the next state change which transitions to `NoLayers` to contain the change's old \
+                         state's end"
                     );
                 };
 

--- a/src/iter/intervals/set_ops/diff.rs
+++ b/src/iter/intervals/set_ops/diff.rs
@@ -13,23 +13,35 @@
 //! let intervals = [
 //!     AbsoluteBoundPair::new(
 //!         AbsoluteFiniteBound::new(
-//!             "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!         ).to_start_bound(),
+//!             "2025-01-01 08:00:00[Europe/Oslo]"
+//!                 .parse::<Zoned>()?
+//!                 .timestamp(),
+//!         )
+//!         .to_start_bound(),
 //!         AbsoluteEndBound::InfiniteFuture,
 //!     ),
 //!     AbsoluteBoundPair::new(
 //!         AbsoluteFiniteBound::new(
-//!             "2025-01-01 10:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!         ).to_start_bound(),
+//!             "2025-01-01 10:00:00[Europe/Oslo]"
+//!                 .parse::<Zoned>()?
+//!                 .timestamp(),
+//!         )
+//!         .to_start_bound(),
 //!         AbsoluteEndBound::InfiniteFuture,
 //!     ),
 //!     AbsoluteBoundPair::new(
 //!         AbsoluteFiniteBound::new(
-//!             "2025-01-01 12:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!         ).to_start_bound(),
+//!             "2025-01-01 12:00:00[Europe/Oslo]"
+//!                 .parse::<Zoned>()?
+//!                 .timestamp(),
+//!         )
+//!         .to_start_bound(),
 //!         AbsoluteFiniteBound::new(
-//!             "2025-01-01 14:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!         ).to_end_bound(),
+//!             "2025-01-01 14:00:00[Europe/Oslo]"
+//!                 .parse::<Zoned>()?
+//!                 .timestamp(),
+//!         )
+//!         .to_end_bound(),
 //!     ),
 //! ];
 //!
@@ -39,32 +51,52 @@
 //!         (
 //!             AbsoluteBoundPair::new(
 //!                 AbsoluteFiniteBound::new(
-//!                     "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!                 ).to_start_bound(),
+//!                     "2025-01-01 08:00:00[Europe/Oslo]"
+//!                         .parse::<Zoned>()?
+//!                         .timestamp(),
+//!                 )
+//!                 .to_start_bound(),
 //!                 AbsoluteFiniteBound::new_with_inclusivity(
-//!                     "2025-01-01 10:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+//!                     "2025-01-01 10:00:00[Europe/Oslo]"
+//!                         .parse::<Zoned>()?
+//!                         .timestamp(),
 //!                     BoundInclusivity::Exclusive,
-//!                 ).to_end_bound(),
-//!             ).to_emptiable(),
+//!                 )
+//!                 .to_end_bound(),
+//!             )
+//!             .to_emptiable(),
 //!             None,
 //!         ),
 //!         (
 //!             AbsoluteBoundPair::new(
 //!                 AbsoluteFiniteBound::new(
-//!                     "2025-01-01 10:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!                 ).to_start_bound(),
+//!                     "2025-01-01 10:00:00[Europe/Oslo]"
+//!                         .parse::<Zoned>()?
+//!                         .timestamp(),
+//!                 )
+//!                 .to_start_bound(),
 //!                 AbsoluteFiniteBound::new_with_inclusivity(
-//!                     "2025-01-01 12:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+//!                     "2025-01-01 12:00:00[Europe/Oslo]"
+//!                         .parse::<Zoned>()?
+//!                         .timestamp(),
 //!                     BoundInclusivity::Exclusive,
-//!                 ).to_end_bound(),
-//!             ).to_emptiable(),
-//!             Some(AbsoluteBoundPair::new(
-//!                 AbsoluteFiniteBound::new_with_inclusivity(
-//!                     "2025-01-01 14:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-//!                     BoundInclusivity::Exclusive,
-//!                 ).to_start_bound(),
-//!                 AbsoluteEndBound::InfiniteFuture,
-//!             ).to_emptiable()),
+//!                 )
+//!                 .to_end_bound(),
+//!             )
+//!             .to_emptiable(),
+//!             Some(
+//!                 AbsoluteBoundPair::new(
+//!                     AbsoluteFiniteBound::new_with_inclusivity(
+//!                         "2025-01-01 14:00:00[Europe/Oslo]"
+//!                             .parse::<Zoned>()?
+//!                             .timestamp(),
+//!                         BoundInclusivity::Exclusive,
+//!                     )
+//!                     .to_start_bound(),
+//!                     AbsoluteEndBound::InfiniteFuture,
+//!                 )
+//!                 .to_emptiable()
+//!             ),
 //!         ),
 //!     ],
 //! );

--- a/src/iter/intervals/united_bounds.rs
+++ b/src/iter/intervals/united_bounds.rs
@@ -69,9 +69,8 @@ where
     /// # Input requirements
     ///
     /// 1. The bounds **must be sorted chronologically**
-    /// 2. The bounds **must be paired**, that means there should be an equal
-    ///    amount of [`Start`](AbsoluteBound::Start)s and
-    ///    [`End`](AbsoluteBound::End)s.
+    /// 2. The bounds **must be paired**, that means there should be an equal amount of [`Start`](AbsoluteBound::Start)s
+    ///    and [`End`](AbsoluteBound::End)s.
     ///
     /// The responsibility of verifying those requirements are left to the
     /// caller in order to prevent double-processing.
@@ -115,38 +114,62 @@ where
     /// let first_layer_intervals = [
     ///     AbsoluteBoundPair::new(
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_start_bound(),
+    ///             "2025-01-01 08:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_start_bound(),
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 12:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_end_bound(),
+    ///             "2025-01-01 12:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_end_bound(),
     ///     ),
     ///     AbsoluteBoundPair::new(
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 13:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_start_bound(),
+    ///             "2025-01-01 13:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_start_bound(),
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_end_bound(),
+    ///             "2025-01-01 16:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_end_bound(),
     ///     ),
     /// ];
     ///
     /// let second_layer_intervals = [
     ///     AbsoluteBoundPair::new(
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 07:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_start_bound(),
+    ///             "2025-01-01 07:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_start_bound(),
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 11:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_end_bound(),
+    ///             "2025-01-01 11:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_end_bound(),
     ///     ),
     ///     AbsoluteBoundPair::new(
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 14:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_start_bound(),
+    ///             "2025-01-01 14:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_start_bound(),
     ///         AbsoluteFiniteBound::new(
-    ///             "2025-01-01 18:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    ///         ).to_end_bound(),
+    ///             "2025-01-01 18:00:00[Europe/Oslo]"
+    ///                 .parse::<Zoned>()?
+    ///                 .timestamp(),
+    ///         )
+    ///         .to_end_bound(),
     ///     ),
     /// ];
     ///
@@ -279,9 +302,8 @@ where
     /// # Input requirements
     ///
     /// 1. The bounds **must be sorted chronologically**
-    /// 2. The bounds **must be paired**, that means there should be an equal
-    ///    amount of [`Start`](RelativeBound::Start)s and
-    ///    [`End`](RelativeBound::End)s.
+    /// 2. The bounds **must be paired**, that means there should be an equal amount of [`Start`](RelativeBound::Start)s
+    ///    and [`End`](RelativeBound::End)s.
     ///
     /// The responsibility of verifying those requirements are left to the
     /// caller in order to prevent double-processing.
@@ -324,39 +346,23 @@ where
     /// # use periodical::iter::intervals::bounds::RelativeBoundsIteratorDispatcher;
     /// let first_layer_intervals = [
     ///     RelativeBoundPair::new(
-    ///         RelativeFiniteBound::new(
-    ///             SignedDuration::from_hours(8),
-    ///         ).to_start_bound(),
-    ///         RelativeFiniteBound::new(
-    ///             SignedDuration::from_hours(12),
-    ///         ).to_end_bound(),
+    ///         RelativeFiniteBound::new(SignedDuration::from_hours(8)).to_start_bound(),
+    ///         RelativeFiniteBound::new(SignedDuration::from_hours(12)).to_end_bound(),
     ///     ),
     ///     RelativeBoundPair::new(
-    ///         RelativeFiniteBound::new(
-    ///             SignedDuration::from_hours(13),
-    ///         ).to_start_bound(),
-    ///         RelativeFiniteBound::new(
-    ///             SignedDuration::from_hours(16),
-    ///         ).to_end_bound(),
+    ///         RelativeFiniteBound::new(SignedDuration::from_hours(13)).to_start_bound(),
+    ///         RelativeFiniteBound::new(SignedDuration::from_hours(16)).to_end_bound(),
     ///     ),
     /// ];
     ///
     /// let second_layer_intervals = [
     ///     RelativeBoundPair::new(
-    ///         RelativeFiniteBound::new(
-    ///             SignedDuration::from_hours(7),
-    ///         ).to_start_bound(),
-    ///         RelativeFiniteBound::new(
-    ///             SignedDuration::from_hours(11),
-    ///         ).to_end_bound(),
+    ///         RelativeFiniteBound::new(SignedDuration::from_hours(7)).to_start_bound(),
+    ///         RelativeFiniteBound::new(SignedDuration::from_hours(11)).to_end_bound(),
     ///     ),
     ///     RelativeBoundPair::new(
-    ///         RelativeFiniteBound::new(
-    ///             SignedDuration::from_hours(14),
-    ///         ).to_start_bound(),
-    ///         RelativeFiniteBound::new(
-    ///             SignedDuration::from_hours(18),
-    ///         ).to_end_bound(),
+    ///         RelativeFiniteBound::new(SignedDuration::from_hours(14)).to_start_bound(),
+    ///         RelativeFiniteBound::new(SignedDuration::from_hours(18)).to_end_bound(),
     ///     ),
     /// ];
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,10 +61,8 @@
 //!
 //! # Crate features
 //!
-//! - `serde` provides serialization and deserialization of all common
-//!   `periodical` structures
-//! - `arbitrary` provides a way of generating structured data from unstructured
-//!   data, useful for fuzzing
+//! - `serde` provides serialization and deserialization of all common `periodical` structures
+//! - `arbitrary` provides a way of generating structured data from unstructured data, useful for fuzzing
 
 pub mod intervals;
 pub mod iter;

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -98,18 +98,23 @@ impl PrecisionMode {
 /// # use std::time::Duration;
 /// # use jiff::Zoned;
 /// # use periodical::ops::{Precision, PrecisionMode};
-/// let round_to_nearest_five_mins = Precision::new(Duration::from_mins(5), PrecisionMode::ToNearest)?;
+/// let round_to_nearest_five_mins =
+///     Precision::new(Duration::from_mins(5), PrecisionMode::ToNearest)?;
 ///
 /// let two_minutes_after_eight = "2025-01-01 08:02:11[Europe/Oslo]".parse::<Zoned>()?;
 /// let fourteen_minutes_after_ten = "2025-01-01 10:14:21[Europe/Oslo]".parse::<Zoned>()?;
 ///
 /// assert_eq!(
-///     round_to_nearest_five_mins.precise_time(&two_minutes_after_eight)?.unambiguous()?,
+///     round_to_nearest_five_mins
+///         .precise_time(&two_minutes_after_eight)?
+///         .unambiguous()?,
 ///     "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?,
 /// );
 ///
 /// assert_eq!(
-///     round_to_nearest_five_mins.precise_time(&fourteen_minutes_after_ten)?.unambiguous()?,
+///     round_to_nearest_five_mins
+///         .precise_time(&fourteen_minutes_after_ten)?
+///         .unambiguous()?,
 ///     "2025-01-01 10:15:00[Europe/Oslo]".parse::<Zoned>()?,
 /// );
 /// # Ok::<(), Box<dyn Error>>(())
@@ -131,20 +136,16 @@ impl PrecisionMode {
 /// // 13 * 35m = 07:35
 /// // 14 * 35m = 08:10
 /// assert_eq!(
-///     round_up_every_35_mins.precise_time_with_base_time(
-///         &two_minutes_after_eight,
-///         &first_january_2025,
-///     )?,
+///     round_up_every_35_mins
+///         .precise_time_with_base_time(&two_minutes_after_eight, &first_january_2025,)?,
 ///     "2025-01-01 08:10:00[Europe/Oslo]".parse::<Zoned>()?,
 /// );
 ///
 /// // 17 * 35m = 09:55
 /// // 18 * 35m = 10:30
 /// assert_eq!(
-///     round_up_every_35_mins.precise_time_with_base_time(
-///         &fourteen_minutes_after_ten,
-///         &first_january_2025,
-///     )?,
+///     round_up_every_35_mins
+///         .precise_time_with_base_time(&fourteen_minutes_after_ten, &first_january_2025,)?,
 ///     "2025-01-01 10:30:00[Europe/Oslo]".parse::<Zoned>()?,
 /// );
 /// # Ok::<(), Box<dyn Error>>(())
@@ -448,10 +449,7 @@ impl Precision {
     /// let precision = Precision::new(Duration::from_mins(5), PrecisionMode::ToFuture)?;
     /// let time = "2026-01-01 08:45:00[Europe/Oslo]".parse::<Zoned>()?;
     ///
-    /// assert_eq!(
-    ///     precision.precise_time(&time)?.unambiguous()?,
-    ///     time,
-    /// );
+    /// assert_eq!(precision.precise_time(&time)?.unambiguous()?, time,);
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
     ///
@@ -804,7 +802,10 @@ impl<C> ComplementResult<C> {
     ///
     /// ```
     /// # use periodical::ops::ComplementResult;
-    /// assert_eq!(ComplementResult::<u8>::Split(10, 20).split(), Some((10, 20)));
+    /// assert_eq!(
+    ///     ComplementResult::<u8>::Split(10, 20).split(),
+    ///     Some((10, 20))
+    /// );
     /// assert_eq!(ComplementResult::<u8>::Single(10).split(), None);
     /// ```
     #[must_use]
@@ -984,10 +985,7 @@ impl<I> IntersectionResult<I> {
     ///     IntersectionResult::<u8>::Intersected(10).intersected(),
     ///     Some(10),
     /// );
-    /// assert_eq!(
-    ///     IntersectionResult::<u8>::Separate.intersected(),
-    ///     None,
-    /// );
+    /// assert_eq!(IntersectionResult::<u8>::Separate.intersected(), None,);
     /// ```
     #[must_use]
     pub fn intersected(self) -> Option<I> {
@@ -1128,7 +1126,10 @@ impl<D> DifferenceResult<D> {
     ///
     /// ```
     /// # use periodical::ops::DifferenceResult;
-    /// assert_eq!(DifferenceResult::<u8>::Split(10, 20).split(), Some((10, 20)));
+    /// assert_eq!(
+    ///     DifferenceResult::<u8>::Split(10, 20).split(),
+    ///     Some((10, 20))
+    /// );
     /// assert_eq!(DifferenceResult::<u8>::Single(10).split(), None);
     /// assert_eq!(DifferenceResult::<u8>::Separate.split(), None);
     /// ```
@@ -1267,10 +1268,7 @@ impl<D> SymmetricDifferenceResult<D> {
     ///     SymmetricDifferenceResult::<u8>::Split(10, 20).single(),
     ///     None,
     /// );
-    /// assert_eq!(
-    ///     SymmetricDifferenceResult::<u8>::Separate.single(),
-    ///     None,
-    /// );
+    /// assert_eq!(SymmetricDifferenceResult::<u8>::Separate.single(), None,);
     /// ```
     #[must_use]
     pub fn single(self) -> Option<D> {
@@ -1296,14 +1294,8 @@ impl<D> SymmetricDifferenceResult<D> {
     ///     SymmetricDifferenceResult::<u8>::Split(10, 20).split(),
     ///     Some((10, 20)),
     /// );
-    /// assert_eq!(
-    ///     SymmetricDifferenceResult::<u8>::Single(10).split(),
-    ///     None,
-    /// );
-    /// assert_eq!(
-    ///     SymmetricDifferenceResult::<u8>::Separate.split(),
-    ///     None,
-    /// );
+    /// assert_eq!(SymmetricDifferenceResult::<u8>::Single(10).split(), None,);
+    /// assert_eq!(SymmetricDifferenceResult::<u8>::Separate.split(), None,);
     /// ```
     #[must_use]
     pub fn split(self) -> Option<(D, D)> {


### PR DESCRIPTION
# Explanation

Code linting rules set in `rustfmt.toml` uses currently unstable options,
so instead of using the regular `cargo fmt` command, we use `cargo +nightly fmt`.

This requires adjusting the GitHub actions to download the nightly toolchain.
