### PR TITLE
Improved: Added `from_range` and `try_from_range` on all interval types

### DIFF
--- a/branch-changelog.md
+++ b/branch-changelog.md
@@ -6,6 +6,8 @@
 
 - Implemented `try_from_range` on `BoundedAbsoluteInterval`
 - Implemented `from_range` on `EmptiableAbsoluteBoundPair`
+- Implemented `from_range` on `AbsoluteInterval`
+- Implemented `from_range` on `EmptiableAbsoluteInterval`
 
 ## Changed
 

--- a/branch-changelog.md
+++ b/branch-changelog.md
@@ -5,6 +5,7 @@
 ## Added
 
 - Implemented `try_from_range` on `BoundedAbsoluteInterval`
+- Implemented `try_from_range` on `HalfBoundedAbsoluteInterval`
 - Implemented `from_range` on `EmptiableAbsoluteBoundPair`
 - Implemented `from_range` on `AbsoluteInterval`
 - Implemented `from_range` on `EmptiableAbsoluteInterval`

--- a/branch-changelog.md
+++ b/branch-changelog.md
@@ -1,20 +1,32 @@
 <!-- CLEAN THIS FILE AFTER CREATING PR -->
 
-# Changelog
+<details>
+<summary><h1>Changelog</h1></summary>
+
+Remove the sections that don't apply to your PR
 
 ## Added
 
-- Implemented `try_from_range` on `BoundedAbsoluteInterval`
-- Implemented `try_from_range` on `HalfBoundedAbsoluteInterval`
-- Implemented `from_range` on `EmptiableAbsoluteBoundPair`
-- Implemented `from_range` on `EmptiableAbsoluteInterval`
-- Implemented `try_from_range` on `BoundedRelativeInterval`
-- Implemented `try_from_range` on `HalfBoundedRelativeInterval`
-- Implemented `from_range` on `EmptiableRelativeBoundPair`
-- Implemented `from_range` on `EmptiableAbsoluteInterval`
+- Things you've added
 
 ## Changed
 
-- Updated `from_range` implementation on `AbsoluteInterval`
-- Updated `from_range` implementation on `RelativeInterval`
-- Changed re-exports internally (not global `prelude`) to use wildcards
+- Things you've changed
+
+## Deprecated
+
+- Things you've marked as deprecated
+
+## Removed
+
+- Things you've removed
+
+## Fixed
+
+- Things you've fixed
+
+## Security
+
+- Vulnerabilities you've fixed (add relevant CVE and any other relevant info/links)
+
+</details>

--- a/branch-changelog.md
+++ b/branch-changelog.md
@@ -7,27 +7,14 @@
 - Implemented `try_from_range` on `BoundedAbsoluteInterval`
 - Implemented `try_from_range` on `HalfBoundedAbsoluteInterval`
 - Implemented `from_range` on `EmptiableAbsoluteBoundPair`
-- Implemented `from_range` on `AbsoluteInterval`
 - Implemented `from_range` on `EmptiableAbsoluteInterval`
 - Implemented `try_from_range` on `BoundedRelativeInterval`
 - Implemented `try_from_range` on `HalfBoundedRelativeInterval`
+- Implemented `from_range` on `EmptiableRelativeBoundPair`
+- Implemented `from_range` on `EmptiableAbsoluteInterval`
 
 ## Changed
 
-- Changed re-exports internally (not global `prelude`) to use wildcard
-
-## Deprecated
-
-- Things you've marked as deprecated
-
-## Removed
-
-- Things you've removed
-
-## Fixed
-
-- Things you've fixed
-
-## Security
-
-- Vulnerabilities you've fixed (add relevant CVE and any other relevant info/links)
+- Updated `from_range` implementation on `AbsoluteInterval`
+- Updated `from_range` implementation on `RelativeInterval`
+- Changed re-exports internally (not global `prelude`) to use wildcards

--- a/branch-changelog.md
+++ b/branch-changelog.md
@@ -4,7 +4,7 @@
 
 ## Added
 
-- 
+- Implemented `try_from_range` on `BoundedAbsoluteInterval`
 
 ## Changed
 

--- a/branch-changelog.md
+++ b/branch-changelog.md
@@ -5,6 +5,7 @@
 ## Added
 
 - Implemented `try_from_range` on `BoundedAbsoluteInterval`
+- Implemented `from_range` on `EmptiableAbsoluteBoundPair`
 
 ## Changed
 

--- a/branch-changelog.md
+++ b/branch-changelog.md
@@ -9,6 +9,8 @@
 - Implemented `from_range` on `EmptiableAbsoluteBoundPair`
 - Implemented `from_range` on `AbsoluteInterval`
 - Implemented `from_range` on `EmptiableAbsoluteInterval`
+- Implemented `try_from_range` on `BoundedRelativeInterval`
+- Implemented `try_from_range` on `HalfBoundedRelativeInterval`
 
 ## Changed
 

--- a/branch-changelog.md
+++ b/branch-changelog.md
@@ -4,18 +4,11 @@
 
 ## Added
 
-- [x] Implement `Emptiable` on every interval type
-- [x] Implement additional conversions on absolute emptiable types
-- [x] Implement additional conversions on relative emptiable types
+- 
 
 ## Changed
 
-- [x] Renamed `AbsoluteInterval::to_emptiable_interval` to `to_emptiable`
-- [x] Renamed `RelativeInterval::to_emptiable_interval` to `to_emptiable`
-- [x] `EmptiableAbsoluteInterval` has the same semantics as `EmptiableAbsoluteBoundPair`:
-      two variants: `Bound`, `Empty`.
-- [x] `EmptiableRelativeInterval` has the same semantics as `EmptiableRelativeBoundPair`:
-      two variants: `Bound`, `Empty`.
+- Changed re-exports internally (not global `prelude`) to use wildcard
 
 ## Deprecated
 

