### PR TITLE
Improved: `Emptiable` intervals and `Emptiable` trait impl

### DIFF
--- a/branch-changelog.md
+++ b/branch-changelog.md
@@ -1,1 +1,34 @@
 <!-- CLEAN THIS FILE AFTER CREATING PR -->
+
+# Changelog
+
+## Added
+
+- [ ] Implement `Emptiable` on every interval type
+- [x] Implement additional conversions on absolute emptiable types
+- [x] Implement additional conversions on relative emptiable types
+
+## Changed
+
+- [ ] Renamed `AbsoluteInterval::to_emptiable_interval` to `to_emptiable`
+- [ ] Renamed `RelativeInterval::to_emptiable_interval` to `to_emptiable`
+- [x] `EmptiableAbsoluteInterval` has the same semantics as `EmptiableAbsoluteBoundPair`:
+      two variants: `Bound`, `Empty`.
+- [x] `EmptiableRelativeInterval` has the same semantics as `EmptiableRelativeBoundPair`:
+      two variants: `Bound`, `Empty`.
+
+## Deprecated
+
+- Things you've marked as deprecated
+
+## Removed
+
+- Things you've removed
+
+## Fixed
+
+- Things you've fixed
+
+## Security
+
+- Vulnerabilities you've fixed (add relevant CVE and any other relevant info/links)

--- a/branch-changelog.md
+++ b/branch-changelog.md
@@ -4,7 +4,7 @@
 
 ## Added
 
-- [ ] Implement `Emptiable` on every interval type
+- [x] Implement `Emptiable` on every interval type
 - [x] Implement additional conversions on absolute emptiable types
 - [x] Implement additional conversions on relative emptiable types
 

--- a/branch-changelog.md
+++ b/branch-changelog.md
@@ -10,8 +10,8 @@
 
 ## Changed
 
-- [ ] Renamed `AbsoluteInterval::to_emptiable_interval` to `to_emptiable`
-- [ ] Renamed `RelativeInterval::to_emptiable_interval` to `to_emptiable`
+- [x] Renamed `AbsoluteInterval::to_emptiable_interval` to `to_emptiable`
+- [x] Renamed `RelativeInterval::to_emptiable_interval` to `to_emptiable`
 - [x] `EmptiableAbsoluteInterval` has the same semantics as `EmptiableAbsoluteBoundPair`:
       two variants: `Bound`, `Empty`.
 - [x] `EmptiableRelativeInterval` has the same semantics as `EmptiableRelativeBoundPair`:

--- a/src/intervals/absolute/bound_pair.rs
+++ b/src/intervals/absolute/bound_pair.rs
@@ -29,6 +29,7 @@ use crate::intervals::absolute::{
     prepare_absolute_bound_pair_for_interval_creation,
 };
 use crate::intervals::meta::{
+    BoundInclusivity,
     Duration as IntervalDuration,
     Epsilon,
     HasBoundInclusivity,
@@ -450,6 +451,41 @@ impl Ord for AbsoluteBoundPair {
         // absolute bound pair inside a BTreeSet, then if we use `range()`,
         // one can be considered out of the range when it shouldn't.
         self.start.cmp(&other.start)
+    }
+}
+
+/// Converts `(Option<Timestamp>, Option<Timestamp>)` into [`AbsoluteBoundPair`]
+///
+/// The first tuple element represents the start bound, the second element
+/// represents the end bound.
+impl From<(Option<Timestamp>, Option<Timestamp>)> for AbsoluteBoundPair {
+    fn from((start_opt, end_opt): (Option<Timestamp>, Option<Timestamp>)) -> Self {
+        let start = AbsoluteStartBound::from(start_opt);
+        let end = AbsoluteEndBound::from(end_opt);
+        AbsoluteBoundPair::new(start, end)
+    }
+}
+
+/// Converts `(Option<(Timestamp, BoundInclusivity)>, Option<(Timestamp, BoundInclusivity)>)`
+/// into [`AbsoluteBoundPair`]
+///
+/// The first tuple element represents the start bound, the second element
+/// represents the end bound.
+impl
+    From<(
+        Option<(Timestamp, BoundInclusivity)>,
+        Option<(Timestamp, BoundInclusivity)>,
+    )> for AbsoluteBoundPair
+{
+    fn from(
+        (start_opt, end_opt): (
+            Option<(Timestamp, BoundInclusivity)>,
+            Option<(Timestamp, BoundInclusivity)>,
+        ),
+    ) -> Self {
+        let start = AbsoluteStartBound::from(start_opt);
+        let end = AbsoluteEndBound::from(end_opt);
+        Self::new(start, end)
     }
 }
 