--- a/src/intervals/absolute.rs
+++ b/src/intervals/absolute.rs
@@ -42,19 +42,16 @@ tests! {
 }
 
 inline_docs! {
-    pub use bounded_interval::{
-        BoundedAbsoluteInterval, BoundedAbsoluteIntervalCreationError,
-        BoundedAbsoluteIntervalFromAbsoluteBoundPairError, BoundedAbsoluteIntervalFromAbsoluteIntervalError,
-    };
-    pub use bound::AbsoluteBound;
-    pub use bound_pair::{AbsoluteBoundPair, AbsoluteBoundPairFromEmptiableAbsoluteBoundPairError, HasAbsoluteBoundPair};
-    pub use end_bound::AbsoluteEndBound;
-    pub use emptiable_bound_pair::{HasEmptiableAbsoluteBoundPair, EmptiableAbsoluteBoundPair};
-    pub use emptiable_interval::EmptiableAbsoluteInterval;
-    pub use finite_bound::{AbsoluteFiniteBound, AbsoluteFiniteBoundFromBoundError};
-    pub use half_bounded_interval::{HalfBoundedAbsoluteInterval, HalfBoundedAbsoluteIntervalCreationError};
-    pub use interval::AbsoluteInterval;
-    pub use start_bound::AbsoluteStartBound;
+    pub use bounded_interval::*;
+    pub use bound::*;
+    pub use bound_pair::*;
+    pub use end_bound::*;
+    pub use emptiable_bound_pair::*;
+    pub use emptiable_interval::*;
+    pub use finite_bound::*;
+    pub use half_bounded_interval::*;
+    pub use interval::*;
+    pub use start_bound::*;
 }
 
 /// Swaps an absolute start bound with an absolute end bound

--- a/src/intervals/absolute/bounded_interval.rs
+++ b/src/intervals/absolute/bounded_interval.rs
@@ -225,7 +225,7 @@ impl BoundedAbsoluteInterval {
         }
     }
 
-    /// Attempts to create a [`BoundedAbsoluteInterval`] from a [`RangeBounds`] implementor
+    /// Attempts to create a [`BoundedAbsoluteInterval`] from a [`Timestamp`] range
     ///
     /// # Errors
     ///

--- a/src/intervals/absolute/bounded_interval.rs
+++ b/src/intervals/absolute/bounded_interval.rs
@@ -15,7 +15,7 @@
 use std::cmp::Ordering;
 use std::error::Error;
 use std::fmt::Display;
-use std::ops::{Range, RangeInclusive};
+use std::ops::{Bound, Range, RangeBounds, RangeInclusive};
 
 use jiff::Timestamp;
 #[cfg(feature = "serde")]
@@ -223,6 +223,54 @@ impl BoundedAbsoluteInterval {
             Ordering::Equal => Self::unchecked_new(start, end),
             Ordering::Greater => Self::unchecked_new_with_inclusivity(end, end_inclusivity, start, start_inclusivity),
         }
+    }
+
+    /// Attempts to create a [`BoundedAbsoluteInterval`] from a [`RangeBounds`] implementor
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BoundedAbsoluteIntervalTryFromRangeError`] if any range bound is [unbounded](Bound::Unbounded).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::error::Error;
+    /// # use jiff::Timestamp;
+    /// # use periodical::intervals::absolute::{BoundedAbsoluteInterval, BoundedAbsoluteIntervalTryFromRangeError};
+    /// # use periodical::intervals::meta::BoundInclusivity;
+    /// let start = "2026-01-01 08:00:00Z".parse::<Timestamp>()?;
+    /// let end = "2026-01-01 16:00:00Z".parse::<Timestamp>()?;
+    ///
+    /// let interval = BoundedAbsoluteInterval::try_from_range(start..end)?;
+    ///
+    /// assert_eq!(interval.start(), start);
+    /// assert_eq!(interval.start_inclusivity(), BoundInclusivity::Inclusive);
+    /// assert_eq!(interval.end(), end);
+    /// assert_eq!(interval.end_inclusivity(), BoundInclusivity::Exclusive);
+    /// # Ok::<(), Box<dyn Error>>(())
+    /// ```
+    pub fn try_from_range<R>(range: R) -> Result<Self, BoundedAbsoluteIntervalTryFromRangeError>
+    where
+        R: RangeBounds<Timestamp>,
+    {
+        let (start, start_inclusivity) = match range.start_bound() {
+            Bound::Included(&time) => (time, BoundInclusivity::Inclusive),
+            Bound::Excluded(&time) => (time, BoundInclusivity::Exclusive),
+            Bound::Unbounded => return Err(BoundedAbsoluteIntervalTryFromRangeError),
+        };
+
+        let (end, end_inclusivity) = match range.end_bound() {
+            Bound::Included(&time) => (time, BoundInclusivity::Inclusive),
+            Bound::Excluded(&time) => (time, BoundInclusivity::Exclusive),
+            Bound::Unbounded => return Err(BoundedAbsoluteIntervalTryFromRangeError),
+        };
+
+        Ok(Self::new_with_inclusivity(
+            start,
+            start_inclusivity,
+            end,
+            end_inclusivity,
+        ))
     }
 
     /// Returns the start time
@@ -672,6 +720,22 @@ impl Display for BoundedAbsoluteIntervalCreationError {
 }
 
 impl Error for BoundedAbsoluteIntervalCreationError {}