--- a/src/intervals/absolute/bound_pair.rs
+++ b/src/intervals/absolute/bound_pair.rs
@@ -31,6 +31,7 @@ use crate::intervals::absolute::{
 use crate::intervals::meta::{
     BoundInclusivity,
     Duration as IntervalDuration,
+    Emptiable,
     Epsilon,
     HasBoundInclusivity,
     HasDuration,
@@ -451,6 +452,12 @@ impl Ord for AbsoluteBoundPair {
         // absolute bound pair inside a BTreeSet, then if we use `range()`,
         // one can be considered out of the range when it shouldn't.
         self.start.cmp(&other.start)
+    }
+}
+
+impl Emptiable for AbsoluteBoundPair {
+    fn is_empty(&self) -> bool {
+        false
     }
 }
 

--- a/src/intervals/absolute/bounded_interval.rs
+++ b/src/intervals/absolute/bounded_interval.rs
@@ -638,7 +638,7 @@ impl BoundedAbsoluteInterval {
 
     /// Wraps the interval in [`EmptiableAbsoluteInterval`]
     #[must_use]
-    pub fn to_emptiable_interval(self) -> EmptiableAbsoluteInterval {
+    pub fn to_emptiable(self) -> EmptiableAbsoluteInterval {
         EmptiableAbsoluteInterval::from(self)
     }
 }

--- a/src/intervals/absolute/bounded_interval.rs
+++ b/src/intervals/absolute/bounded_interval.rs
@@ -33,6 +33,7 @@ use crate::intervals::absolute::{
 use crate::intervals::meta::{
     BoundInclusivity,
     Duration as IntervalDuration,
+    Emptiable,
     Epsilon,
     HasBoundInclusivity,
     HasDuration,
@@ -728,6 +729,12 @@ impl HasAbsoluteBoundPair for BoundedAbsoluteInterval {
 
     fn abs_end(&self) -> AbsoluteEndBound {
         AbsoluteFiniteBound::new_with_inclusivity(self.end, self.end_inclusivity).to_end_bound()
+    }
+}
+
+impl Emptiable for BoundedAbsoluteInterval {
+    fn is_empty(&self) -> bool {
+        false
     }
 }
 

--- a/src/intervals/absolute/emptiable_bound_pair.rs
+++ b/src/intervals/absolute/emptiable_bound_pair.rs
@@ -9,11 +9,13 @@ use std::time::Duration;
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
+use jiff::Timestamp;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::intervals::absolute::{AbsoluteBoundPair, AbsoluteEndBound, AbsoluteStartBound, HasAbsoluteBoundPair};
 use crate::intervals::meta::{
+    BoundInclusivity,
     Duration as IntervalDuration,
     Emptiable,
     Epsilon,
@@ -72,8 +74,8 @@ where
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum EmptiableAbsoluteBoundPair {
-    Empty,
     Bound(AbsoluteBoundPair),
+    Empty,
 }
 
 impl EmptiableAbsoluteBoundPair {
@@ -210,6 +212,67 @@ impl Ord for EmptiableAbsoluteBoundPair {
                 EmptiableAbsoluteBoundPair::Bound(other_abs_bound_pair),
             ) => og_abs_bound_pair.cmp(other_abs_bound_pair),
         }
+    }
+}
+
+/// Converts `(bool, AbsoluteStartBound, AbsoluteEndBound)` into [`EmptiableAbsoluteBoundPair`]
+///
+/// The second tuple element represents the start bound, the third element
+/// represents the end bound.
+///
+/// The first boolean indicates whether the interval is an empty interval.
+/// If it is set to `true`, the next elements are ignored altogether.
+impl From<(bool, AbsoluteStartBound, AbsoluteEndBound)> for EmptiableAbsoluteBoundPair {
+    fn from((is_empty, start, end): (bool, AbsoluteStartBound, AbsoluteEndBound)) -> Self {
+        if is_empty {
+            return Self::Empty;
+        }
+
+        Self::from(AbsoluteBoundPair::new(start, end))
+    }
+}
+
+/// Converts `(bool, Option<Timestamp>, Option<Timestamp>)` into
+/// [`EmptiableAbsoluteBoundPair`]
+///
+/// The second tuple element represents the start bound, the third element
+/// represents the end bound.
+///
+/// The first boolean indicates whether the interval is an empty interval.
+/// If it is set to `true`, the next elements are ignored altogether.
+impl From<(bool, Option<Timestamp>, Option<Timestamp>)> for EmptiableAbsoluteBoundPair {
+    fn from((is_empty, start_opt, end_opt): (bool, Option<Timestamp>, Option<Timestamp>)) -> Self {
+        let start = AbsoluteStartBound::from(start_opt);
+        let end = AbsoluteEndBound::from(end_opt);
+        Self::from((is_empty, start, end))
+    }
+}
+
+/// Converts `(bool, Option<(Timestamp, BoundInclusivity)>, Option<(Timestamp, BoundInclusivity)>)`
+/// into [`EmptiableAbsoluteBoundPair`]
+///
+/// The second tuple element represents the start bound, the third element
+/// represents the end bound.
+///
+/// The first boolean indicates whether the interval is an empty interval.
+/// If it is set to `true`, the next elements are ignored altogether.
+impl
+    From<(
+        bool,
+        Option<(Timestamp, BoundInclusivity)>,
+        Option<(Timestamp, BoundInclusivity)>,
+    )> for EmptiableAbsoluteBoundPair
+{
+    fn from(
+        (is_empty, start_opt, end_opt): (
+            bool,
+            Option<(Timestamp, BoundInclusivity)>,
+            Option<(Timestamp, BoundInclusivity)>,
+        ),
+    ) -> Self {
+        let start = AbsoluteStartBound::from(start_opt);
+        let end = AbsoluteEndBound::from(end_opt);
+        Self::from((is_empty, start, end))
     }
 }
 

--- a/src/intervals/absolute/emptiable_interval.rs
+++ b/src/intervals/absolute/emptiable_interval.rs
@@ -28,7 +28,6 @@ use serde::{Deserialize, Serialize};
 use crate::intervals::absolute::{
     AbsoluteBoundPair,
     AbsoluteEndBound,
-    AbsoluteFiniteBound,
     AbsoluteInterval,
     AbsoluteStartBound,
     BoundedAbsoluteInterval,
@@ -45,7 +44,6 @@ use crate::intervals::meta::{
     HasOpenness,
     HasRelativity,
     Interval,
-    OpeningDirection,
     Openness,
     Relativity,
 };
@@ -55,13 +53,49 @@ use crate::intervals::special::{EmptyInterval, UnboundedInterval};
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum EmptiableAbsoluteInterval {
-    Bounded(BoundedAbsoluteInterval),
-    HalfBounded(HalfBoundedAbsoluteInterval),
-    Unbounded(UnboundedInterval),
+    Bound(AbsoluteInterval),
     Empty(EmptyInterval),
 }
 
 impl EmptiableAbsoluteInterval {
+    /// Returns the content of the [`Bound`](EmptiableAbsoluteInterval::Bound) variant
+    ///
+    /// Consumes `self` and puts the content of the [`Bound`](EmptiableAbsoluteInterval::Bound) variant
+    /// in an [`Option`]. If instead `self` is another variant, the method returns [`None`]
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::error::Error;
+    /// # use jiff::Zoned;
+    /// # use periodical::intervals::absolute::{
+    /// #     EmptiableAbsoluteInterval, AbsoluteInterval, BoundedAbsoluteInterval,
+    /// # };
+    /// # use periodical::intervals::special::EmptyInterval;
+    /// let interval = BoundedAbsoluteInterval::new(
+    ///     "2026-01-01 08:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
+    ///     "2026-01-01 16:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
+    /// );
+    ///
+    /// let bound_emptiable_interval = EmptiableAbsoluteInterval::Bound(interval.clone());
+    /// let empty_emptiable_interval = EmptiableAbsoluteInterval::Empty(EmptyInterval);
+    ///
+    /// assert_eq!(bound_emptiable_interval.bound(), Some(interval));
+    /// assert_eq!(empty_emptiable_interval.bound(), None);
+    /// # Ok::<(), Box<dyn Error>>(())
+    /// ```
+    #[must_use]
+    pub fn bound(self) -> Option<AbsoluteInterval> {
+        match self {
+            Self::Bound(interval) => Some(interval),
+            Self::Empty(_) => None,
+        }
+    }
+
     /// Compares two [`AbsoluteInterval`], but if they have the same start,
     /// order by decreasing length
     ///
@@ -90,10 +124,8 @@ impl Interval for EmptiableAbsoluteInterval {}
 impl HasDuration for EmptiableAbsoluteInterval {
     fn duration(&self) -> IntervalDuration {
         match self {
-            Self::Bounded(interval) => interval.duration(),
-            Self::HalfBounded(interval) => interval.duration(),
-            Self::Unbounded(interval) => interval.duration(),
-            Self::Empty(interval) => interval.duration(),
+            Self::Bound(interval) => interval.duration(),
+            Self::Empty(empty) => empty.duration(),
         }
     }
 }
@@ -101,10 +133,8 @@ impl HasDuration for EmptiableAbsoluteInterval {
 impl HasRelativity for EmptiableAbsoluteInterval {
     fn relativity(&self) -> Relativity {
         match self {
-            Self::Bounded(interval) => interval.relativity(),
-            Self::HalfBounded(interval) => interval.relativity(),
-            Self::Unbounded(interval) => interval.relativity(),
-            Self::Empty(interval) => interval.relativity(),
+            Self::Bound(interval) => interval.relativity(),
+            Self::Empty(empty) => empty.relativity(),
         }
     }
 }
@@ -112,10 +142,8 @@ impl HasRelativity for EmptiableAbsoluteInterval {
 impl HasOpenness for EmptiableAbsoluteInterval {
     fn openness(&self) -> Openness {
         match self {
-            Self::Bounded(interval) => interval.openness(),
-            Self::HalfBounded(interval) => interval.openness(),
-            Self::Unbounded(interval) => interval.openness(),
-            Self::Empty(interval) => interval.openness(),
+            Self::Bound(interval) => interval.openness(),
+            Self::Empty(empty) => empty.openness(),
         }
     }
 }
@@ -123,27 +151,21 @@ impl HasOpenness for EmptiableAbsoluteInterval {
 impl HasEmptiableAbsoluteBoundPair for EmptiableAbsoluteInterval {
     fn emptiable_abs_bound_pair(&self) -> EmptiableAbsoluteBoundPair {
         match self {
-            Self::Bounded(interval) => EmptiableAbsoluteBoundPair::from(interval.abs_bound_pair()),
-            Self::HalfBounded(interval) => EmptiableAbsoluteBoundPair::from(interval.abs_bound_pair()),
-            Self::Unbounded(interval) => EmptiableAbsoluteBoundPair::from(interval.abs_bound_pair()),
+            Self::Bound(interval) => EmptiableAbsoluteBoundPair::from(interval.abs_bound_pair()),
             Self::Empty(interval) => interval.emptiable_abs_bound_pair(),
         }
     }
 
     fn partial_abs_start(&self) -> Option<AbsoluteStartBound> {
         match self {
-            Self::Bounded(interval) => interval.partial_abs_start(),
-            Self::HalfBounded(interval) => interval.partial_abs_start(),
-            Self::Unbounded(interval) => interval.partial_abs_start(),
+            Self::Bound(interval) => interval.partial_abs_start(),
             Self::Empty(interval) => interval.partial_abs_start(),
         }
     }
 
     fn partial_abs_end(&self) -> Option<AbsoluteEndBound> {
         match self {
-            Self::Bounded(interval) => interval.partial_abs_end(),
-            Self::HalfBounded(interval) => interval.partial_abs_end(),
-            Self::Unbounded(interval) => interval.partial_abs_end(),
+            Self::Bound(interval) => interval.partial_abs_end(),
             Self::Empty(interval) => interval.partial_abs_end(),
         }
     }
@@ -169,19 +191,19 @@ impl Ord for EmptiableAbsoluteInterval {
 
 impl From<BoundedAbsoluteInterval> for EmptiableAbsoluteInterval {
     fn from(value: BoundedAbsoluteInterval) -> Self {
-        EmptiableAbsoluteInterval::Bounded(value)
+        EmptiableAbsoluteInterval::Bound(value.to_interval())
     }
 }
 
 impl From<HalfBoundedAbsoluteInterval> for EmptiableAbsoluteInterval {
     fn from(value: HalfBoundedAbsoluteInterval) -> Self {
-        EmptiableAbsoluteInterval::HalfBounded(value)
+        EmptiableAbsoluteInterval::Bound(value.to_interval())
     }
 }
 
 impl From<UnboundedInterval> for EmptiableAbsoluteInterval {
     fn from(value: UnboundedInterval) -> Self {
-        EmptiableAbsoluteInterval::Unbounded(value)
+        EmptiableAbsoluteInterval::Bound(AbsoluteInterval::Unbounded(value))
     }
 }
 
@@ -193,110 +215,22 @@ impl From<EmptyInterval> for EmptiableAbsoluteInterval {
 
 impl From<AbsoluteBoundPair> for EmptiableAbsoluteInterval {
     fn from(value: AbsoluteBoundPair) -> Self {
-        type StartB = AbsoluteStartBound;
-        type EndB = AbsoluteEndBound;
-
-        match (value.abs_start(), value.abs_end()) {
-            (StartB::InfinitePast, EndB::InfiniteFuture) => EmptiableAbsoluteInterval::Unbounded(UnboundedInterval),
-            (
-                StartB::InfinitePast,
-                EndB::Finite(AbsoluteFiniteBound {
-                    time,
-                    inclusivity,
-                }),
-            ) => EmptiableAbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new_with_inclusivity(
-                time,
-                inclusivity,
-                OpeningDirection::ToPast,
-            )),
-            (
-                StartB::Finite(AbsoluteFiniteBound {
-                    time,
-                    inclusivity,
-                }),
-                EndB::InfiniteFuture,
-            ) => EmptiableAbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new_with_inclusivity(
-                time,
-                inclusivity,
-                OpeningDirection::ToFuture,
-            )),
-            (
-                StartB::Finite(AbsoluteFiniteBound {
-                    time: start_time,
-                    inclusivity: start_inclusivity,
-                }),
-                EndB::Finite(AbsoluteFiniteBound {
-                    time: end_time,
-                    inclusivity: end_inclusivity,
-                }),
-            ) => EmptiableAbsoluteInterval::Bounded(BoundedAbsoluteInterval::unchecked_new_with_inclusivity(
-                start_time,
-                start_inclusivity,
-                end_time,
-                end_inclusivity,
-            )),
-        }
+        EmptiableAbsoluteInterval::Bound(AbsoluteInterval::from(value))
     }
 }
 
 impl From<EmptiableAbsoluteBoundPair> for EmptiableAbsoluteInterval {
     fn from(value: EmptiableAbsoluteBoundPair) -> Self {
-        type StartB = AbsoluteStartBound;
-        type EndB = AbsoluteEndBound;
-
-        match (value.partial_abs_start(), value.partial_abs_end()) {
-            (None, _) | (_, None) => EmptiableAbsoluteInterval::Empty(EmptyInterval),
-            (Some(StartB::InfinitePast), Some(EndB::InfiniteFuture)) => {
-                EmptiableAbsoluteInterval::Unbounded(UnboundedInterval)
-            },
-            (
-                Some(StartB::InfinitePast),
-                Some(EndB::Finite(AbsoluteFiniteBound {
-                    time,
-                    inclusivity,
-                })),
-            ) => EmptiableAbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new_with_inclusivity(
-                time,
-                inclusivity,
-                OpeningDirection::ToPast,
-            )),
-            (
-                Some(StartB::Finite(AbsoluteFiniteBound {
-                    time,
-                    inclusivity,
-                })),
-                Some(EndB::InfiniteFuture),
-            ) => EmptiableAbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new_with_inclusivity(
-                time,
-                inclusivity,
-                OpeningDirection::ToFuture,
-            )),
-            (
-                Some(StartB::Finite(AbsoluteFiniteBound {
-                    time: start_time,
-                    inclusivity: start_inclusivity,
-                })),
-                Some(EndB::Finite(AbsoluteFiniteBound {
-                    time: end_time,
-                    inclusivity: end_inclusivity,
-                })),
-            ) => EmptiableAbsoluteInterval::Bounded(BoundedAbsoluteInterval::unchecked_new_with_inclusivity(
-                start_time,
-                start_inclusivity,
-                end_time,
-                end_inclusivity,
-            )),
+        match value.bound() {
+            Some(abs_bound_pair) => Self::from(abs_bound_pair),
+            None => Self::Empty(EmptyInterval),
         }
     }
 }
 
 impl From<AbsoluteInterval> for EmptiableAbsoluteInterval {
     fn from(value: AbsoluteInterval) -> Self {
-        match value {
-            AbsoluteInterval::Bounded(bounded) => EmptiableAbsoluteInterval::Bounded(bounded),
-            AbsoluteInterval::HalfBounded(half_bounded) => EmptiableAbsoluteInterval::HalfBounded(half_bounded),
-            AbsoluteInterval::Unbounded(unbounded) => EmptiableAbsoluteInterval::Unbounded(unbounded),
-        }
+        Self::Bound(value)
     }
 }
 
@@ -306,17 +240,7 @@ impl From<AbsoluteInterval> for EmptiableAbsoluteInterval {
 /// represents the end bound.
 impl From<(Option<Timestamp>, Option<Timestamp>)> for EmptiableAbsoluteInterval {
     fn from((from_opt, to_opt): (Option<Timestamp>, Option<Timestamp>)) -> Self {
-        match (from_opt, to_opt) {
-            (Some(from), Some(to)) => EmptiableAbsoluteInterval::Bounded(BoundedAbsoluteInterval::new(from, to)),
-            (Some(from), None) => EmptiableAbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new(
-                from,
-                OpeningDirection::ToFuture,
-            )),
-            (None, Some(to)) => {
-                EmptiableAbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new(to, OpeningDirection::ToPast))
-            },
-            (None, None) => EmptiableAbsoluteInterval::Unbounded(UnboundedInterval),
-        }
+        Self::from(AbsoluteBoundPair::from((from_opt, to_opt)).to_emptiable())
     }
 }
 
@@ -332,28 +256,29 @@ impl
     )> for EmptiableAbsoluteInterval
 {
     fn from(
-        (start_opt, end_opt): (
+        value: (
             Option<(Timestamp, BoundInclusivity)>,
             Option<(Timestamp, BoundInclusivity)>,
         ),
     ) -> Self {
-        match (start_opt, end_opt) {
-            (Some((start, start_inclusivity)), Some((end, end_inclusivity))) => EmptiableAbsoluteInterval::Bounded(
-                BoundedAbsoluteInterval::new_with_inclusivity(start, start_inclusivity, end, end_inclusivity),
-            ),
-            (Some((start, start_inclusivity)), None) => EmptiableAbsoluteInterval::HalfBounded(
-                HalfBoundedAbsoluteInterval::new_with_inclusivity(start, start_inclusivity, OpeningDirection::ToFuture),
-            ),
-            (None, Some((end, end_inclusivity))) => EmptiableAbsoluteInterval::HalfBounded(
-                HalfBoundedAbsoluteInterval::new_with_inclusivity(end, end_inclusivity, OpeningDirection::ToPast),
-            ),
-            (None, None) => EmptiableAbsoluteInterval::Unbounded(UnboundedInterval),
-        }
+        Self::from(AbsoluteBoundPair::from(value))
     }
 }
 
-/// Converts `(bool, Option<Timestamp>, Option<Timestamp>)` into
-/// [`AbsoluteInterval`]
+/// Converts `(bool, AbsoluteStartBound, AbsoluteEndBound)` into [`EmptiableAbsoluteInterval`]
+///
+/// The second tuple element represents the start bound, the third element
+/// represents the end bound.
+///
+/// The first boolean indicates whether the interval is an empty interval.
+/// If it is set to `true`, the next elements are ignored altogether.
+impl From<(bool, AbsoluteStartBound, AbsoluteEndBound)> for EmptiableAbsoluteInterval {
+    fn from(value: (bool, AbsoluteStartBound, AbsoluteEndBound)) -> Self {
+        Self::from(EmptiableAbsoluteBoundPair::from(value))
+    }
+}
+
+/// Converts `(bool, Option<Timestamp>, Option<Timestamp>)` into [`AbsoluteInterval`]
 ///
 /// The second tuple element represents the start bound, the third element
 /// represents the end bound.
@@ -361,22 +286,8 @@ impl
 /// The first boolean indicates whether the interval is an [`EmptyInterval`].
 /// If it is set to `true`, the next elements are ignored altogether.
 impl From<(bool, Option<Timestamp>, Option<Timestamp>)> for EmptiableAbsoluteInterval {
-    fn from((is_empty, from_opt, to_opt): (bool, Option<Timestamp>, Option<Timestamp>)) -> Self {
-        if is_empty {
-            return EmptiableAbsoluteInterval::Empty(EmptyInterval);
-        }
-
-        match (from_opt, to_opt) {
-            (Some(from), Some(to)) => EmptiableAbsoluteInterval::Bounded(BoundedAbsoluteInterval::new(from, to)),
-            (Some(from), None) => EmptiableAbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new(
-                from,
-                OpeningDirection::ToFuture,
-            )),
-            (None, Some(to)) => {
-                EmptiableAbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new(to, OpeningDirection::ToPast))
-            },
-            (None, None) => EmptiableAbsoluteInterval::Unbounded(UnboundedInterval),
-        }
+    fn from(value: (bool, Option<Timestamp>, Option<Timestamp>)) -> Self {
+        Self::from(EmptiableAbsoluteBoundPair::from(value))
     }
 }
 
@@ -396,28 +307,13 @@ impl
     )> for EmptiableAbsoluteInterval
 {
     fn from(
-        (is_empty, start_opt, end_opt): (
+        value: (
             bool,
             Option<(Timestamp, BoundInclusivity)>,
             Option<(Timestamp, BoundInclusivity)>,
         ),
     ) -> Self {
-        if is_empty {
-            return EmptiableAbsoluteInterval::Empty(EmptyInterval);
-        }
-
-        match (start_opt, end_opt) {
-            (Some((start, start_inclusivity)), Some((end, end_inclusivity))) => EmptiableAbsoluteInterval::Bounded(
-                BoundedAbsoluteInterval::new_with_inclusivity(start, start_inclusivity, end, end_inclusivity),
-            ),
-            (Some((start, start_inclusivity)), None) => EmptiableAbsoluteInterval::HalfBounded(
-                HalfBoundedAbsoluteInterval::new_with_inclusivity(start, start_inclusivity, OpeningDirection::ToFuture),
-            ),
-            (None, Some((end, end_inclusivity))) => EmptiableAbsoluteInterval::HalfBounded(
-                HalfBoundedAbsoluteInterval::new_with_inclusivity(end, end_inclusivity, OpeningDirection::ToPast),
-            ),
-            (None, None) => EmptiableAbsoluteInterval::Unbounded(UnboundedInterval),
-        }
+        Self::from(EmptiableAbsoluteBoundPair::from(value))
     }
 }
 

--- a/src/intervals/absolute/emptiable_interval.rs
+++ b/src/intervals/absolute/emptiable_interval.rs
@@ -79,7 +79,8 @@ impl EmptiableAbsoluteInterval {
     ///     "2026-01-01 16:00:00[Europe/Oslo]"
     ///         .parse::<Zoned>()?
     ///         .timestamp(),
-    /// ).to_interval();
+    /// )
+    /// .to_interval();
     ///
     /// let bound_emptiable_interval = EmptiableAbsoluteInterval::Bound(interval.clone());
     /// let empty_emptiable_interval = EmptiableAbsoluteInterval::Empty(EmptyInterval);

--- a/src/intervals/absolute/emptiable_interval.rs
+++ b/src/intervals/absolute/emptiable_interval.rs
@@ -79,7 +79,7 @@ impl EmptiableAbsoluteInterval {
     ///     "2026-01-01 16:00:00[Europe/Oslo]"
     ///         .parse::<Zoned>()?
     ///         .timestamp(),
-    /// );
+    /// ).to_interval();
     ///
     /// let bound_emptiable_interval = EmptiableAbsoluteInterval::Bound(interval.clone());
     /// let empty_emptiable_interval = EmptiableAbsoluteInterval::Empty(EmptyInterval);

--- a/src/intervals/absolute/emptiable_interval_tests.rs
+++ b/src/intervals/absolute/emptiable_interval_tests.rs
@@ -26,11 +26,13 @@ fn from_absolute_bounds() -> Result<(), Box<dyn Error>> {
             )),
             AbsoluteEndBound::InfiniteFuture,
         )),
-        EmptiableAbsoluteInterval::Bound(AbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new_with_inclusivity(
-            "2025-01-01 00:00:00Z".parse::<Timestamp>()?,
-            BoundInclusivity::Exclusive,
-            OpeningDirection::ToFuture,
-        ))),
+        EmptiableAbsoluteInterval::Bound(AbsoluteInterval::HalfBounded(
+            HalfBoundedAbsoluteInterval::new_with_inclusivity(
+                "2025-01-01 00:00:00Z".parse::<Timestamp>()?,
+                BoundInclusivity::Exclusive,
+                OpeningDirection::ToFuture,
+            )
+        )),
     );
 
     Ok(())
@@ -46,11 +48,13 @@ fn from_emptiable_absolute_bounds() -> Result<(), Box<dyn Error>> {
             )),
             AbsoluteEndBound::InfiniteFuture,
         ))),
-        EmptiableAbsoluteInterval::Bound(AbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new_with_inclusivity(
-            "2025-01-01 00:00:00Z".parse::<Timestamp>()?,
-            BoundInclusivity::Exclusive,
-            OpeningDirection::ToFuture,
-        ))),
+        EmptiableAbsoluteInterval::Bound(AbsoluteInterval::HalfBounded(
+            HalfBoundedAbsoluteInterval::new_with_inclusivity(
+                "2025-01-01 00:00:00Z".parse::<Timestamp>()?,
+                BoundInclusivity::Exclusive,
+                OpeningDirection::ToFuture,
+            )
+        )),
     );
 
     Ok(())
@@ -90,12 +94,14 @@ fn from_opt_datetime_bound_inclusivity_pairs() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Exclusive
             )),
         )),
-        EmptiableAbsoluteInterval::Bound(AbsoluteInterval::Bounded(BoundedAbsoluteInterval::new_with_inclusivity(
-            "2025-01-01 00:00:00Z".parse::<Timestamp>()?,
-            BoundInclusivity::Exclusive,
-            "2025-01-02 00:00:00Z".parse::<Timestamp>()?,
-            BoundInclusivity::Exclusive,
-        ))),
+        EmptiableAbsoluteInterval::Bound(AbsoluteInterval::Bounded(
+            BoundedAbsoluteInterval::new_with_inclusivity(
+                "2025-01-01 00:00:00Z".parse::<Timestamp>()?,
+                BoundInclusivity::Exclusive,
+                "2025-01-02 00:00:00Z".parse::<Timestamp>()?,
+                BoundInclusivity::Exclusive,
+            )
+        )),
     );
 
     Ok(())
@@ -112,7 +118,11 @@ fn from_bool_and_two_opt_datetime_empty() {
 #[test]
 fn from_bool_and_two_opt_datetime() -> Result<(), Box<dyn Error>> {
     assert_eq!(
-        EmptiableAbsoluteInterval::from((false, Some("2025-01-01 00:00:00Z".parse::<Timestamp>()?), Some("2025-01-02 00:00:00Z".parse::<Timestamp>()?),)),
+        EmptiableAbsoluteInterval::from((
+            false,
+            Some("2025-01-01 00:00:00Z".parse::<Timestamp>()?),
+            Some("2025-01-02 00:00:00Z".parse::<Timestamp>()?),
+        )),
         EmptiableAbsoluteInterval::Bound(AbsoluteInterval::Bounded(BoundedAbsoluteInterval::new(
             "2025-01-01 00:00:00Z".parse::<Timestamp>()?,
             "2025-01-02 00:00:00Z".parse::<Timestamp>()?
@@ -148,12 +158,14 @@ fn from_bool_and_two_opt_datetime_bound_inclusivity() -> Result<(), Box<dyn Erro
                 BoundInclusivity::Exclusive
             )),
         )),
-        EmptiableAbsoluteInterval::Bound(AbsoluteInterval::Bounded(BoundedAbsoluteInterval::new_with_inclusivity(
-            "2025-01-01 00:00:00Z".parse::<Timestamp>()?,
-            BoundInclusivity::Exclusive,
-            "2025-01-02 00:00:00Z".parse::<Timestamp>()?,
-            BoundInclusivity::Exclusive,
-        ))),
+        EmptiableAbsoluteInterval::Bound(AbsoluteInterval::Bounded(
+            BoundedAbsoluteInterval::new_with_inclusivity(
+                "2025-01-01 00:00:00Z".parse::<Timestamp>()?,
+                BoundInclusivity::Exclusive,
+                "2025-01-02 00:00:00Z".parse::<Timestamp>()?,
+                BoundInclusivity::Exclusive,
+            )
+        )),
     );
 
     Ok(())

--- a/src/intervals/absolute/emptiable_interval_tests.rs
+++ b/src/intervals/absolute/emptiable_interval_tests.rs
@@ -7,6 +7,7 @@ use crate::intervals::absolute::{
     AbsoluteBoundPair,
     AbsoluteEndBound,
     AbsoluteFiniteBound,
+    AbsoluteInterval,
     AbsoluteStartBound,
     BoundedAbsoluteInterval,
     EmptiableAbsoluteBoundPair,
@@ -25,11 +26,11 @@ fn from_absolute_bounds() -> Result<(), Box<dyn Error>> {
             )),
             AbsoluteEndBound::InfiniteFuture,
         )),
-        EmptiableAbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new_with_inclusivity(
+        EmptiableAbsoluteInterval::Bound(AbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new_with_inclusivity(
             "2025-01-01 00:00:00Z".parse::<Timestamp>()?,
             BoundInclusivity::Exclusive,
             OpeningDirection::ToFuture,
-        )),
+        ))),
     );
 
     Ok(())
@@ -45,11 +46,11 @@ fn from_emptiable_absolute_bounds() -> Result<(), Box<dyn Error>> {
             )),
             AbsoluteEndBound::InfiniteFuture,
         ))),
-        EmptiableAbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new_with_inclusivity(
+        EmptiableAbsoluteInterval::Bound(AbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new_with_inclusivity(
             "2025-01-01 00:00:00Z".parse::<Timestamp>()?,
             BoundInclusivity::Exclusive,
             OpeningDirection::ToFuture,
-        )),
+        ))),
     );
 
     Ok(())
@@ -59,7 +60,7 @@ fn from_emptiable_absolute_bounds() -> Result<(), Box<dyn Error>> {
 fn from_opt_datetime_pair_unbounded() {
     assert_eq!(
         <EmptiableAbsoluteInterval as From<(Option<Timestamp>, Option<Timestamp>)>>::from((None, None)),
-        EmptiableAbsoluteInterval::Unbounded(UnboundedInterval),
+        EmptiableAbsoluteInterval::Bound(AbsoluteInterval::Unbounded(UnboundedInterval)),
     );
 }
 
@@ -67,10 +68,10 @@ fn from_opt_datetime_pair_unbounded() {
 fn from_opt_datetime_pair_half_bounded() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         EmptiableAbsoluteInterval::from((None, Some("2025-01-01 00:00:00Z".parse::<Timestamp>()?))),
-        EmptiableAbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new(
+        EmptiableAbsoluteInterval::Bound(AbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new(
             "2025-01-01 00:00:00Z".parse::<Timestamp>()?,
             OpeningDirection::ToPast,
-        )),
+        ))),
     );
 
     Ok(())
@@ -89,12 +90,12 @@ fn from_opt_datetime_bound_inclusivity_pairs() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Exclusive
             )),
         )),
-        EmptiableAbsoluteInterval::Bounded(BoundedAbsoluteInterval::new_with_inclusivity(
+        EmptiableAbsoluteInterval::Bound(AbsoluteInterval::Bounded(BoundedAbsoluteInterval::new_with_inclusivity(
             "2025-01-01 00:00:00Z".parse::<Timestamp>()?,
             BoundInclusivity::Exclusive,
             "2025-01-02 00:00:00Z".parse::<Timestamp>()?,
             BoundInclusivity::Exclusive,
-        )),
+        ))),
     );
 
     Ok(())
@@ -111,15 +112,11 @@ fn from_bool_and_two_opt_datetime_empty() {
 #[test]
 fn from_bool_and_two_opt_datetime() -> Result<(), Box<dyn Error>> {
     assert_eq!(
-        EmptiableAbsoluteInterval::from((
-            false,
-            Some("2025-01-01 00:00:00Z".parse::<Timestamp>()?),
-            Some("2025-01-02 00:00:00Z".parse::<Timestamp>()?),
-        )),
-        EmptiableAbsoluteInterval::Bounded(BoundedAbsoluteInterval::new(
+        EmptiableAbsoluteInterval::from((false, Some("2025-01-01 00:00:00Z".parse::<Timestamp>()?), Some("2025-01-02 00:00:00Z".parse::<Timestamp>()?),)),
+        EmptiableAbsoluteInterval::Bound(AbsoluteInterval::Bounded(BoundedAbsoluteInterval::new(
             "2025-01-01 00:00:00Z".parse::<Timestamp>()?,
             "2025-01-02 00:00:00Z".parse::<Timestamp>()?
-        )),
+        ))),
     );
 
     Ok(())
@@ -151,12 +148,12 @@ fn from_bool_and_two_opt_datetime_bound_inclusivity() -> Result<(), Box<dyn Erro
                 BoundInclusivity::Exclusive
             )),
         )),
-        EmptiableAbsoluteInterval::Bounded(BoundedAbsoluteInterval::new_with_inclusivity(
+        EmptiableAbsoluteInterval::Bound(AbsoluteInterval::Bounded(BoundedAbsoluteInterval::new_with_inclusivity(
             "2025-01-01 00:00:00Z".parse::<Timestamp>()?,
             BoundInclusivity::Exclusive,
             "2025-01-02 00:00:00Z".parse::<Timestamp>()?,
             BoundInclusivity::Exclusive,
-        )),
+        ))),
     );
 
     Ok(())

--- a/src/intervals/absolute/end_bound.rs
+++ b/src/intervals/absolute/end_bound.rs
@@ -259,6 +259,26 @@ impl From<AbsoluteFiniteBound> for AbsoluteEndBound {
     }
 }
 