+
+/// Error that can occur when trying to create a [`BoundedAbsoluteInterval`]
+/// from a [`RangeBounds`] implementor
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct BoundedAbsoluteIntervalTryFromRangeError;
+
+impl Display for BoundedAbsoluteIntervalTryFromRangeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "An error occurred when trying to create a `BoundedAbsoluteInterval` from a `RangeBounds` implementor",
+        )
+    }
+}
+
+impl Error for BoundedAbsoluteIntervalTryFromRangeError {}
 
 /// Errors that can occur when updating a [`BoundedAbsoluteInterval`]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/src/intervals/absolute/bounded_interval.rs
+++ b/src/intervals/absolute/bounded_interval.rs
@@ -722,7 +722,7 @@ impl Display for BoundedAbsoluteIntervalCreationError {
 impl Error for BoundedAbsoluteIntervalCreationError {}
 
 /// Error that can occur when trying to create a [`BoundedAbsoluteInterval`]
-/// from a [`RangeBounds`] implementor
+/// from a [`Timestamp`] range
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct BoundedAbsoluteIntervalTryFromRangeError;
 
@@ -730,7 +730,7 @@ impl Display for BoundedAbsoluteIntervalTryFromRangeError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "An error occurred when trying to create a `BoundedAbsoluteInterval` from a `RangeBounds` implementor",
+            "An error occurred when trying to convert a `Timestamp` range into a `BoundedAbsoluteInterval`",
         )
     }
 }

--- a/src/intervals/absolute/emptiable_bound_pair.rs
+++ b/src/intervals/absolute/emptiable_bound_pair.rs
@@ -5,6 +5,7 @@
 //! interval](crate::intervals::special::EmptyInterval).
 
 use std::cmp::Ordering;
+use std::ops::RangeBounds;
 use std::time::Duration;
 
 #[cfg(feature = "arbitrary")]