+impl From<Option<Timestamp>> for AbsoluteEndBound {
+    fn from(value: Option<Timestamp>) -> Self {
+        match value {
+            Some(timestamp) => Self::Finite(AbsoluteFiniteBound::from(timestamp)),
+            None => Self::InfiniteFuture,
+        }
+    }
+}
+
+impl From<Option<(Timestamp, BoundInclusivity)>> for AbsoluteEndBound {
+    fn from(value: Option<(Timestamp, BoundInclusivity)>) -> Self {
+        match value {
+            Some((timestamp, inclusivity)) => {
+                Self::Finite(AbsoluteFiniteBound::new_with_inclusivity(timestamp, inclusivity))
+            },
+            None => Self::InfiniteFuture,
+        }
+    }
+}
+
 impl From<Bound<Timestamp>> for AbsoluteEndBound {
     fn from(bound: Bound<Timestamp>) -> Self {
         match bound {

--- a/src/intervals/absolute/half_bounded_interval.rs
+++ b/src/intervals/absolute/half_bounded_interval.rs
@@ -30,6 +30,7 @@ use crate::intervals::absolute::{
 use crate::intervals::meta::{
     BoundInclusivity,
     Duration as IntervalDuration,
+    Emptiable,
     HasBoundInclusivity,
     HasDuration,
     HasOpenness,
@@ -362,6 +363,12 @@ impl HasAbsoluteBoundPair for HalfBoundedAbsoluteInterval {
             },
             OpeningDirection::ToFuture => AbsoluteEndBound::InfiniteFuture,
         }
+    }
+}
+
+impl Emptiable for HalfBoundedAbsoluteInterval {
+    fn is_empty(&self) -> bool {
+        false
     }
 }
 

--- a/src/intervals/absolute/half_bounded_interval.rs
+++ b/src/intervals/absolute/half_bounded_interval.rs
@@ -294,7 +294,7 @@ impl HalfBoundedAbsoluteInterval {
 
     /// Wraps the interval in [`EmptiableAbsoluteInterval`]
     #[must_use]
-    pub fn to_emptiable_interval(self) -> EmptiableAbsoluteInterval {
+    pub fn to_emptiable(self) -> EmptiableAbsoluteInterval {
         EmptiableAbsoluteInterval::from(self)
     }
 }

--- a/src/intervals/absolute/interval.rs
+++ b/src/intervals/absolute/interval.rs
@@ -44,6 +44,7 @@ use crate::intervals::absolute::{
 use crate::intervals::meta::{
     BoundInclusivity,
     Duration as IntervalDuration,
+    Emptiable,
     HasDuration,
     HasOpenness,
     HasRelativity,
@@ -249,6 +250,12 @@ impl PartialOrd for AbsoluteInterval {
 impl Ord for AbsoluteInterval {
     fn cmp(&self, other: &Self) -> Ordering {
         self.abs_bound_pair().cmp(&other.abs_bound_pair())
+    }
+}
+
+impl Emptiable for AbsoluteInterval {
+    fn is_empty(&self) -> bool {
+        false
     }
 }
 

--- a/src/intervals/absolute/interval.rs
+++ b/src/intervals/absolute/interval.rs
@@ -177,7 +177,7 @@ impl AbsoluteInterval {
 
     /// Wraps the interval in [`EmptiableAbsoluteInterval`]
     #[must_use]
-    pub fn to_emptiable_interval(self) -> EmptiableAbsoluteInterval {
+    pub fn to_emptiable(self) -> EmptiableAbsoluteInterval {
         EmptiableAbsoluteInterval::from(self)
     }
 }

--- a/src/intervals/absolute/start_bound.rs
+++ b/src/intervals/absolute/start_bound.rs
@@ -277,6 +277,26 @@ impl From<AbsoluteFiniteBound> for AbsoluteStartBound {
     }
 }
 
+impl From<Option<Timestamp>> for AbsoluteStartBound {
+    fn from(value: Option<Timestamp>) -> Self {
+        match value {
+            Some(timestamp) => Self::Finite(AbsoluteFiniteBound::from(timestamp)),
+            None => Self::InfinitePast,
+        }
+    }
+}
+
+impl From<Option<(Timestamp, BoundInclusivity)>> for AbsoluteStartBound {
+    fn from(value: Option<(Timestamp, BoundInclusivity)>) -> Self {
+        match value {
+            Some((timestamp, inclusivity)) => {
+                Self::Finite(AbsoluteFiniteBound::new_with_inclusivity(timestamp, inclusivity))
+            },
+            None => Self::InfinitePast,
+        }
+    }
+}
+
 impl From<Bound<Timestamp>> for AbsoluteStartBound {
     fn from(bound: Bound<Timestamp>) -> Self {
         match bound {

--- a/src/intervals/ops/complement_tests.rs
+++ b/src/intervals/ops/complement_tests.rs
@@ -106,13 +106,13 @@ fn abs_interval_half_bounded() -> Result<(), Box<dyn Error>> {
             OpeningDirection::ToPast,
         ))
         .complement(),
-        ComplementResult::Single(EmptiableAbsoluteInterval::HalfBounded(
+        ComplementResult::Single(EmptiableAbsoluteInterval::Bound(AbsoluteInterval::HalfBounded(
             HalfBoundedAbsoluteInterval::new_with_inclusivity(
                 "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
                 OpeningDirection::ToFuture,
             )
-        )),
+        ))),
     );
 
     Ok(())
@@ -129,16 +129,16 @@ fn abs_interval_bounded() -> Result<(), Box<dyn Error>> {
         ))
         .complement(),
         ComplementResult::Split(
-            EmptiableAbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new_with_inclusivity(
+            EmptiableAbsoluteInterval::Bound(AbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new_with_inclusivity(
                 "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
                 OpeningDirection::ToPast,
-            )),
-            EmptiableAbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new_with_inclusivity(
+            ))),
+            EmptiableAbsoluteInterval::Bound(AbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
                 OpeningDirection::ToFuture,
-            )),
+            ))),
         ),
     );
 
@@ -149,6 +149,6 @@ fn abs_interval_bounded() -> Result<(), Box<dyn Error>> {
 fn abs_interval_empty() {
     assert_eq!(
         EmptiableAbsoluteInterval::Empty(EmptyInterval).complement(),
-        ComplementResult::Single(EmptiableAbsoluteInterval::Unbounded(UnboundedInterval)),
+        ComplementResult::Single(EmptiableAbsoluteInterval::Bound(AbsoluteInterval::Unbounded(UnboundedInterval))),
     );
 }

--- a/src/intervals/ops/complement_tests.rs
+++ b/src/intervals/ops/complement_tests.rs
@@ -129,16 +129,20 @@ fn abs_interval_bounded() -> Result<(), Box<dyn Error>> {
         ))
         .complement(),
         ComplementResult::Split(
-            EmptiableAbsoluteInterval::Bound(AbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new_with_inclusivity(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                BoundInclusivity::Inclusive,
-                OpeningDirection::ToPast,
-            ))),
-            EmptiableAbsoluteInterval::Bound(AbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new_with_inclusivity(
-                "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                BoundInclusivity::Inclusive,
-                OpeningDirection::ToFuture,
-            ))),
+            EmptiableAbsoluteInterval::Bound(AbsoluteInterval::HalfBounded(
+                HalfBoundedAbsoluteInterval::new_with_inclusivity(
+                    "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                    BoundInclusivity::Inclusive,
+                    OpeningDirection::ToPast,
+                )
+            )),
+            EmptiableAbsoluteInterval::Bound(AbsoluteInterval::HalfBounded(
+                HalfBoundedAbsoluteInterval::new_with_inclusivity(
+                    "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                    BoundInclusivity::Inclusive,
+                    OpeningDirection::ToFuture,
+                )
+            )),
         ),
     );
 
@@ -149,6 +153,8 @@ fn abs_interval_bounded() -> Result<(), Box<dyn Error>> {
 fn abs_interval_empty() {
     assert_eq!(
         EmptiableAbsoluteInterval::Empty(EmptyInterval).complement(),
-        ComplementResult::Single(EmptiableAbsoluteInterval::Bound(AbsoluteInterval::Unbounded(UnboundedInterval))),
+        ComplementResult::Single(EmptiableAbsoluteInterval::Bound(AbsoluteInterval::Unbounded(
+            UnboundedInterval
+        ))),
     );
 }

--- a/src/intervals/ops/continuation_tests.rs
+++ b/src/intervals/ops/continuation_tests.rs
@@ -4,14 +4,7 @@ use jiff::Zoned;
 
 use super::continuation::*;
 use crate::intervals::absolute::{
-    AbsoluteBoundPair,
-    AbsoluteEndBound,
-    AbsoluteFiniteBound,
-    AbsoluteStartBound,
-    BoundedAbsoluteInterval,
-    EmptiableAbsoluteBoundPair,
-    EmptiableAbsoluteInterval,
-    HalfBoundedAbsoluteInterval,
+    AbsoluteBoundPair, AbsoluteEndBound, AbsoluteFiniteBound, AbsoluteStartBound, BoundedAbsoluteInterval, EmptiableAbsoluteBoundPair, EmptiableAbsoluteInterval, HalfBoundedAbsoluteInterval, AbsoluteInterval
 };
 use crate::intervals::meta::{BoundInclusivity, OpeningDirection};
 use crate::intervals::special::{EmptyInterval, UnboundedInterval};
@@ -60,11 +53,11 @@ fn future_continuation_half_bounded_to_past_interval() -> Result<(), Box<dyn Err
             OpeningDirection::ToPast,
         )
         .future_continuation(),
-        EmptiableAbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new_with_inclusivity(
+        EmptiableAbsoluteInterval::Bound(AbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new_with_inclusivity(
             "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             BoundInclusivity::Inclusive,
             OpeningDirection::ToFuture,
-        )),
+        ))),
     );
 
     Ok(())
@@ -76,13 +69,12 @@ fn past_continuation_half_bounded_to_future_interval() -> Result<(), Box<dyn Err
         HalfBoundedAbsoluteInterval::new(
             "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             OpeningDirection::ToFuture,
-        )
-        .past_continuation(),
-        EmptiableAbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new_with_inclusivity(
+        ).past_continuation(),
+        EmptiableAbsoluteInterval::Bound(AbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new_with_inclusivity(
             "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             BoundInclusivity::Exclusive,
             OpeningDirection::ToPast,
-        )),
+        ))),
     );
 
     Ok(())
@@ -206,7 +198,7 @@ fn future_continuation_abs_bounds_bounded() -> Result<(), Box<dyn Error>> {
 #[test]
 fn past_continuation_abs_interval_unbounded() {
     assert_eq!(
-        EmptiableAbsoluteInterval::Unbounded(UnboundedInterval).past_continuation(),
+        EmptiableAbsoluteInterval::Bound(AbsoluteInterval::Unbounded(UnboundedInterval)).past_continuation(),
         EmptiableAbsoluteInterval::Empty(EmptyInterval),
     );
 }
@@ -214,7 +206,7 @@ fn past_continuation_abs_interval_unbounded() {
 #[test]
 fn future_continuation_abs_interval_unbounded() {
     assert_eq!(
-        EmptiableAbsoluteInterval::Unbounded(UnboundedInterval).future_continuation(),
+        EmptiableAbsoluteInterval::Bound(AbsoluteInterval::Unbounded(UnboundedInterval)).future_continuation(),
         EmptiableAbsoluteInterval::Empty(EmptyInterval),
     );
 }

--- a/src/intervals/ops/continuation_tests.rs
+++ b/src/intervals/ops/continuation_tests.rs
@@ -4,7 +4,15 @@ use jiff::Zoned;
 
 use super::continuation::*;
 use crate::intervals::absolute::{
-    AbsoluteBoundPair, AbsoluteEndBound, AbsoluteFiniteBound, AbsoluteStartBound, BoundedAbsoluteInterval, EmptiableAbsoluteBoundPair, EmptiableAbsoluteInterval, HalfBoundedAbsoluteInterval, AbsoluteInterval
+    AbsoluteBoundPair,
+    AbsoluteEndBound,
+    AbsoluteFiniteBound,
+    AbsoluteInterval,
+    AbsoluteStartBound,
+    BoundedAbsoluteInterval,
+    EmptiableAbsoluteBoundPair,
+    EmptiableAbsoluteInterval,
+    HalfBoundedAbsoluteInterval,
 };
 use crate::intervals::meta::{BoundInclusivity, OpeningDirection};
 use crate::intervals::special::{EmptyInterval, UnboundedInterval};
@@ -53,11 +61,13 @@ fn future_continuation_half_bounded_to_past_interval() -> Result<(), Box<dyn Err
             OpeningDirection::ToPast,
         )
         .future_continuation(),
-        EmptiableAbsoluteInterval::Bound(AbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new_with_inclusivity(
-            "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            BoundInclusivity::Inclusive,
-            OpeningDirection::ToFuture,
-        ))),
+        EmptiableAbsoluteInterval::Bound(AbsoluteInterval::HalfBounded(
+            HalfBoundedAbsoluteInterval::new_with_inclusivity(
+                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                BoundInclusivity::Inclusive,
+                OpeningDirection::ToFuture,
+            )
+        )),
     );
 
     Ok(())
@@ -69,12 +79,15 @@ fn past_continuation_half_bounded_to_future_interval() -> Result<(), Box<dyn Err
         HalfBoundedAbsoluteInterval::new(
             "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             OpeningDirection::ToFuture,
-        ).past_continuation(),
-        EmptiableAbsoluteInterval::Bound(AbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new_with_inclusivity(
-            "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            BoundInclusivity::Exclusive,
-            OpeningDirection::ToPast,
-        ))),
+        )
+        .past_continuation(),
+        EmptiableAbsoluteInterval::Bound(AbsoluteInterval::HalfBounded(
+            HalfBoundedAbsoluteInterval::new_with_inclusivity(
+                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                BoundInclusivity::Exclusive,
+                OpeningDirection::ToPast,
+            )
+        )),
     );
 
     Ok(())

--- a/src/intervals/ops/relativity_conversion.rs
+++ b/src/intervals/ops/relativity_conversion.rs
@@ -304,11 +304,7 @@ impl ToAbsolute for EmptiableRelativeInterval {
         D: Into<Timestamp>,
     {
         match self {
-            Self::Bounded(bounded) => EmptiableAbsoluteInterval::Bounded(bounded.to_absolute(reference)),
-            Self::HalfBounded(half_bounded) => {
-                EmptiableAbsoluteInterval::HalfBounded(half_bounded.to_absolute(reference))
-            },
-            Self::Unbounded(unbounded) => EmptiableAbsoluteInterval::Unbounded(unbounded.to_absolute(reference)),
+            Self::Bound(interval) => EmptiableAbsoluteInterval::Bound(interval.to_absolute(reference)),
             Self::Empty(empty) => EmptiableAbsoluteInterval::Empty(empty.to_absolute(reference)),
         }
     }
@@ -551,11 +547,7 @@ impl ToRelative for EmptiableAbsoluteInterval {
         D: Into<Timestamp>,
     {
         match self {
-            Self::Bounded(bounded) => EmptiableRelativeInterval::Bounded(bounded.to_relative(reference)),
-            Self::HalfBounded(half_bounded) => {
-                EmptiableRelativeInterval::HalfBounded(half_bounded.to_relative(reference))
-            },
-            Self::Unbounded(unbounded) => EmptiableRelativeInterval::Unbounded(unbounded.to_relative(reference)),
+            Self::Bound(interval) => EmptiableRelativeInterval::Bound(interval.to_relative(reference)),
             Self::Empty(empty) => EmptiableRelativeInterval::Empty(empty.to_relative(reference)),
         }
     }

--- a/src/intervals/ops/remove_overlap_or_gap_tests.rs
+++ b/src/intervals/ops/remove_overlap_or_gap_tests.rs
@@ -357,14 +357,12 @@ mod remove_overlap_or_gap {
                     "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
                     OpeningDirection::ToPast,
-                ))
-                .to_emptiable_interval(),
+                )).to_emptiable(),
                 AbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
                     OpeningDirection::ToFuture,
-                ))
-                .to_emptiable_interval(),
+                )).to_emptiable(),
             ),
         );
 

--- a/src/intervals/ops/remove_overlap_or_gap_tests.rs
+++ b/src/intervals/ops/remove_overlap_or_gap_tests.rs
@@ -357,12 +357,14 @@ mod remove_overlap_or_gap {
                     "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
                     OpeningDirection::ToPast,
-                )).to_emptiable(),
+                ))
+                .to_emptiable(),
                 AbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
                     OpeningDirection::ToFuture,
-                )).to_emptiable(),
+                ))
+                .to_emptiable(),
             ),
         );
 

--- a/src/intervals/relative/bound_pair.rs
+++ b/src/intervals/relative/bound_pair.rs
@@ -24,6 +24,7 @@ use serde::{Deserialize, Serialize};
 use crate::intervals::meta::{
     BoundInclusivity,
     Duration as IntervalDuration,
+    Emptiable,
     Epsilon,
     HasBoundInclusivity,
     HasDuration,
@@ -433,6 +434,12 @@ impl Ord for RelativeBoundPair {
         // absolute bounds inside a BTreeSet, then if we use `range()`,
         // one can be considered out of the range when it shouldn't.
         self.start.cmp(&other.start)
+    }
+}
+
+impl Emptiable for RelativeBoundPair {
+    fn is_empty(&self) -> bool {
+        false
     }
 }
 

--- a/src/intervals/relative/bound_pair.rs
+++ b/src/intervals/relative/bound_pair.rs
@@ -22,6 +22,7 @@ use jiff::SignedDuration;
 use serde::{Deserialize, Serialize};
 
 use crate::intervals::meta::{
+    BoundInclusivity,
     Duration as IntervalDuration,
     Epsilon,
     HasBoundInclusivity,
@@ -432,6 +433,41 @@ impl Ord for RelativeBoundPair {
         // absolute bounds inside a BTreeSet, then if we use `range()`,
         // one can be considered out of the range when it shouldn't.
         self.start.cmp(&other.start)
+    }
+}
+
+/// Converts `(Option<SignedDuration>, Option<SignedDuration>)` into [`RelativeBoundPair`]
+///
+/// The first tuple element represents the start bound, the second element
+/// represents the end bound.
+impl From<(Option<SignedDuration>, Option<SignedDuration>)> for RelativeBoundPair {
+    fn from((start_opt, end_opt): (Option<SignedDuration>, Option<SignedDuration>)) -> Self {
+        let start = RelativeStartBound::from(start_opt);
+        let end = RelativeEndBound::from(end_opt);
+        RelativeBoundPair::new(start, end)
+    }
+}
+
+/// Converts `(Option<(SignedDuration, BoundInclusivity)>, Option<(SignedDuration, BoundInclusivity)>)`
+/// into [`RelativeBoundPair`]
+///
+/// The first tuple element represents the start bound, the second element
+/// represents the end bound.
+impl
+    From<(
+        Option<(SignedDuration, BoundInclusivity)>,
+        Option<(SignedDuration, BoundInclusivity)>,
+    )> for RelativeBoundPair
+{
+    fn from(
+        (start_opt, end_opt): (
+            Option<(SignedDuration, BoundInclusivity)>,
+            Option<(SignedDuration, BoundInclusivity)>,
+        ),
+    ) -> Self {
+        let start = RelativeStartBound::from(start_opt);
+        let end = RelativeEndBound::from(end_opt);
+        Self::new(start, end)
     }
 }
 

--- a/src/intervals/relative/bounded_interval.rs
+++ b/src/intervals/relative/bounded_interval.rs
@@ -796,7 +796,7 @@ impl BoundedRelativeInterval {
 
     /// Wraps the interval in [`EmptiableRelativeInterval`]
     #[must_use]
-    pub fn to_emptiable_interval(self) -> EmptiableRelativeInterval {
+    pub fn to_emptiable(self) -> EmptiableRelativeInterval {
         EmptiableRelativeInterval::from(self)
     }
 }

--- a/src/intervals/relative/bounded_interval.rs
+++ b/src/intervals/relative/bounded_interval.rs
@@ -25,6 +25,7 @@ use serde::{Deserialize, Serialize};
 use crate::intervals::meta::{
     BoundInclusivity,
     Duration as IntervalDuration,
+    Emptiable,
     Epsilon,
     HasBoundInclusivity,
     HasDuration,
@@ -880,6 +881,12 @@ impl HasRelativeBoundPair for BoundedRelativeInterval {
 
     fn rel_end(&self) -> RelativeEndBound {
         RelativeFiniteBound::new_with_inclusivity(self.end, self.end_inclusivity).to_end_bound()
+    }
+}
+
+impl Emptiable for BoundedRelativeInterval {
+    fn is_empty(&self) -> bool {
+        false
     }
 }
 

--- a/src/intervals/relative/emptiable_bound_pair.rs
+++ b/src/intervals/relative/emptiable_bound_pair.rs
@@ -1,8 +1,7 @@
 //! Emptiable absolute bound pair
 //!
 //! Similar to [absolute bound pair](crate::intervals::absolute::bound_pair),
-//! but has the extra ability of being able to represent an [empty
-//! interval](crate::intervals::special::EmptyInterval).
+//! but has the extra ability of being able to represent an [empty interval](crate::intervals::special::EmptyInterval).
 
 use std::cmp::Ordering;
 use std::time::Duration;
@@ -249,7 +248,7 @@ impl From<(bool, Option<SignedDuration>, Option<SignedDuration>)> for EmptiableR
 }
 
 /// Converts `(bool, Option<(SignedDuration, BoundInclusivity)>, Option<(SignedDuration, BoundInclusivity)>)`
-/// into [`RelativeInterval`]
+/// into [`EmptiableRelativeBoundPair`]
 ///
 /// The second tuple element represents the start bound, the third element
 /// represents the end bound.

--- a/src/intervals/relative/emptiable_bound_pair.rs
+++ b/src/intervals/relative/emptiable_bound_pair.rs
@@ -9,10 +9,12 @@ use std::time::Duration;
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
+use jiff::SignedDuration;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::intervals::meta::{
+    BoundInclusivity,
     Duration as IntervalDuration,
     Emptiable,
     Epsilon,
@@ -72,8 +74,8 @@ where
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum EmptiableRelativeBoundPair {
-    Empty,
     Bound(RelativeBoundPair),
+    Empty,
 }
 
 impl EmptiableRelativeBoundPair {
@@ -210,6 +212,67 @@ impl Ord for EmptiableRelativeBoundPair {
                 EmptiableRelativeBoundPair::Bound(other_rel_bound_pair),
             ) => og_rel_bound_pair.cmp(other_rel_bound_pair),
         }
+    }
+}
+
+/// Converts `(bool, RelativeStartBound, RelativeEndBound)` into [`EmptiableRelativeBoundPair`]
+///
+/// The second tuple element represents the start bound, the third element
+/// represents the end bound.
+///
+/// The first boolean indicates whether the interval is an empty interval.
+/// If it is set to `true`, the next elements are ignored altogether.
+impl From<(bool, RelativeStartBound, RelativeEndBound)> for EmptiableRelativeBoundPair {
+    fn from((is_empty, start, end): (bool, RelativeStartBound, RelativeEndBound)) -> Self {
+        if is_empty {
+            return Self::Empty;
+        }
+
+        Self::from(RelativeBoundPair::new(start, end))
+    }
+}
+
+/// Converts `(bool, Option<SignedDuration>, Option<SignedDuration>)` into
+/// [`EmptiableRelativeBoundPair`]
+///
+/// The second tuple element represents the start bound, the third element
+/// represents the end bound.
+///
+/// The first boolean indicates whether the interval is an empty interval.
+/// If it is set to `true`, the next elements are ignored altogether.
+impl From<(bool, Option<SignedDuration>, Option<SignedDuration>)> for EmptiableRelativeBoundPair {
+    fn from((is_empty, start_opt, end_opt): (bool, Option<SignedDuration>, Option<SignedDuration>)) -> Self {
+        let start = RelativeStartBound::from(start_opt);
+        let end = RelativeEndBound::from(end_opt);
+        Self::from((is_empty, start, end))
+    }
+}
+
+/// Converts `(bool, Option<(SignedDuration, BoundInclusivity)>, Option<(SignedDuration, BoundInclusivity)>)`
+/// into [`RelativeInterval`]
+///
+/// The second tuple element represents the start bound, the third element
+/// represents the end bound.
+///
+/// The first boolean indicates whether the interval is an empty interval.
+/// If it is set to `true`, the next elements are ignored altogether.
+impl
+    From<(
+        bool,
+        Option<(SignedDuration, BoundInclusivity)>,
+        Option<(SignedDuration, BoundInclusivity)>,
+    )> for EmptiableRelativeBoundPair
+{
+    fn from(
+        (is_empty, start_opt, end_opt): (
+            bool,
+            Option<(SignedDuration, BoundInclusivity)>,
+            Option<(SignedDuration, BoundInclusivity)>,
+        ),
+    ) -> Self {
+        let start = RelativeStartBound::from(start_opt);
+        let end = RelativeEndBound::from(end_opt);
+        Self::from((is_empty, start, end))
     }
 }
 