@@ -79,6 +80,38 @@ pub enum EmptiableAbsoluteBoundPair {
 }
 
 impl EmptiableAbsoluteBoundPair {
+    /// Creates an [`EmptiableAbsoluteBoundPair`] from a [`Timestamp`] range
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::error::Error;
+    /// # use jiff::Timestamp;
+    /// # use periodical::intervals::absolute::{AbsoluteBoundPair, AbsoluteFiniteBound, EmptiableAbsoluteBoundPair};
+    /// # use periodical::intervals::meta::BoundInclusivity;
+    /// let start = "2026-01-01 00:00:00Z".parse::<Timestamp>()?;
+    /// let end = "2026-05-01 00:00:00Z".parse::<Timestamp>()?;
+    ///
+    /// let emptiable_bounds = EmptiableAbsoluteBoundPair::from_range(start..end);
+    ///
+    /// assert_eq!(
+    ///     emptiable_bounds.clone().bound().map(|bounds| bounds.start()),
+    ///     Some(AbsoluteFiniteBound::new(start).to_start_bound()),
+    /// );
+    /// assert_eq!(
+    ///     emptiable_bounds.clone().bound().map(|bounds| bounds.end()),
+    ///     Some(AbsoluteFiniteBound::new_with_inclusivity(end, BoundInclusivity::Exclusive).to_end_bound()),
+    /// );
+    /// # Ok::<(), Box<dyn Error>>(())
+    /// ```
+    #[must_use]
+    pub fn from_range<R>(range: R) -> Self
+    where
+        R: RangeBounds<Timestamp>,
+    {
+        AbsoluteBoundPair::from_range(range).to_emptiable()
+    }
+
     /// Returns the content of the [`Bound`](EmptiableAbsoluteBoundPair::Bound)
     /// variant
     ///

--- a/src/intervals/absolute/emptiable_bound_pair.rs
+++ b/src/intervals/absolute/emptiable_bound_pair.rs
@@ -89,8 +89,8 @@ impl EmptiableAbsoluteBoundPair {
     /// # use jiff::Timestamp;
     /// # use periodical::intervals::absolute::{AbsoluteBoundPair, AbsoluteFiniteBound, EmptiableAbsoluteBoundPair};
     /// # use periodical::intervals::meta::BoundInclusivity;
-    /// let start = "2026-01-01 00:00:00Z".parse::<Timestamp>()?;
-    /// let end = "2026-05-01 00:00:00Z".parse::<Timestamp>()?;
+    /// let start = "2026-01-01 08:00:00Z".parse::<Timestamp>()?;
+    /// let end = "2026-01-01 16:00:00Z".parse::<Timestamp>()?;
     ///
     /// let emptiable_bounds = EmptiableAbsoluteBoundPair::from_range(start..end);
     ///

--- a/src/intervals/absolute/emptiable_interval.rs
+++ b/src/intervals/absolute/emptiable_interval.rs
@@ -18,6 +18,7 @@
 //! [`AbsoluteInterval`].
 
 use std::cmp::Ordering;
+use std::ops::RangeBounds;
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
@@ -58,6 +59,40 @@ pub enum EmptiableAbsoluteInterval {
 }
 
 impl EmptiableAbsoluteInterval {
+    /// Creates an [`EmptiableAbsoluteInterval`] from a [`Timestamp`] range
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::error::Error;
+    /// # use jiff::Timestamp;
+    /// # use periodical::intervals::absolute::{
+    /// #     AbsoluteFiniteBound, AbsoluteInterval, EmptiableAbsoluteInterval, HasEmptiableAbsoluteBoundPair,
+    /// # };
+    /// # use periodical::intervals::meta::BoundInclusivity;
+    /// let start = "2026-01-01 08:00:00Z".parse::<Timestamp>()?;
+    /// let end = "2026-01-01 16:00:00Z".parse::<Timestamp>()?;
+    ///
+    /// let interval = EmptiableAbsoluteInterval::from_range(start..end);
+    ///
+    /// assert_eq!(
+    ///     interval.partial_abs_start(),
+    ///     Some(AbsoluteFiniteBound::new(start).to_start_bound()),
+    /// );
+    /// assert_eq!(
+    ///     interval.partial_abs_end(),
+    ///     Some(AbsoluteFiniteBound::new_with_inclusivity(end, BoundInclusivity::Exclusive).to_end_bound()),
+    /// );
+    /// # Ok::<(), Box<dyn Error>>(())
+    /// ```
+    #[must_use]
+    pub fn from_range<R>(range: R) -> Self
+    where
+        R: RangeBounds<Timestamp>,
+    {
+        AbsoluteInterval::from_range(range).to_emptiable()
+    }
+
     /// Returns the content of the [`Bound`](EmptiableAbsoluteInterval::Bound) variant
     ///
     /// Consumes `self` and puts the content of the [`Bound`](EmptiableAbsoluteInterval::Bound) variant

--- a/src/intervals/absolute/half_bounded_interval.rs
+++ b/src/intervals/absolute/half_bounded_interval.rs
@@ -12,7 +12,7 @@
 
 use std::error::Error;
 use std::fmt::Display;
-use std::ops::{RangeFrom, RangeTo, RangeToInclusive};
+use std::ops::{Bound, RangeBounds, RangeFrom, RangeTo, RangeToInclusive};
 
 use jiff::Timestamp;
 #[cfg(feature = "serde")]
@@ -134,6 +134,58 @@ impl HalfBoundedAbsoluteInterval {
             reference,
             opening_direction,
             reference_inclusivity,
+        }
+    }
+
+    /// Attempts to create a [`HalfBoundedAbsoluteInterval`] from a [`Timestamp`] range
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HalfBoundedAbsoluteIntervalTryFromRangeError`] if there is not exactly
+    /// one [unbounded](Bound::Unbounded) range bound.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::error::Error;
+    /// # use jiff::Timestamp;
+    /// # use periodical::intervals::absolute::{HalfBoundedAbsoluteInterval, HalfBoundedAbsoluteIntervalTryFromRangeError};
+    /// # use periodical::intervals::meta::BoundInclusivity;
+    /// let reference = "2026-01-01 08:00:00Z".parse::<Timestamp>()?;
+    ///
+    /// let interval = HalfBoundedAbsoluteInterval::try_from_range(..reference)?;
+    ///
+    /// assert_eq!(interval.reference(), reference);
+    /// assert_eq!(interval.reference_inclusivity(), BoundInclusivity::Exclusive);
+    /// # Ok::<(), Box<dyn Error>>(())
+    /// ```
+    pub fn try_from_range<R>(range: R) -> Result<Self, HalfBoundedAbsoluteIntervalTryFromRangeError>
+    where
+        R: RangeBounds<Timestamp>,
+    {
+        match (range.start_bound(), range.end_bound()) {
+            (Bound::Included(_) | Bound::Excluded(_), Bound::Included(_) | Bound::Excluded(_))
+            | (Bound::Unbounded, Bound::Unbounded) => Err(HalfBoundedAbsoluteIntervalTryFromRangeError),
+            (Bound::Unbounded, Bound::Included(&reference)) => Ok(Self::new_with_inclusivity(
+                reference,
+                BoundInclusivity::Inclusive,
+                OpeningDirection::ToPast,
+            )),
+            (Bound::Unbounded, Bound::Excluded(&reference)) => Ok(Self::new_with_inclusivity(
+                reference,
+                BoundInclusivity::Exclusive,
+                OpeningDirection::ToPast,
+            )),
+            (Bound::Included(&reference), Bound::Unbounded) => Ok(Self::new_with_inclusivity(
+                reference,
+                BoundInclusivity::Inclusive,
+                OpeningDirection::ToFuture,
+            )),
+            (Bound::Excluded(&reference), Bound::Unbounded) => Ok(Self::new_with_inclusivity(
+                reference,
+                BoundInclusivity::Exclusive,
+                OpeningDirection::ToFuture,
+            )),
         }
     }
 
@@ -321,6 +373,21 @@ impl Display for HalfBoundedAbsoluteIntervalCreationError {
 }
 
 impl Error for HalfBoundedAbsoluteIntervalCreationError {}
+
+/// Error that can occur when trying to convert a [`Timestamp`] range into a [`HalfBoundedAbsoluteInterval`]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct HalfBoundedAbsoluteIntervalTryFromRangeError;
+
+impl Display for HalfBoundedAbsoluteIntervalTryFromRangeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "An error occurred when trying to convert a `Timestamp` range into a `HalfBoundedAbsoluteInterval`"
+        )
+    }
+}
+
+impl Error for HalfBoundedAbsoluteIntervalTryFromRangeError {}
 
 impl Interval for HalfBoundedAbsoluteInterval {}
 

--- a/src/intervals/absolute/interval.rs
+++ b/src/intervals/absolute/interval.rs
@@ -21,7 +21,7 @@
 use std::cmp::Ordering;
 use std::error::Error;
 use std::fmt::Display;
-use std::ops::{Bound, RangeBounds};
+use std::ops::RangeBounds;
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
@@ -84,74 +84,36 @@ pub enum AbsoluteInterval {
 }
 
 impl AbsoluteInterval {
+    /// Creates an [`AbsoluteInterval`] from a [`Timestamp`] range
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::error::Error;
+    /// # use jiff::Timestamp;
+    /// # use periodical::intervals::absolute::{AbsoluteFiniteBound, AbsoluteInterval, HasAbsoluteBoundPair};
+    /// # use periodical::intervals::meta::BoundInclusivity;
+    /// let start = "2026-01-01 08:00:00Z".parse::<Timestamp>()?;
+    /// let end = "2026-01-01 16:00:00Z".parse::<Timestamp>()?;
+    ///
+    /// let interval = AbsoluteInterval::from_range(start..end);
+    ///
+    /// assert_eq!(
+    ///     interval.abs_start(),
+    ///     AbsoluteFiniteBound::new(start).to_start_bound(),
+    /// );
+    /// assert_eq!(
+    ///     interval.abs_end(),
+    ///     AbsoluteFiniteBound::new_with_inclusivity(end, BoundInclusivity::Exclusive).to_end_bound(),
+    /// );
+    /// # Ok::<(), Box<dyn Error>>(())
+    /// ```
     #[must_use]
     pub fn from_range<R>(range: R) -> Self
     where
         R: RangeBounds<Timestamp>,
     {
-        match (range.start_bound().cloned(), range.end_bound().cloned()) {
-            (Bound::Included(start), Bound::Included(end)) => {
-                AbsoluteInterval::Bounded(BoundedAbsoluteInterval::new_with_inclusivity(
-                    start,
-                    BoundInclusivity::Inclusive,
-                    end,
-                    BoundInclusivity::Inclusive,
-                ))
-            },
-            (Bound::Included(start), Bound::Excluded(end)) => {
-                AbsoluteInterval::Bounded(BoundedAbsoluteInterval::new_with_inclusivity(
-                    start,
-                    BoundInclusivity::Inclusive,
-                    end,
-                    BoundInclusivity::Exclusive,
-                ))
-            },
-            (Bound::Excluded(start), Bound::Included(end)) => {
-                AbsoluteInterval::Bounded(BoundedAbsoluteInterval::new_with_inclusivity(
-                    start,
-                    BoundInclusivity::Exclusive,
-                    end,
-                    BoundInclusivity::Inclusive,
-                ))
-            },
-            (Bound::Excluded(start), Bound::Excluded(end)) => {
-                AbsoluteInterval::Bounded(BoundedAbsoluteInterval::new_with_inclusivity(
-                    start,
-                    BoundInclusivity::Exclusive,
-                    end,
-                    BoundInclusivity::Exclusive,
-                ))
-            },
-            (Bound::Included(start), Bound::Unbounded) => {
-                AbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new_with_inclusivity(
-                    start,
-                    BoundInclusivity::Inclusive,
-                    OpeningDirection::ToFuture,
-                ))
-            },
-            (Bound::Excluded(start), Bound::Unbounded) => {
-                AbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new_with_inclusivity(
-                    start,
-                    BoundInclusivity::Exclusive,
-                    OpeningDirection::ToFuture,
-                ))
-            },
-            (Bound::Unbounded, Bound::Included(start)) => {
-                AbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new_with_inclusivity(
-                    start,
-                    BoundInclusivity::Inclusive,
-                    OpeningDirection::ToPast,
-                ))
-            },
-            (Bound::Unbounded, Bound::Excluded(start)) => {
-                AbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new_with_inclusivity(
-                    start,
-                    BoundInclusivity::Exclusive,
-                    OpeningDirection::ToPast,
-                ))
-            },
-            (Bound::Unbounded, Bound::Unbounded) => AbsoluteInterval::Unbounded(UnboundedInterval),
-        }
+        Self::from(AbsoluteBoundPair::from_range(range))
     }
 
     /// Compares two [`AbsoluteInterval`], but if they have the same start,

--- a/src/intervals/relative.rs
+++ b/src/intervals/relative.rs
@@ -42,16 +42,16 @@ tests! {
 }
 
 inline_docs! {
-    pub use bounded_interval::BoundedRelativeInterval;
-    pub use bound::RelativeBound;
-    pub use bound_pair::{HasRelativeBoundPair, RelativeBoundPair};
-    pub use emptiable_bound_pair::{HasEmptiableRelativeBoundPair, EmptiableRelativeBoundPair};
-    pub use emptiable_interval::EmptiableRelativeInterval;
-    pub use end_bound::RelativeEndBound;
-    pub use finite_bound::RelativeFiniteBound;
-    pub use half_bounded_interval::HalfBoundedRelativeInterval;
-    pub use interval::RelativeInterval;
-    pub use start_bound::RelativeStartBound;
+    pub use bounded_interval::*;
+    pub use bound::*;
+    pub use bound_pair::*;
+    pub use emptiable_bound_pair::*;
+    pub use emptiable_interval::*;
+    pub use end_bound::*;
+    pub use finite_bound::*;
+    pub use half_bounded_interval::*;
+    pub use interval::*;
+    pub use start_bound::*;
 }
 
 /// Swaps a relative start bound with a relative end bound

--- a/src/intervals/relative/bounded_interval.rs
+++ b/src/intervals/relative/bounded_interval.rs
@@ -15,7 +15,7 @@
 use std::cmp::Ordering;
 use std::error::Error;
 use std::fmt::Display;
-use std::ops::{Range, RangeInclusive};
+use std::ops::{Bound, Range, RangeBounds, RangeInclusive};
 use std::time::Duration as StdDuration;
 
 use jiff::SignedDuration;
@@ -309,6 +309,54 @@ impl BoundedRelativeInterval {
                     .checked_add_unsigned(length.as_nanos())
                     .ok_or(BoundedRelativeIntervalCreationError::OutOfRangeEnd)?,
             ),