--- a/src/intervals/relative/emptiable_interval.rs
+++ b/src/intervals/relative/emptiable_interval.rs
@@ -74,7 +74,8 @@ impl EmptiableRelativeInterval {
     /// let interval = BoundedRelativeInterval::new(
     ///     SignedDuration::from_hours(8),
     ///     SignedDuration::from_hours(16),
-    /// ).to_interval();
+    /// )
+    /// .to_interval();
     ///
     /// let bound_emptiable_interval = EmptiableRelativeInterval::Bound(interval.clone());
     /// let empty_emptiable_interval = EmptiableRelativeInterval::Empty(EmptyInterval);

--- a/src/intervals/relative/emptiable_interval.rs
+++ b/src/intervals/relative/emptiable_interval.rs
@@ -67,14 +67,14 @@ impl EmptiableRelativeInterval {
     ///
     /// ```
     /// # use jiff::SignedDuration;
-    /// # use periodical::intervals::absolute::{
-    /// #     EmptiableRelativeInterval, AbsoluteInterval, BoundedAbsoluteInterval,
+    /// # use periodical::intervals::relative::{
+    /// #     EmptiableRelativeInterval, RelativeInterval, BoundedRelativeInterval,
     /// # };
     /// # use periodical::intervals::special::EmptyInterval;
-    /// let interval = BoundedAbsoluteInterval::new(
+    /// let interval = BoundedRelativeInterval::new(
     ///     SignedDuration::from_hours(8),
     ///     SignedDuration::from_hours(16),
-    /// );
+    /// ).to_interval();
     ///
     /// let bound_emptiable_interval = EmptiableRelativeInterval::Bound(interval.clone());
     /// let empty_emptiable_interval = EmptiableRelativeInterval::Empty(EmptyInterval);

--- a/src/intervals/relative/emptiable_interval.rs
+++ b/src/intervals/relative/emptiable_interval.rs
@@ -33,7 +33,6 @@ use crate::intervals::meta::{
     HasOpenness,
     HasRelativity,
     Interval,
-    OpeningDirection,
     Openness,
     Relativity,
 };
@@ -45,7 +44,6 @@ use crate::intervals::relative::{
     HasRelativeBoundPair,
     RelativeBoundPair,
     RelativeEndBound,
-    RelativeFiniteBound,
     RelativeInterval,
     RelativeStartBound,
 };
@@ -55,13 +53,43 @@ use crate::intervals::special::{EmptyInterval, UnboundedInterval};
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum EmptiableRelativeInterval {
-    Bounded(BoundedRelativeInterval),
-    HalfBounded(HalfBoundedRelativeInterval),
-    Unbounded(UnboundedInterval),
+    Bound(RelativeInterval),
     Empty(EmptyInterval),
 }
 
 impl EmptiableRelativeInterval {
+    /// Returns the content of the [`Bound`](EmptiableRelativeInterval::Bound) variant
+    ///
+    /// Consumes `self` and puts the content of the [`Bound`](EmptiableRelativeInterval::Bound) variant
+    /// in an [`Option`]. If instead `self` is another variant, the method returns [`None`]
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use jiff::SignedDuration;
+    /// # use periodical::intervals::absolute::{
+    /// #     EmptiableRelativeInterval, AbsoluteInterval, BoundedAbsoluteInterval,
+    /// # };
+    /// # use periodical::intervals::special::EmptyInterval;
+    /// let interval = BoundedAbsoluteInterval::new(
+    ///     SignedDuration::from_hours(8),
+    ///     SignedDuration::from_hours(16),
+    /// );
+    ///
+    /// let bound_emptiable_interval = EmptiableRelativeInterval::Bound(interval.clone());
+    /// let empty_emptiable_interval = EmptiableRelativeInterval::Empty(EmptyInterval);
+    ///
+    /// assert_eq!(bound_emptiable_interval.bound(), Some(interval));
+    /// assert_eq!(empty_emptiable_interval.bound(), None);
+    /// ```
+    #[must_use]
+    pub fn bound(self) -> Option<RelativeInterval> {
+        match self {
+            Self::Bound(interval) => Some(interval),
+            Self::Empty(_) => None,
+        }
+    }
+
     /// Compares two [`RelativeInterval`], but if they have the same start,
     /// order by decreasing length
     ///
@@ -90,10 +118,8 @@ impl Interval for EmptiableRelativeInterval {}
 impl HasDuration for EmptiableRelativeInterval {
     fn duration(&self) -> IntervalDuration {
         match self {
-            Self::Bounded(interval) => interval.duration(),
-            Self::HalfBounded(interval) => interval.duration(),
-            Self::Unbounded(interval) => interval.duration(),
-            Self::Empty(interval) => interval.duration(),
+            Self::Bound(interval) => interval.duration(),
+            Self::Empty(empty) => empty.duration(),
         }
     }
 }
@@ -101,10 +127,8 @@ impl HasDuration for EmptiableRelativeInterval {
 impl HasRelativity for EmptiableRelativeInterval {
     fn relativity(&self) -> Relativity {
         match self {
-            Self::Bounded(interval) => interval.relativity(),
-            Self::HalfBounded(interval) => interval.relativity(),
-            Self::Unbounded(interval) => interval.relativity(),
-            Self::Empty(interval) => interval.relativity(),
+            Self::Bound(interval) => interval.relativity(),
+            Self::Empty(empty) => empty.relativity(),
         }
     }
 }
@@ -112,10 +136,8 @@ impl HasRelativity for EmptiableRelativeInterval {
 impl HasOpenness for EmptiableRelativeInterval {
     fn openness(&self) -> Openness {
         match self {
-            Self::Bounded(interval) => interval.openness(),
-            Self::HalfBounded(interval) => interval.openness(),
-            Self::Unbounded(interval) => interval.openness(),
-            Self::Empty(interval) => interval.openness(),
+            Self::Bound(interval) => interval.openness(),
+            Self::Empty(empty) => empty.openness(),
         }
     }
 }
@@ -123,28 +145,22 @@ impl HasOpenness for EmptiableRelativeInterval {
 impl HasEmptiableRelativeBoundPair for EmptiableRelativeInterval {
     fn emptiable_rel_bound_pair(&self) -> EmptiableRelativeBoundPair {
         match self {
-            Self::Bounded(interval) => EmptiableRelativeBoundPair::from(interval.rel_bound_pair()),
-            Self::HalfBounded(interval) => EmptiableRelativeBoundPair::from(interval.rel_bound_pair()),
-            Self::Unbounded(interval) => EmptiableRelativeBoundPair::from(interval.rel_bound_pair()),
+            Self::Bound(interval) => EmptiableRelativeBoundPair::from(interval.rel_bound_pair()),
             Self::Empty(interval) => interval.emptiable_rel_bound_pair(),
         }
     }
 
     fn partial_rel_start(&self) -> Option<RelativeStartBound> {
         match self {
-            Self::Bounded(interval) => interval.partial_rel_start(),
-            Self::HalfBounded(interval) => interval.partial_rel_start(),
-            Self::Unbounded(interval) => interval.partial_rel_start(),
-            Self::Empty(interval) => interval.partial_rel_start(),
+            Self::Bound(interval) => interval.partial_rel_start(),
+            Self::Empty(empty) => empty.partial_rel_start(),
         }
     }
 
     fn partial_rel_end(&self) -> Option<RelativeEndBound> {
         match self {
-            Self::Bounded(interval) => interval.partial_rel_end(),
-            Self::HalfBounded(interval) => interval.partial_rel_end(),
-            Self::Unbounded(interval) => interval.partial_rel_end(),
-            Self::Empty(interval) => interval.partial_rel_end(),
+            Self::Bound(interval) => interval.partial_rel_end(),
+            Self::Empty(empty) => empty.partial_rel_end(),
         }
     }
 }
@@ -169,19 +185,19 @@ impl Ord for EmptiableRelativeInterval {
 
 impl From<BoundedRelativeInterval> for EmptiableRelativeInterval {
     fn from(value: BoundedRelativeInterval) -> Self {
-        EmptiableRelativeInterval::Bounded(value)
+        EmptiableRelativeInterval::Bound(value.to_interval())
     }
 }
 
 impl From<HalfBoundedRelativeInterval> for EmptiableRelativeInterval {
     fn from(value: HalfBoundedRelativeInterval) -> Self {
-        EmptiableRelativeInterval::HalfBounded(value)
+        EmptiableRelativeInterval::Bound(value.to_interval())
     }
 }
 
 impl From<UnboundedInterval> for EmptiableRelativeInterval {
     fn from(value: UnboundedInterval) -> Self {
-        EmptiableRelativeInterval::Unbounded(value)
+        EmptiableRelativeInterval::Bound(RelativeInterval::Unbounded(value))
     }
 }
 
@@ -193,131 +209,32 @@ impl From<EmptyInterval> for EmptiableRelativeInterval {
 
 impl From<RelativeBoundPair> for EmptiableRelativeInterval {
     fn from(value: RelativeBoundPair) -> Self {
-        type StartB = RelativeStartBound;
-        type EndB = RelativeEndBound;
-
-        match (value.rel_start(), value.rel_end()) {
-            (StartB::InfinitePast, EndB::InfiniteFuture) => EmptiableRelativeInterval::Unbounded(UnboundedInterval),
-            (
-                StartB::InfinitePast,
-                EndB::Finite(RelativeFiniteBound {
-                    offset,
-                    inclusivity,
-                }),
-            ) => EmptiableRelativeInterval::HalfBounded(HalfBoundedRelativeInterval::new_with_inclusivity(
-                offset,
-                inclusivity,
-                OpeningDirection::ToPast,
-            )),
-            (
-                StartB::Finite(RelativeFiniteBound {
-                    offset,
-                    inclusivity,
-                }),
-                EndB::InfiniteFuture,
-            ) => EmptiableRelativeInterval::HalfBounded(HalfBoundedRelativeInterval::new_with_inclusivity(
-                offset,
-                inclusivity,
-                OpeningDirection::ToFuture,
-            )),
-            (
-                StartB::Finite(RelativeFiniteBound {
-                    offset: start_offset,
-                    inclusivity: start_inclusivity,
-                }),
-                EndB::Finite(RelativeFiniteBound {
-                    offset: end_offset,
-                    inclusivity: end_inclusivity,
-                }),
-            ) => EmptiableRelativeInterval::Bounded(BoundedRelativeInterval::unchecked_new_with_inclusivity(
-                start_offset,
-                start_inclusivity,
-                end_offset,
-                end_inclusivity,
-            )),
-        }
+        EmptiableRelativeInterval::Bound(RelativeInterval::from(value))
     }
 }
 
 impl From<EmptiableRelativeBoundPair> for EmptiableRelativeInterval {
     fn from(value: EmptiableRelativeBoundPair) -> Self {
-        type StartB = RelativeStartBound;
-        type EndB = RelativeEndBound;
-
-        match (value.partial_rel_start(), value.partial_rel_end()) {
-            (None, _) | (_, None) => EmptiableRelativeInterval::Empty(EmptyInterval),
-            (Some(StartB::InfinitePast), Some(EndB::InfiniteFuture)) => {
-                EmptiableRelativeInterval::Unbounded(UnboundedInterval)
-            },
-            (
-                Some(StartB::InfinitePast),
-                Some(EndB::Finite(RelativeFiniteBound {
-                    offset,
-                    inclusivity,
-                })),
-            ) => EmptiableRelativeInterval::HalfBounded(HalfBoundedRelativeInterval::new_with_inclusivity(
-                offset,
-                inclusivity,
-                OpeningDirection::ToPast,
-            )),
-            (
-                Some(StartB::Finite(RelativeFiniteBound {
-                    offset,
-                    inclusivity,
-                })),
-                Some(EndB::InfiniteFuture),
-            ) => EmptiableRelativeInterval::HalfBounded(HalfBoundedRelativeInterval::new_with_inclusivity(
-                offset,
-                inclusivity,
-                OpeningDirection::ToFuture,
-            )),
-            (
-                Some(StartB::Finite(RelativeFiniteBound {
-                    offset: start_offset,
-                    inclusivity: start_inclusivity,
-                })),
-                Some(EndB::Finite(RelativeFiniteBound {
-                    offset: end_offset,
-                    inclusivity: end_inclusivity,
-                })),
-            ) => EmptiableRelativeInterval::Bounded(BoundedRelativeInterval::unchecked_new_with_inclusivity(
-                start_offset,
-                start_inclusivity,
-                end_offset,
-                end_inclusivity,
-            )),
+        match value.bound() {
+            Some(rel_bound_pair) => Self::from(rel_bound_pair),
+            None => Self::Empty(EmptyInterval),
         }
     }
 }
 
 impl From<RelativeInterval> for EmptiableRelativeInterval {
     fn from(value: RelativeInterval) -> Self {
-        match value {
-            RelativeInterval::Bounded(bounded) => EmptiableRelativeInterval::Bounded(bounded),
-            RelativeInterval::HalfBounded(half_bounded) => EmptiableRelativeInterval::HalfBounded(half_bounded),
-            RelativeInterval::Unbounded(unbounded) => EmptiableRelativeInterval::Unbounded(unbounded),
-        }
+        Self::Bound(value)
     }
 }
 
-/// Converts `(Option<SignedDuration>, Option<SignedDuration>)` into
-/// [`RelativeInterval`]
+/// Converts `(Option<SignedDuration>, Option<SignedDuration>)` into [`RelativeInterval`]
 ///
 /// The first tuple element represents the start bound, the second element
 /// represents the end bound.
 impl From<(Option<SignedDuration>, Option<SignedDuration>)> for EmptiableRelativeInterval {
     fn from((from_opt, to_opt): (Option<SignedDuration>, Option<SignedDuration>)) -> Self {
-        match (from_opt, to_opt) {
-            (Some(from), Some(to)) => EmptiableRelativeInterval::Bounded(BoundedRelativeInterval::new(from, to)),
-            (Some(from), None) => EmptiableRelativeInterval::HalfBounded(HalfBoundedRelativeInterval::new(
-                from,
-                OpeningDirection::ToFuture,
-            )),
-            (None, Some(to)) => {
-                EmptiableRelativeInterval::HalfBounded(HalfBoundedRelativeInterval::new(to, OpeningDirection::ToPast))
-            },
-            (None, None) => EmptiableRelativeInterval::Unbounded(UnboundedInterval),
-        }
+        Self::from(RelativeBoundPair::from((from_opt, to_opt)).to_emptiable())
     }
 }
 
@@ -333,23 +250,25 @@ impl
     )> for EmptiableRelativeInterval
 {
     fn from(
-        (start_opt, end_opt): (
+        value: (
             Option<(SignedDuration, BoundInclusivity)>,
             Option<(SignedDuration, BoundInclusivity)>,
         ),
     ) -> Self {
-        match (start_opt, end_opt) {
-            (Some((start, start_inclusivity)), Some((end, end_inclusivity))) => EmptiableRelativeInterval::Bounded(
-                BoundedRelativeInterval::new_with_inclusivity(start, start_inclusivity, end, end_inclusivity),
-            ),
-            (Some((start, start_inclusivity)), None) => EmptiableRelativeInterval::HalfBounded(
-                HalfBoundedRelativeInterval::new_with_inclusivity(start, start_inclusivity, OpeningDirection::ToFuture),
-            ),
-            (None, Some((end, end_inclusivity))) => EmptiableRelativeInterval::HalfBounded(
-                HalfBoundedRelativeInterval::new_with_inclusivity(end, end_inclusivity, OpeningDirection::ToPast),
-            ),
-            (None, None) => EmptiableRelativeInterval::Unbounded(UnboundedInterval),
-        }
+        Self::from(RelativeBoundPair::from(value))
+    }
+}
+
+/// Converts `(bool, RelativeStartBound, RelativeEndBound)` into [`EmptiableRelativeInterval`]
+///
+/// The second tuple element represents the start bound, the third element
+/// represents the end bound.
+///
+/// The first boolean indicates whether the interval is an empty interval.
+/// If it is set to `true`, the next elements are ignored altogether.
+impl From<(bool, RelativeStartBound, RelativeEndBound)> for EmptiableRelativeInterval {
+    fn from(value: (bool, RelativeStartBound, RelativeEndBound)) -> Self {
+        Self::from(EmptiableRelativeBoundPair::from(value))
     }
 }
 
@@ -362,22 +281,8 @@ impl
 /// The first boolean indicates whether the interval is an [`EmptyInterval`].
 /// If it is set to `true`, the next elements are ignored altogether.
 impl From<(bool, Option<SignedDuration>, Option<SignedDuration>)> for EmptiableRelativeInterval {
-    fn from((is_empty, from_opt, to_opt): (bool, Option<SignedDuration>, Option<SignedDuration>)) -> Self {
-        if is_empty {
-            return EmptiableRelativeInterval::Empty(EmptyInterval);
-        }
-
-        match (from_opt, to_opt) {
-            (Some(from), Some(to)) => EmptiableRelativeInterval::Bounded(BoundedRelativeInterval::new(from, to)),
-            (Some(from), None) => EmptiableRelativeInterval::HalfBounded(HalfBoundedRelativeInterval::new(
-                from,
-                OpeningDirection::ToFuture,
-            )),
-            (None, Some(to)) => {
-                EmptiableRelativeInterval::HalfBounded(HalfBoundedRelativeInterval::new(to, OpeningDirection::ToPast))
-            },
-            (None, None) => EmptiableRelativeInterval::Unbounded(UnboundedInterval),
-        }
+    fn from(value: (bool, Option<SignedDuration>, Option<SignedDuration>)) -> Self {
+        Self::from(EmptiableRelativeBoundPair::from(value))
     }
 }
 
@@ -397,28 +302,13 @@ impl
     )> for EmptiableRelativeInterval
 {
     fn from(
-        (is_empty, start_opt, end_opt): (
+        value: (
             bool,
             Option<(SignedDuration, BoundInclusivity)>,
             Option<(SignedDuration, BoundInclusivity)>,
         ),
     ) -> Self {
-        if is_empty {
-            return EmptiableRelativeInterval::Empty(EmptyInterval);
-        }
-
-        match (start_opt, end_opt) {
-            (Some((start, start_inclusivity)), Some((end, end_inclusivity))) => EmptiableRelativeInterval::Bounded(
-                BoundedRelativeInterval::new_with_inclusivity(start, start_inclusivity, end, end_inclusivity),
-            ),
-            (Some((start, start_inclusivity)), None) => EmptiableRelativeInterval::HalfBounded(
-                HalfBoundedRelativeInterval::new_with_inclusivity(start, start_inclusivity, OpeningDirection::ToFuture),
-            ),
-            (None, Some((end, end_inclusivity))) => EmptiableRelativeInterval::HalfBounded(
-                HalfBoundedRelativeInterval::new_with_inclusivity(end, end_inclusivity, OpeningDirection::ToPast),
-            ),
-            (None, None) => EmptiableRelativeInterval::Unbounded(UnboundedInterval),
-        }
+        Self::from(EmptiableRelativeBoundPair::from(value))
     }
 }
 

--- a/src/intervals/relative/emptiable_interval_tests.rs
+++ b/src/intervals/relative/emptiable_interval_tests.rs
@@ -1,17 +1,10 @@
 use jiff::SignedDuration;
 
-use super::emptiable_interval::*;
 use crate::intervals::meta::{BoundInclusivity, OpeningDirection};
-use crate::intervals::relative::{
-    BoundedRelativeInterval,
-    EmptiableRelativeBoundPair,
-    HalfBoundedRelativeInterval,
-    RelativeBoundPair,
-    RelativeEndBound,
-    RelativeFiniteBound,
-    RelativeStartBound,
-};
+use crate::intervals::relative::{BoundedRelativeInterval, EmptiableRelativeBoundPair, HalfBoundedRelativeInterval, RelativeBoundPair, RelativeEndBound, RelativeFiniteBound, RelativeStartBound, RelativeInterval};
 use crate::intervals::special::{EmptyInterval, UnboundedInterval};
+
+use super::emptiable_interval::*;
 
 #[test]
 fn relative_interval_from_relative_bounds() {
@@ -23,11 +16,11 @@ fn relative_interval_from_relative_bounds() {
             )),
             RelativeEndBound::InfiniteFuture,
         )),
-        EmptiableRelativeInterval::HalfBounded(HalfBoundedRelativeInterval::new_with_inclusivity(
+        EmptiableRelativeInterval::Bound(RelativeInterval::HalfBounded(HalfBoundedRelativeInterval::new_with_inclusivity(
             SignedDuration::from_hours(1),
             BoundInclusivity::Exclusive,
             OpeningDirection::ToFuture,
-        )),
+        ))),
     );
 }
 
@@ -41,11 +34,11 @@ fn relative_interval_from_emptiable_relative_bounds() {
             )),
             RelativeEndBound::InfiniteFuture,
         ))),
-        EmptiableRelativeInterval::HalfBounded(HalfBoundedRelativeInterval::new_with_inclusivity(
+        EmptiableRelativeInterval::Bound(RelativeInterval::HalfBounded(HalfBoundedRelativeInterval::new_with_inclusivity(
             SignedDuration::from_hours(1),
             BoundInclusivity::Exclusive,
             OpeningDirection::ToFuture,
-        )),
+        ))),
     );
 }
 