+            end_inclusivity,
+        ))
+    }
+
+    /// Attempts to create a [`BoundedRelativeInterval`] from a [`SignedDuration`] range
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BoundedRelativeIntervalTryFromRangeError`] if any range bound is [unbounded](Bound::Unbounded).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::error::Error;
+    /// # use jiff::SignedDuration;
+    /// # use periodical::intervals::meta::BoundInclusivity;
+    /// # use periodical::intervals::relative::{BoundedRelativeInterval, BoundedRelativeIntervalTryFromRangeError};
+    /// let start = SignedDuration::from_hours(8);
+    /// let end = SignedDuration::from_hours(16);
+    ///
+    /// let interval = BoundedRelativeInterval::try_from_range(start..end)?;
+    ///
+    /// assert_eq!(interval.start(), start);
+    /// assert_eq!(interval.start_inclusivity(), BoundInclusivity::Inclusive);
+    /// assert_eq!(interval.end(), end);
+    /// assert_eq!(interval.end_inclusivity(), BoundInclusivity::Exclusive);
+    /// # Ok::<(), Box<dyn Error>>(())
+    /// ```
+    pub fn try_from_range<R>(range: R) -> Result<Self, BoundedRelativeIntervalTryFromRangeError>
+    where
+        R: RangeBounds<SignedDuration>,
+    {
+        let (start, start_inclusivity) = match range.start_bound() {
+            Bound::Included(&offset) => (offset, BoundInclusivity::Inclusive),
+            Bound::Excluded(&offset) => (offset, BoundInclusivity::Exclusive),
+            Bound::Unbounded => return Err(BoundedRelativeIntervalTryFromRangeError),
+        };
+
+        let (end, end_inclusivity) = match range.end_bound() {
+            Bound::Included(&offset) => (offset, BoundInclusivity::Inclusive),
+            Bound::Excluded(&offset) => (offset, BoundInclusivity::Exclusive),
+            Bound::Unbounded => return Err(BoundedRelativeIntervalTryFromRangeError),
+        };
+
+        Ok(Self::new_with_inclusivity(
+            start,
+            start_inclusivity,
+            end,
             end_inclusivity,
         ))
     }
@@ -821,6 +869,22 @@ impl Display for BoundedRelativeIntervalCreationError {
 }
 
 impl Error for BoundedRelativeIntervalCreationError {}
+
+/// Error that can occur when trying to create a [`BoundedRelativeInterval`]
+/// from a [`SignedDuration`] range
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct BoundedRelativeIntervalTryFromRangeError;
+
+impl Display for BoundedRelativeIntervalTryFromRangeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "An error occurred when trying to convert a `SignedDuration` range into a `BoundedRelativeInterval`",
+        )
+    }
+}
+
+impl Error for BoundedRelativeIntervalTryFromRangeError {}
 
 /// Errors that can occur when updating a [`BoundedRelativeInterval`]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/src/intervals/relative/emptiable_bound_pair.rs
+++ b/src/intervals/relative/emptiable_bound_pair.rs
@@ -4,6 +4,7 @@
 //! but has the extra ability of being able to represent an [empty interval](crate::intervals::special::EmptyInterval).
 
 use std::cmp::Ordering;
+use std::ops::RangeBounds;
 use std::time::Duration;
 
 #[cfg(feature = "arbitrary")]
@@ -78,6 +79,38 @@ pub enum EmptiableRelativeBoundPair {
 }
 
 impl EmptiableRelativeBoundPair {
+    /// Creates an [`EmptiableRelativeBoundPair`] from a [`SignedDuration`] range
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::error::Error;
+    /// # use jiff::SignedDuration;
+    /// # use periodical::intervals::relative::{RelativeBoundPair, RelativeFiniteBound, EmptiableRelativeBoundPair};
+    /// # use periodical::intervals::meta::BoundInclusivity;
+    /// let start = SignedDuration::from_hours(8);
+    /// let end = SignedDuration::from_hours(16);
+    ///
+    /// let emptiable_bounds = EmptiableRelativeBoundPair::from_range(start..end);
+    ///
+    /// assert_eq!(
+    ///     emptiable_bounds.clone().bound().map(|bounds| bounds.start()),
+    ///     Some(RelativeFiniteBound::new(start).to_start_bound()),
+    /// );
+    /// assert_eq!(
+    ///     emptiable_bounds.clone().bound().map(|bounds| bounds.end()),
+    ///     Some(RelativeFiniteBound::new_with_inclusivity(end, BoundInclusivity::Exclusive).to_end_bound()),
+    /// );
+    /// # Ok::<(), Box<dyn Error>>(())
+    /// ```
+    #[must_use]
+    pub fn from_range<R>(range: R) -> Self
+    where
+        R: RangeBounds<SignedDuration>,
+    {
+        RelativeBoundPair::from_range(range).to_emptiable()
+    }
+
     /// Returns the content of the [`Bound`](EmptiableRelativeBoundPair::Bound)
     /// variant
     ///

--- a/src/intervals/relative/emptiable_interval.rs
+++ b/src/intervals/relative/emptiable_interval.rs
@@ -18,6 +18,7 @@
 //! [`RelativeInterval`].
 
 use std::cmp::Ordering;
+use std::ops::RangeBounds;
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
@@ -58,6 +59,40 @@ pub enum EmptiableRelativeInterval {
 }
 
 impl EmptiableRelativeInterval {
+    /// Creates an [`EmptiableRelativeInterval`] from a [`SignedDuration`] range
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::error::Error;
+    /// # use jiff::SignedDuration;
+    /// # use periodical::intervals::meta::BoundInclusivity;
+    /// # use periodical::intervals::relative::{
+    /// #     RelativeFiniteBound, RelativeInterval, EmptiableRelativeInterval, HasEmptiableRelativeBoundPair,
+    /// # };
+    /// let start = SignedDuration::from_hours(8);
+    /// let end = SignedDuration::from_hours(16);
+    ///
+    /// let interval = EmptiableRelativeInterval::from_range(start..end);
+    ///
+    /// assert_eq!(
+    ///     interval.partial_rel_start(),
+    ///     Some(RelativeFiniteBound::new(start).to_start_bound()),
+    /// );
+    /// assert_eq!(
+    ///     interval.partial_rel_end(),
+    ///     Some(RelativeFiniteBound::new_with_inclusivity(end, BoundInclusivity::Exclusive).to_end_bound()),
+    /// );
+    /// # Ok::<(), Box<dyn Error>>(())
+    /// ```
+    #[must_use]
+    pub fn from_range<R>(range: R) -> Self
+    where
+        R: RangeBounds<SignedDuration>,
+    {
+        RelativeInterval::from_range(range).to_emptiable()
+    }
+
     /// Returns the content of the [`Bound`](EmptiableRelativeInterval::Bound) variant
     ///
     /// Consumes `self` and puts the content of the [`Bound`](EmptiableRelativeInterval::Bound) variant

--- a/src/intervals/relative/half_bounded_interval.rs
+++ b/src/intervals/relative/half_bounded_interval.rs
@@ -12,7 +12,7 @@
 
 use std::error::Error;
 use std::fmt::Display;
-use std::ops::{RangeFrom, RangeTo, RangeToInclusive};
+use std::ops::{Bound, RangeBounds, RangeFrom, RangeTo, RangeToInclusive};
 
 use jiff::SignedDuration;
 #[cfg(feature = "serde")]
@@ -132,6 +132,63 @@ impl HalfBoundedRelativeInterval {
             reference,
             opening_direction,
             reference_inclusivity,
+        }
+    }
+
+    /// Attempts to create a [`HalfBoundedRelativeInterval`] from a [`SignedDuration`] range
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HalfBoundedRelativeIntervalTryFromRangeError`] if there is not exactly
+    /// one [unbounded](Bound::Unbounded) range bound.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::error::Error;
+    /// # use jiff::SignedDuration;
+    /// # use periodical::intervals::relative::{
+    /// #     HalfBoundedRelativeInterval, HalfBoundedRelativeIntervalTryFromRangeError,
+    /// # };
+    /// # use periodical::intervals::meta::BoundInclusivity;
+    /// let reference = SignedDuration::from_hours(8);
+    ///
+    /// let interval = HalfBoundedRelativeInterval::try_from_range(..reference)?;
+    ///
+    /// assert_eq!(interval.reference(), reference);
+    /// assert_eq!(
+    ///     interval.reference_inclusivity(),
+    ///     BoundInclusivity::Exclusive
+    /// );
+    /// # Ok::<(), Box<dyn Error>>(())
+    /// ```
+    pub fn try_from_range<R>(range: R) -> Result<Self, HalfBoundedRelativeIntervalTryFromRangeError>
+    where
+        R: RangeBounds<SignedDuration>,
+    {
+        match (range.start_bound(), range.end_bound()) {
+            (Bound::Included(_) | Bound::Excluded(_), Bound::Included(_) | Bound::Excluded(_))
+            | (Bound::Unbounded, Bound::Unbounded) => Err(HalfBoundedRelativeIntervalTryFromRangeError),
+            (Bound::Unbounded, Bound::Included(&reference)) => Ok(Self::new_with_inclusivity(
+                reference,
+                BoundInclusivity::Inclusive,
+                OpeningDirection::ToPast,
+            )),
+            (Bound::Unbounded, Bound::Excluded(&reference)) => Ok(Self::new_with_inclusivity(
+                reference,
+                BoundInclusivity::Exclusive,
+                OpeningDirection::ToPast,
+            )),
+            (Bound::Included(&reference), Bound::Unbounded) => Ok(Self::new_with_inclusivity(
+                reference,
+                BoundInclusivity::Inclusive,
+                OpeningDirection::ToFuture,
+            )),
+            (Bound::Excluded(&reference), Bound::Unbounded) => Ok(Self::new_with_inclusivity(
+                reference,
+                BoundInclusivity::Exclusive,
+                OpeningDirection::ToFuture,
+            )),
         }
     }
 
@@ -283,6 +340,38 @@ impl HalfBoundedRelativeInterval {
     }
 }
 
+/// Errors that can occur when trying to convert [`RelativeBoundPair`] into
+/// [`HalfBoundedRelativeInterval`]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum HalfBoundedRelativeIntervalFromRelativeBoundPairError {
+    NotHalfBoundedInterval,
+}
+
+impl Display for HalfBoundedRelativeIntervalFromRelativeBoundPairError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotHalfBoundedInterval => write!(f, "Not a half-bounded interval"),
+        }
+    }
+}
+
+impl Error for HalfBoundedRelativeIntervalFromRelativeBoundPairError {}
+
+/// Error that can occur when trying to convert a [`SignedDuration`] range into a [`HalfBoundedRelativeInterval`]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct HalfBoundedRelativeIntervalTryFromRangeError;
+
+impl Display for HalfBoundedRelativeIntervalTryFromRangeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "An error occurred when trying to convert a `SignedDuration` range into a `HalfBoundedRelativeInterval`"
+        )
+    }
+}
+
+impl Error for HalfBoundedRelativeIntervalTryFromRangeError {}
+
 impl Interval for HalfBoundedRelativeInterval {}
 
 impl HasOpenness for HalfBoundedRelativeInterval {
@@ -374,23 +463,6 @@ impl From<RangeToInclusive<SignedDuration>> for HalfBoundedRelativeInterval {
         )
     }
 }