@@ -53,7 +46,7 @@ fn relative_interval_from_emptiable_relative_bounds() {
 fn relative_interval_from_opt_datetime_pair_unbounded() {
     assert_eq!(
         <EmptiableRelativeInterval as From<(Option<SignedDuration>, Option<SignedDuration>)>>::from((None, None)),
-        EmptiableRelativeInterval::Unbounded(UnboundedInterval),
+        EmptiableRelativeInterval::Bound(RelativeInterval::Unbounded(UnboundedInterval)),
     );
 }
 
@@ -61,10 +54,10 @@ fn relative_interval_from_opt_datetime_pair_unbounded() {
 fn relative_interval_from_opt_datetime_pair_half_bounded() {
     assert_eq!(
         EmptiableRelativeInterval::from((None, Some(SignedDuration::from_hours(1)))),
-        EmptiableRelativeInterval::HalfBounded(HalfBoundedRelativeInterval::new(
+        EmptiableRelativeInterval::Bound(RelativeInterval::HalfBounded(HalfBoundedRelativeInterval::new(
             SignedDuration::from_hours(1),
             OpeningDirection::ToPast,
-        )),
+        ))),
     );
 }
 
@@ -75,12 +68,12 @@ fn relative_interval_from_opt_datetime_bound_inclusivity_pairs() {
             Some((SignedDuration::from_hours(1), BoundInclusivity::Exclusive)),
             Some((SignedDuration::from_hours(2), BoundInclusivity::Exclusive)),
         )),
-        EmptiableRelativeInterval::Bounded(BoundedRelativeInterval::new_with_inclusivity(
+        EmptiableRelativeInterval::Bound(RelativeInterval::Bounded(BoundedRelativeInterval::new_with_inclusivity(
             SignedDuration::from_hours(1),
             BoundInclusivity::Exclusive,
             SignedDuration::from_hours(2),
             BoundInclusivity::Exclusive,
-        )),
+        ))),
     );
 }
 
@@ -97,15 +90,8 @@ fn relative_interval_from_bool_and_two_opt_datetime_empty() {
 #[test]
 fn relative_interval_from_bool_and_two_opt_datetime() {
     assert_eq!(
-        EmptiableRelativeInterval::from((
-            false,
-            Some(SignedDuration::from_hours(1)),
-            Some(SignedDuration::from_hours(2)),
-        )),
-        EmptiableRelativeInterval::Bounded(BoundedRelativeInterval::new(
-            SignedDuration::from_hours(1),
-            SignedDuration::from_hours(2)
-        )),
+        EmptiableRelativeInterval::from((false, Some(SignedDuration::from_hours(1)), Some(SignedDuration::from_hours(2)),)),
+        EmptiableRelativeInterval::Bound(RelativeInterval::Bounded(BoundedRelativeInterval::new(SignedDuration::from_hours(1), SignedDuration::from_hours(2)))),
     );
 }
 
@@ -129,11 +115,11 @@ fn relative_interval_from_bool_and_two_opt_datetime_bound_inclusivity() {
             Some((SignedDuration::from_hours(1), BoundInclusivity::Exclusive)),
             Some((SignedDuration::from_hours(2), BoundInclusivity::Exclusive)),
         )),
-        EmptiableRelativeInterval::Bounded(BoundedRelativeInterval::new_with_inclusivity(
+        EmptiableRelativeInterval::Bound(RelativeInterval::Bounded(BoundedRelativeInterval::new_with_inclusivity(
             SignedDuration::from_hours(1),
             BoundInclusivity::Exclusive,
             SignedDuration::from_hours(2),
             BoundInclusivity::Exclusive,
-        )),
+        ))),
     );
 }

--- a/src/intervals/relative/emptiable_interval_tests.rs
+++ b/src/intervals/relative/emptiable_interval_tests.rs
@@ -1,10 +1,18 @@
 use jiff::SignedDuration;
 
-use crate::intervals::meta::{BoundInclusivity, OpeningDirection};
-use crate::intervals::relative::{BoundedRelativeInterval, EmptiableRelativeBoundPair, HalfBoundedRelativeInterval, RelativeBoundPair, RelativeEndBound, RelativeFiniteBound, RelativeStartBound, RelativeInterval};
-use crate::intervals::special::{EmptyInterval, UnboundedInterval};
-
 use super::emptiable_interval::*;
+use crate::intervals::meta::{BoundInclusivity, OpeningDirection};
+use crate::intervals::relative::{
+    BoundedRelativeInterval,
+    EmptiableRelativeBoundPair,
+    HalfBoundedRelativeInterval,
+    RelativeBoundPair,
+    RelativeEndBound,
+    RelativeFiniteBound,
+    RelativeInterval,
+    RelativeStartBound,
+};
+use crate::intervals::special::{EmptyInterval, UnboundedInterval};
 
 #[test]
 fn relative_interval_from_relative_bounds() {
@@ -16,11 +24,13 @@ fn relative_interval_from_relative_bounds() {
             )),
             RelativeEndBound::InfiniteFuture,
         )),
-        EmptiableRelativeInterval::Bound(RelativeInterval::HalfBounded(HalfBoundedRelativeInterval::new_with_inclusivity(
-            SignedDuration::from_hours(1),
-            BoundInclusivity::Exclusive,
-            OpeningDirection::ToFuture,
-        ))),
+        EmptiableRelativeInterval::Bound(RelativeInterval::HalfBounded(
+            HalfBoundedRelativeInterval::new_with_inclusivity(
+                SignedDuration::from_hours(1),
+                BoundInclusivity::Exclusive,
+                OpeningDirection::ToFuture,
+            )
+        )),
     );
 }
 
@@ -34,11 +44,13 @@ fn relative_interval_from_emptiable_relative_bounds() {
             )),
             RelativeEndBound::InfiniteFuture,
         ))),
-        EmptiableRelativeInterval::Bound(RelativeInterval::HalfBounded(HalfBoundedRelativeInterval::new_with_inclusivity(
-            SignedDuration::from_hours(1),
-            BoundInclusivity::Exclusive,
-            OpeningDirection::ToFuture,
-        ))),
+        EmptiableRelativeInterval::Bound(RelativeInterval::HalfBounded(
+            HalfBoundedRelativeInterval::new_with_inclusivity(
+                SignedDuration::from_hours(1),
+                BoundInclusivity::Exclusive,
+                OpeningDirection::ToFuture,
+            )
+        )),
     );
 }
 
@@ -68,12 +80,14 @@ fn relative_interval_from_opt_datetime_bound_inclusivity_pairs() {
             Some((SignedDuration::from_hours(1), BoundInclusivity::Exclusive)),
             Some((SignedDuration::from_hours(2), BoundInclusivity::Exclusive)),
         )),
-        EmptiableRelativeInterval::Bound(RelativeInterval::Bounded(BoundedRelativeInterval::new_with_inclusivity(
-            SignedDuration::from_hours(1),
-            BoundInclusivity::Exclusive,
-            SignedDuration::from_hours(2),
-            BoundInclusivity::Exclusive,
-        ))),
+        EmptiableRelativeInterval::Bound(RelativeInterval::Bounded(
+            BoundedRelativeInterval::new_with_inclusivity(
+                SignedDuration::from_hours(1),
+                BoundInclusivity::Exclusive,
+                SignedDuration::from_hours(2),
+                BoundInclusivity::Exclusive,
+            )
+        )),
     );
 }
 
@@ -90,8 +104,15 @@ fn relative_interval_from_bool_and_two_opt_datetime_empty() {
 #[test]
 fn relative_interval_from_bool_and_two_opt_datetime() {
     assert_eq!(
-        EmptiableRelativeInterval::from((false, Some(SignedDuration::from_hours(1)), Some(SignedDuration::from_hours(2)),)),
-        EmptiableRelativeInterval::Bound(RelativeInterval::Bounded(BoundedRelativeInterval::new(SignedDuration::from_hours(1), SignedDuration::from_hours(2)))),
+        EmptiableRelativeInterval::from((
+            false,
+            Some(SignedDuration::from_hours(1)),
+            Some(SignedDuration::from_hours(2)),
+        )),
+        EmptiableRelativeInterval::Bound(RelativeInterval::Bounded(BoundedRelativeInterval::new(
+            SignedDuration::from_hours(1),
+            SignedDuration::from_hours(2)
+        ))),
     );
 }
 
@@ -115,11 +136,13 @@ fn relative_interval_from_bool_and_two_opt_datetime_bound_inclusivity() {
             Some((SignedDuration::from_hours(1), BoundInclusivity::Exclusive)),
             Some((SignedDuration::from_hours(2), BoundInclusivity::Exclusive)),
         )),
-        EmptiableRelativeInterval::Bound(RelativeInterval::Bounded(BoundedRelativeInterval::new_with_inclusivity(
-            SignedDuration::from_hours(1),
-            BoundInclusivity::Exclusive,
-            SignedDuration::from_hours(2),
-            BoundInclusivity::Exclusive,
-        ))),
+        EmptiableRelativeInterval::Bound(RelativeInterval::Bounded(
+            BoundedRelativeInterval::new_with_inclusivity(
+                SignedDuration::from_hours(1),
+                BoundInclusivity::Exclusive,
+                SignedDuration::from_hours(2),
+                BoundInclusivity::Exclusive,
+            )
+        )),
     );
 }

--- a/src/intervals/relative/end_bound.rs
+++ b/src/intervals/relative/end_bound.rs
@@ -253,6 +253,24 @@ impl From<RelativeFiniteBound> for RelativeEndBound {
     }
 }
 