-
-/// Errors that can occur when trying to convert [`RelativeBoundPair`] into
-/// [`HalfBoundedRelativeInterval`]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum HalfBoundedRelativeIntervalFromRelativeBoundPairError {
-    NotHalfBoundedInterval,
-}
-
-impl Display for HalfBoundedRelativeIntervalFromRelativeBoundPairError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::NotHalfBoundedInterval => write!(f, "Not a half-bounded interval"),
-        }
-    }
-}
-
-impl Error for HalfBoundedRelativeIntervalFromRelativeBoundPairError {}
 
 impl TryFrom<RelativeBoundPair> for HalfBoundedRelativeInterval {
     type Error = HalfBoundedRelativeIntervalFromRelativeBoundPairError;

--- a/src/intervals/relative/interval.rs
+++ b/src/intervals/relative/interval.rs
@@ -21,7 +21,7 @@
 use std::cmp::Ordering;
 use std::error::Error;
 use std::fmt::Display;
-use std::ops::{Bound, RangeBounds};
+use std::ops::RangeBounds;
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
@@ -84,74 +84,36 @@ pub enum RelativeInterval {
 }
 
 impl RelativeInterval {
+    /// Creates an [`RelativeInterval`] from a [`SignedDuration`] range
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::error::Error;
+    /// # use jiff::SignedDuration;
+    /// # use periodical::intervals::meta::BoundInclusivity;
+    /// # use periodical::intervals::relative::{RelativeFiniteBound, RelativeInterval, HasRelativeBoundPair};
+    /// let start = SignedDuration::from_hours(8);
+    /// let end = SignedDuration::from_hours(16);
+    ///
+    /// let interval = RelativeInterval::from_range(start..end);
+    ///
+    /// assert_eq!(
+    ///     interval.rel_start(),
+    ///     RelativeFiniteBound::new(start).to_start_bound(),
+    /// );
+    /// assert_eq!(
+    ///     interval.rel_end(),
+    ///     RelativeFiniteBound::new_with_inclusivity(end, BoundInclusivity::Exclusive).to_end_bound(),
+    /// );
+    /// # Ok::<(), Box<dyn Error>>(())
+    /// ```
     #[must_use]
     pub fn from_range<R>(range: R) -> Self
     where
         R: RangeBounds<SignedDuration>,
     {
-        match (range.start_bound().cloned(), range.end_bound().cloned()) {
-            (Bound::Included(start), Bound::Included(end)) => {
-                RelativeInterval::Bounded(BoundedRelativeInterval::new_with_inclusivity(
-                    start,
-                    BoundInclusivity::Inclusive,
-                    end,
-                    BoundInclusivity::Inclusive,
-                ))
-            },
-            (Bound::Included(start), Bound::Excluded(end)) => {
-                RelativeInterval::Bounded(BoundedRelativeInterval::new_with_inclusivity(
-                    start,
-                    BoundInclusivity::Inclusive,
-                    end,
-                    BoundInclusivity::Exclusive,
-                ))
-            },
-            (Bound::Excluded(start), Bound::Included(end)) => {
-                RelativeInterval::Bounded(BoundedRelativeInterval::new_with_inclusivity(
-                    start,
-                    BoundInclusivity::Exclusive,
-                    end,
-                    BoundInclusivity::Inclusive,
-                ))
-            },
-            (Bound::Excluded(start), Bound::Excluded(end)) => {
-                RelativeInterval::Bounded(BoundedRelativeInterval::new_with_inclusivity(
-                    start,
-                    BoundInclusivity::Exclusive,
-                    end,
-                    BoundInclusivity::Exclusive,
-                ))
-            },
-            (Bound::Included(start), Bound::Unbounded) => {
-                RelativeInterval::HalfBounded(HalfBoundedRelativeInterval::new_with_inclusivity(
-                    start,
-                    BoundInclusivity::Inclusive,
-                    OpeningDirection::ToFuture,
-                ))
-            },
-            (Bound::Excluded(start), Bound::Unbounded) => {
-                RelativeInterval::HalfBounded(HalfBoundedRelativeInterval::new_with_inclusivity(
-                    start,
-                    BoundInclusivity::Exclusive,
-                    OpeningDirection::ToFuture,
-                ))
-            },
-            (Bound::Unbounded, Bound::Included(start)) => {
-                RelativeInterval::HalfBounded(HalfBoundedRelativeInterval::new_with_inclusivity(
-                    start,
-                    BoundInclusivity::Inclusive,
-                    OpeningDirection::ToPast,
-                ))
-            },
-            (Bound::Unbounded, Bound::Excluded(start)) => {
-                RelativeInterval::HalfBounded(HalfBoundedRelativeInterval::new_with_inclusivity(
-                    start,
-                    BoundInclusivity::Exclusive,
-                    OpeningDirection::ToPast,
-                ))
-            },
-            (Bound::Unbounded, Bound::Unbounded) => RelativeInterval::Unbounded(UnboundedInterval),
-        }
+        Self::from(RelativeBoundPair::from_range(range))
     }
 
     /// Compares two [`RelativeInterval`], but if they have the same start,


### PR DESCRIPTION
# Explanation

As listed in #29 , in order to improve convenience, being able to create intervals from
native ranges is a good improvement.

# Changelog

## Added

- Implemented `try_from_range` on `BoundedAbsoluteInterval`
- Implemented `try_from_range` on `HalfBoundedAbsoluteInterval`
- Implemented `from_range` on `EmptiableAbsoluteBoundPair`
- Implemented `from_range` on `EmptiableAbsoluteInterval`
- Implemented `try_from_range` on `BoundedRelativeInterval`
- Implemented `try_from_range` on `HalfBoundedRelativeInterval`
- Implemented `from_range` on `EmptiableRelativeBoundPair`
- Implemented `from_range` on `EmptiableAbsoluteInterval`

## Changed

- Updated `from_range` implementation on `AbsoluteInterval`
- Updated `from_range` implementation on `RelativeInterval`
- Changed re-exports internally (not global `prelude`) to use wildcards