+impl From<Option<SignedDuration>> for RelativeEndBound {
+    fn from(value: Option<SignedDuration>) -> Self {
+        match value {
+            Some(offset) => Self::Finite(RelativeFiniteBound::from(offset)),
+            None => Self::InfiniteFuture,
+        }
+    }
+}
+
+impl From<Option<(SignedDuration, BoundInclusivity)>> for RelativeEndBound {
+    fn from(value: Option<(SignedDuration, BoundInclusivity)>) -> Self {
+        match value {
+            Some((offset, inclusivity)) => Self::Finite(RelativeFiniteBound::new_with_inclusivity(offset, inclusivity)),
+            None => Self::InfiniteFuture,
+        }
+    }
+}
+
 impl From<Bound<SignedDuration>> for RelativeEndBound {
     fn from(bound: Bound<SignedDuration>) -> Self {
         match bound {

--- a/src/intervals/relative/half_bounded_interval.rs
+++ b/src/intervals/relative/half_bounded_interval.rs
@@ -21,6 +21,7 @@ use serde::{Deserialize, Serialize};
 use crate::intervals::meta::{
     BoundInclusivity,
     Duration as IntervalDuration,
+    Emptiable,
     HasBoundInclusivity,
     HasDuration,
     HasOpenness,
@@ -323,6 +324,12 @@ impl HasRelativeBoundPair for HalfBoundedRelativeInterval {
             },
             OpeningDirection::ToFuture => RelativeEndBound::InfiniteFuture,
         }
+    }
+}
+
+impl Emptiable for HalfBoundedRelativeInterval {
+    fn is_empty(&self) -> bool {
+        false
     }
 }
 

--- a/src/intervals/relative/half_bounded_interval.rs
+++ b/src/intervals/relative/half_bounded_interval.rs
@@ -277,7 +277,7 @@ impl HalfBoundedRelativeInterval {
 
     /// Wraps the interval in [`EmptiableRelativeInterval`]
     #[must_use]
-    pub fn to_emptiable_interval(self) -> EmptiableRelativeInterval {
+    pub fn to_emptiable(self) -> EmptiableRelativeInterval {
         EmptiableRelativeInterval::from(self)
     }
 }

--- a/src/intervals/relative/interval.rs
+++ b/src/intervals/relative/interval.rs
@@ -32,6 +32,7 @@ use serde::{Deserialize, Serialize};
 use crate::intervals::meta::{
     BoundInclusivity,
     Duration as IntervalDuration,
+    Emptiable,
     HasDuration,
     HasOpenness,
     HasRelativity,
@@ -249,6 +250,12 @@ impl PartialOrd for RelativeInterval {
 impl Ord for RelativeInterval {
     fn cmp(&self, other: &Self) -> Ordering {
         self.rel_bound_pair().cmp(&other.rel_bound_pair())
+    }
+}
+
+impl Emptiable for RelativeInterval {
+    fn is_empty(&self) -> bool {
+        false
     }
 }
 

--- a/src/intervals/relative/interval.rs
+++ b/src/intervals/relative/interval.rs
@@ -177,7 +177,7 @@ impl RelativeInterval {
 
     /// Wraps the interval in [`EmptiableRelativeInterval`]
     #[must_use]
-    pub fn to_emptiable_interval(self) -> EmptiableRelativeInterval {
+    pub fn to_emptiable(self) -> EmptiableRelativeInterval {
         EmptiableRelativeInterval::from(self)
     }
 }

--- a/src/intervals/relative/start_bound.rs
+++ b/src/intervals/relative/start_bound.rs
@@ -271,6 +271,24 @@ impl From<RelativeFiniteBound> for RelativeStartBound {
     }
 }
 
+impl From<Option<SignedDuration>> for RelativeStartBound {
+    fn from(value: Option<SignedDuration>) -> Self {
+        match value {
+            Some(offset) => Self::Finite(RelativeFiniteBound::from(offset)),
+            None => Self::InfinitePast,
+        }
+    }
+}
+
+impl From<Option<(SignedDuration, BoundInclusivity)>> for RelativeStartBound {
+    fn from(value: Option<(SignedDuration, BoundInclusivity)>) -> Self {
+        match value {
+            Some((offset, inclusivity)) => Self::Finite(RelativeFiniteBound::new_with_inclusivity(offset, inclusivity)),
+            None => Self::InfinitePast,
+        }
+    }
+}
+
 impl From<Bound<SignedDuration>> for RelativeStartBound {
     fn from(bound: Bound<SignedDuration>) -> Self {
         match bound {

--- a/src/iter/intervals/complement_tests.rs
+++ b/src/iter/intervals/complement_tests.rs
@@ -54,12 +54,14 @@ fn run() -> Result<(), Box<dyn Error>> {
                     "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
                     OpeningDirection::ToPast,
-                )).to_emptiable(),
+                ))
+                .to_emptiable(),
                 AbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
                     OpeningDirection::ToFuture,
-                )).to_emptiable(),
+                ))
+                .to_emptiable(),
             ),
             ComplementResult::Single(EmptiableAbsoluteInterval::Empty(EmptyInterval)),
             ComplementResult::Single(
@@ -67,8 +69,9 @@ fn run() -> Result<(), Box<dyn Error>> {
                     "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
                     OpeningDirection::ToPast,
-                )
-            ).to_emptiable()),
+                ))
+                .to_emptiable()
+            ),
         ],
     );
 
@@ -97,20 +100,23 @@ fn run_reverse() -> Result<(), Box<dyn Error>> {
                     "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
                     OpeningDirection::ToPast,
-                )
-            ).to_emptiable()),
+                ))
+                .to_emptiable()
+            ),
             ComplementResult::Single(EmptiableAbsoluteInterval::Empty(EmptyInterval)),
             ComplementResult::Split(
                 AbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new_with_inclusivity(
                     "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
                     OpeningDirection::ToPast,
-                )).to_emptiable(),
+                ))
+                .to_emptiable(),
                 AbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
                     OpeningDirection::ToFuture,
-                )).to_emptiable(),
+                ))
+                .to_emptiable(),
             ),
         ],
     );

--- a/src/iter/intervals/complement_tests.rs
+++ b/src/iter/intervals/complement_tests.rs
@@ -54,14 +54,12 @@ fn run() -> Result<(), Box<dyn Error>> {
                     "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
                     OpeningDirection::ToPast,
-                ))
-                .to_emptiable_interval(),
+                )).to_emptiable(),
                 AbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
                     OpeningDirection::ToFuture,
-                ))
-                .to_emptiable_interval(),
+                )).to_emptiable(),
             ),
             ComplementResult::Single(EmptiableAbsoluteInterval::Empty(EmptyInterval)),
             ComplementResult::Single(
@@ -69,9 +67,8 @@ fn run() -> Result<(), Box<dyn Error>> {
                     "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
                     OpeningDirection::ToPast,
-                ))
-                .to_emptiable_interval()
-            ),
+                )
+            ).to_emptiable()),
         ],
     );
 
@@ -100,23 +97,20 @@ fn run_reverse() -> Result<(), Box<dyn Error>> {
                     "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
                     OpeningDirection::ToPast,
-                ))
-                .to_emptiable_interval()
-            ),
+                )
+            ).to_emptiable()),
             ComplementResult::Single(EmptiableAbsoluteInterval::Empty(EmptyInterval)),
             ComplementResult::Split(
                 AbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new_with_inclusivity(
                     "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
                     OpeningDirection::ToPast,
-                ))
-                .to_emptiable_interval(),
+                )).to_emptiable(),
                 AbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
                     OpeningDirection::ToFuture,
-                ))
-                .to_emptiable_interval(),
+                )).to_emptiable(),
             ),
         ],
     );

--- a/src/iter/intervals/remove_empty_tests.rs
+++ b/src/iter/intervals/remove_empty_tests.rs
@@ -15,18 +15,16 @@ use crate::intervals::special::{EmptyInterval, UnboundedInterval};
 #[test]
 fn create() -> Result<(), Box<dyn Error>> {
     let intervals = [
-        AbsoluteInterval::Unbounded(UnboundedInterval).to_emptiable_interval(),
+        AbsoluteInterval::Unbounded(UnboundedInterval).to_emptiable(),
         AbsoluteInterval::Bounded(BoundedAbsoluteInterval::new(
             "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-        ))
-        .to_emptiable_interval(),
+        )).to_emptiable(),
         EmptiableAbsoluteInterval::Empty(EmptyInterval),
         AbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new(
             "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             OpeningDirection::ToPast,
-        ))
-        .to_emptiable_interval(),
+        )).to_emptiable(),
     ];
 
     intervals.remove_empty_intervals();
@@ -37,36 +35,32 @@ fn create() -> Result<(), Box<dyn Error>> {
 #[test]
 fn run() -> Result<(), Box<dyn Error>> {
     let intervals = [
-        AbsoluteInterval::Unbounded(UnboundedInterval).to_emptiable_interval(),
+        AbsoluteInterval::Unbounded(UnboundedInterval).to_emptiable(),
         AbsoluteInterval::Bounded(BoundedAbsoluteInterval::new(
             "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-        ))
-        .to_emptiable_interval(),
+        )).to_emptiable(),
         EmptiableAbsoluteInterval::Empty(EmptyInterval),
         EmptiableAbsoluteInterval::Empty(EmptyInterval),
         AbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new(
             "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             OpeningDirection::ToPast,
-        ))
-        .to_emptiable_interval(),
+        )).to_emptiable(),
         EmptiableAbsoluteInterval::Empty(EmptyInterval),
     ];
 
     assert_eq!(
         intervals.remove_empty_intervals().collect::<Vec<_>>(),
         vec![
-            AbsoluteInterval::Unbounded(UnboundedInterval).to_emptiable_interval(),
+            AbsoluteInterval::Unbounded(UnboundedInterval).to_emptiable(),
             AbsoluteInterval::Bounded(BoundedAbsoluteInterval::new(
                 "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            ))
-            .to_emptiable_interval(),
+            )).to_emptiable(),
             AbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new(
                 "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 OpeningDirection::ToPast
-            ))
-            .to_emptiable_interval(),
+            )).to_emptiable(),
         ],
     );
 
@@ -76,19 +70,17 @@ fn run() -> Result<(), Box<dyn Error>> {
 #[test]
 fn run_reverse() -> Result<(), Box<dyn Error>> {
     let intervals = [
-        AbsoluteInterval::Unbounded(UnboundedInterval).to_emptiable_interval(),
+        AbsoluteInterval::Unbounded(UnboundedInterval).to_emptiable(),
         AbsoluteInterval::Bounded(BoundedAbsoluteInterval::new(
             "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-        ))
-        .to_emptiable_interval(),
+        )).to_emptiable(),
         EmptiableAbsoluteInterval::Empty(EmptyInterval),
         EmptiableAbsoluteInterval::Empty(EmptyInterval),
         AbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new(
             "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             OpeningDirection::ToPast,
-        ))
-        .to_emptiable_interval(),
+        )).to_emptiable(),
         EmptiableAbsoluteInterval::Empty(EmptyInterval),
     ];
 
@@ -98,14 +90,12 @@ fn run_reverse() -> Result<(), Box<dyn Error>> {
             AbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new(
                 "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 OpeningDirection::ToPast
-            ))
-            .to_emptiable_interval(),
+            )).to_emptiable(),
             AbsoluteInterval::Bounded(BoundedAbsoluteInterval::new(
                 "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            ))
-            .to_emptiable_interval(),
-            AbsoluteInterval::Unbounded(UnboundedInterval).to_emptiable_interval(),
+            )).to_emptiable(),
+            AbsoluteInterval::Unbounded(UnboundedInterval).to_emptiable(),
         ],
     );
 

--- a/src/iter/intervals/remove_empty_tests.rs
+++ b/src/iter/intervals/remove_empty_tests.rs
@@ -19,12 +19,14 @@ fn create() -> Result<(), Box<dyn Error>> {
         AbsoluteInterval::Bounded(BoundedAbsoluteInterval::new(
             "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-        )).to_emptiable(),
+        ))
+        .to_emptiable(),
         EmptiableAbsoluteInterval::Empty(EmptyInterval),
         AbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new(
             "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             OpeningDirection::ToPast,
-        )).to_emptiable(),
+        ))
+        .to_emptiable(),
     ];
 
     intervals.remove_empty_intervals();
@@ -39,13 +41,15 @@ fn run() -> Result<(), Box<dyn Error>> {
         AbsoluteInterval::Bounded(BoundedAbsoluteInterval::new(
             "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-        )).to_emptiable(),
+        ))
+        .to_emptiable(),
         EmptiableAbsoluteInterval::Empty(EmptyInterval),
         EmptiableAbsoluteInterval::Empty(EmptyInterval),
         AbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new(
             "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             OpeningDirection::ToPast,
-        )).to_emptiable(),
+        ))
+        .to_emptiable(),
         EmptiableAbsoluteInterval::Empty(EmptyInterval),
     ];
 
@@ -56,11 +60,13 @@ fn run() -> Result<(), Box<dyn Error>> {
             AbsoluteInterval::Bounded(BoundedAbsoluteInterval::new(
                 "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )).to_emptiable(),
+            ))
+            .to_emptiable(),
             AbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new(
                 "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 OpeningDirection::ToPast
-            )).to_emptiable(),
+            ))
+            .to_emptiable(),
         ],
     );
 
@@ -74,13 +80,15 @@ fn run_reverse() -> Result<(), Box<dyn Error>> {
         AbsoluteInterval::Bounded(BoundedAbsoluteInterval::new(
             "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-        )).to_emptiable(),
+        ))
+        .to_emptiable(),
         EmptiableAbsoluteInterval::Empty(EmptyInterval),
         EmptiableAbsoluteInterval::Empty(EmptyInterval),
         AbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new(
             "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             OpeningDirection::ToPast,
-        )).to_emptiable(),
+        ))
+        .to_emptiable(),
         EmptiableAbsoluteInterval::Empty(EmptyInterval),
     ];
 
@@ -90,11 +98,13 @@ fn run_reverse() -> Result<(), Box<dyn Error>> {
             AbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new(
                 "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 OpeningDirection::ToPast
-            )).to_emptiable(),
+            ))
+            .to_emptiable(),
             AbsoluteInterval::Bounded(BoundedAbsoluteInterval::new(
                 "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )).to_emptiable(),
+            ))
+            .to_emptiable(),
             AbsoluteInterval::Unbounded(UnboundedInterval).to_emptiable(),
         ],
     );


### PR DESCRIPTION
# Explanation

As mentioned in #24 , the `Emptiable` trait should be implemented even on trivially
non-empty intervals, `to_emptiable_interval` should be renamed to `to_emptiable` to
match `Emptiable*Interval`'s semantics, and `Emptiable*Interval` should have the same
semantics as `Emptiable*BoundPair`: a `Bound` variant and an `Empty` variant.

# Noticed problems

`cargo fmt` broke markdown links (both code and non-code) links :c

# Changelog

## Added

- Implement `Emptiable` on every interval type
- Implement additional conversion methods for `EmptiableAbsoluteBoundPair`
- Implement additional conversion methods for `EmptiableRelativeBoundPair`
- Implement additional conversion methods for `EmptiableAbsoluteInterval`
- Implement additional conversion methods for `EmptiableRelativeInterval`

## Changed

- Re-structured some conversion methods for better separation of concerns
- Renamed `AbsoluteInterval::to_emptiable_interval` to `to_emptiable`
- Renamed `RelativeInterval::to_emptiable_interval` to `to_emptiable`
- Restructured `EmptiableAbsoluteInterval` to have the same semantics as `EmptiableAbsoluteBoundPair`:
  one `Bound` variant, one `Empty` variant.
- Restructured `EmptiableRelativeInterval` to have the same semantics as `EmptiableRelativeBoundPair`:
  one `Bound` variant, one `Empty` variant.
