### PR TITLE
Improved: Added tons of conversions for intervals

### DIFF
--- a/branch-changelog.md
+++ b/branch-changelog.md
@@ -7,7 +7,7 @@ Find way to handle multiple interval durations to handle correctly mathematical 
 
 FIXME: Conversion errors and descriptions are backwards
 
-FIXME: Remove single-variant errors
+FIXME: Remove implementations of operations where it always returns an error
 
 <details>
 <summary><h1>Changelog</h1></summary>
@@ -73,18 +73,50 @@ FIXME: Remove single-variant errors
 ## Changed
 
 - `BoundedAbsoluteIntervalFromAbsoluteIntervalError` was converted from a single-variant enum to a tag struct
+  and renamed to `BoundedAbsoluteIntervalTryFromAbsoluteIntervalError`
 - `AbsoluteBoundPairFromEmptiableAbsoluteBoundPairError` was converted from a single-variant enum to a tag struct
+  and renamed to `AbsoluteBoundPairTryFromEmptiableAbsoluteBoundPairError`
+- `BoundedAbsoluteIntervalFromAbsoluteBoundPairError` was converted from a single-variant enum to a tag struct
+  and renamed to `BoundedAbsoluteIntervalTryFromAbsoluteBoundPairError`
+- `AbsoluteFiniteBoundFromBoundError` was converted from a single-variant enum to a tag struct
+  and renamed to `AbsoluteFiniteBoundTryFromBoundError`
+- `HalfBoundedAbsoluteIntervalFromAbsoluteBoundPairError` was converted from a single-variant enum to a tag struct
+  and renamed to `HalfBoundedAbsoluteIntervalTryFromAbsoluteBoundPairError`
+- `HalfBoundedAbsoluteIntervalFromAbsoluteIntervalError` was converted from a single-variant enum to a tag struct
+  and renamed `HalfBoundedAbsoluteIntervalTryFromAbsoluteIntervalError`
 - `TryFrom<AbsoluteInterval>` implementation on `BoundedAbsoluteInterval` was re-expressed using the new
   variant retrieval methods of `AbsoluteInterval`
 - `BoundedAbsoluteInterval::to_emptiable` was renamed `to_emptiable_interval` for explicitness
 - `HalfBoundedAbsoluteInterval::to_emptiable` was renamed `to_emptiable_interval` for explicitness
+
 - `BoundedRelativeIntervalFromRelativeIntervalError` was converted from a single-variant enum to a tag struct
+  and renamed to `BoundedRelativeIntervalTryFromRelativeIntervalError`
 - `RelativeBoundPairFromEmptiableRelativeBoundPairError` was converted from a single-variant enum to a tag struct
+  and renamed to `RelativeBoundPairTryFromEmptiableRelativeBoundPairError`
+- `BoundedRelativeIntervalFromRelativeBoundPairError` was converted from a single-variant enum to a tag struct
+  and renamed to `BoundedRelativeIntervalTryFromRelativeBoundPairError`
+- `RelativeFiniteBoundFromBoundError` was converted from a single-variant enum to a tag struct
+  and renamed to `RelativeFiniteBoundTryFromBoundError`
+- `HalfBoundedRelativeIntervalFromRelativeBoundPairError` was converted from a single-variant enum to a tag struct
+  and renamed to `HalfBoundedRelativeIntervalTryFromRelativeBoundPairError`
+- `HalfBoundedRelativeIntervalFromRelativeIntervalError` was converted from a single-variant enum to a tag struct
+  and renamed to `HalfBoundedRelativeIntervalTryFromRelativeIntervalError`
 - `TryFrom<RelativeInterval>` implementation on `BoundedRelativeInterval` was re-expressed using the new
   variant retrieval methods of `RelativeInterval`
 - `BoundedRelativeInterval::to_emptiable` was renamed `to_emptiable_interval` for explicitness
 - `HalfBoundedRelativeInterval::to_emptiable` was renamed `to_emptiable_interval` for explicitness
 - Renamed `Emptiable` trait to `IsEmpty` for explicitness
+
+- `OverlapRemovalErr` was converted from a single-variant enum to a tag struct and renamed
+  to `OverlapRemovalNoOverlapFoundError`
+- `GapFillError` was converted from a single-variant enum to a tag struct and renamed
+  to `GapFillOverlapFoundError`
+- `PrecisionCreationError` was converted from a single-variant enum to a tag struct and renamed
+  to `PrecisionCreationPrecisionIsZeroError`
+- `PrecisionError` was converted from a single-variant enum to a tag struct
+  and renamed to `PrecisionOutOfRangeDateError`
+- `EpsilonInterpretationDurationError` was converted from a single-variant enum to a tag struct
+  and renamed to `EpsilonInterpretationDurationOverflowError`
 
 ## Deprecated
 

--- a/branch-changelog.md
+++ b/branch-changelog.md
@@ -19,6 +19,12 @@ FIXME: Remove single-variant errors
 - Implemented `From<HalfBoundedAbsoluteInterval>` on `AbsoluteBoundPair`
 - Implemented `From<AbsoluteInterval>` on `AbsoluteBoundPair`
 - Implemented `From<UnboundedInterval>` on `AbsoluteBoundPair`
+- Implemented `From<BoundedAbsoluteInterval>` on `EmptiableAbsoluteBoundPair`
+- Implemented `From<HalfBoundedAbsoluteInterval>` on `EmptiableAbsoluteBoundPair`
+- Implemented `From<AbsoluteInterval>` on `EmptiableAbsoluteBoundPair`
+- Implemented `From<EmptiableAbsoluteInterval>` on `EmptiableAbsoluteBoundPair`
+- Implemented `From<UnboundedInterval>` on `EmptiableAbsoluteBoundPair`
+- Implemented `From<EmptyInterval>` on `EmptiableAbsoluteBoundPair`
 - Implemented `TryFrom<AbsoluteBound>` on `AbsoluteStartBound`
 - Implemented `TryFrom<AbsoluteBound>` on `AbsoluteEndBound`
 - Implemented `TryFrom<EmptiableAbsoluteBoundPair>` on `BoundedAbsoluteInterval`
@@ -30,6 +36,12 @@ FIXME: Remove single-variant errors
 - Implemented `From<HalfBoundedRelativeInterval>` on `RelativeBoundPair`
 - Implemented `From<RelativeInterval>` on `RelativeBoundPair`
 - Implemented `From<UnboundedInterval>` on `RelativeBoundPair`
+- Implemented `From<BoundedRelativeInterval>` on `EmptiableRelativeBoundPair`
+- Implemented `From<HalfBoundedRelativeInterval>` on `EmptiableRelativeBoundPair`
+- Implemented `From<RelativeInterval>` on `EmptiableRelativeBoundPair`
+- Implemented `From<EmptiableRelativeInterval>` on `EmptiableRelativeBoundPair`
+- Implemented `From<UnboundedInterval>` on `EmptiableRelativeBoundPair`
+- Implemented `From<EmptyInterval>` on `EmptiableRelativeBoundPair`
 - Implemented `TryFrom<RelativeBound>` on `RelativeStartBound`
 - Implemented `TryFrom<RelativeBound>` on `RelativeEndBound`
 - Implemented `TryFrom<EmptiableRelativeBoundPair>` on `BoundedRelativeInterval`

--- a/branch-changelog.md
+++ b/branch-changelog.md
@@ -9,12 +9,21 @@
 - Added methods to retrieve individual variants of `RelativeInterval` (`bounded`, `half_bounded`, `unbounded`)
 - Implemented `TryFrom<AbsoluteBound>` on `AbsoluteStartBound`
 - Implemented `TryFrom<AbsoluteBound>` on `AbsoluteEndBound`
+- Implemented `TryFrom<EmptiableAbsoluteBoundPair>` on `BoundedAbsoluteInterval`
+- Implemented `TryFrom<EmptiableAbsoluteInterval>` on `BoundedAbsoluteInterval`
 - Implemented `TryFrom<RelativeBound>` on `RelativeStartBound`
 - Implemented `TryFrom<RelativeBound>` on `RelativeEndBound`
+- Implemented `TryFrom<EmptiableRelativeBoundPair>` on `BoundedRelativeInterval`
+- Implemented `TryFrom<EmptiableRelativeInterval>` on `BoundedRelativeInterval`
 
 ## Changed
 
-- Things you've changed
+- `BoundedAbsoluteIntervalFromAbsoluteIntervalError` was converted from a single-variant enum to a tag struct
+- `TryFrom<AbsoluteInterval>` implementation on `BoundedAbsoluteInterval` was re-expressed using the new
+  variant retrieval methods of `AbsoluteInterval`
+- `BoundedAbsoluteIntervalFromRelativeIntervalError` was converted from a single-variant enum to a tag struct
+- `TryFrom<RelativeInterval>` implementation on `BoundedRelativeInterval` was re-expressed using the new
+  variant retrieval methods of `RelativeInterval`
 
 ## Deprecated
 

--- a/branch-changelog.md
+++ b/branch-changelog.md
@@ -50,14 +50,23 @@ FIXME: Remove single-variant errors
 
 - Added methods to convert `UnboundedInterval` into either `AbsoluteBoundPair`, `EmptiableAbsoluteBoundPair`,
   `AbsoluteInterval`, `EmptiableAbsoluteInterval`
-- Implemented `TryFrom<AbsoluteBoundPair>`on ` UnboundedInterval`
-- Implemented `TryFrom<EmptiableAbsoluteBoundPair>`on ` UnboundedInterval`
-- Implemented `TryFrom<AbsoluteInterval>`on ` UnboundedInterval`
-- Implemented `TryFrom<EmptiableAbsoluteInterval>`on ` UnboundedInterval`
-- Implemented `TryFrom<RelativeBoundPair>`on ` UnboundedInterval`
-- Implemented `TryFrom<EmptiableRelativeBoundPair>`on ` UnboundedInterval`
-- Implemented `TryFrom<RelativeInterval>`on ` UnboundedInterval`
-- Implemented `TryFrom<EmptiableRelativeInterval>`on ` UnboundedInterval`
+- Added methods to convert `UnboundedInterval` into either `RelativeBoundPair`, `EmptiableRelativeBoundPair`,
+  `RelativeInterval`, `EmptiableRelativeInterval`
+- Implemented `TryFrom<AbsoluteBoundPair>` on `UnboundedInterval`
+- Implemented `TryFrom<EmptiableAbsoluteBoundPair>` on `UnboundedInterval`
+- Implemented `TryFrom<AbsoluteInterval>` on `UnboundedInterval`
+- Implemented `TryFrom<EmptiableAbsoluteInterval>` on `UnboundedInterval`
+- Implemented `TryFrom<RelativeBoundPair>` on `UnboundedInterval`
+- Implemented `TryFrom<EmptiableRelativeBoundPair>` on `UnboundedInterval`
+- Implemented `TryFrom<RelativeInterval>` on `UnboundedInterval`
+- Implemented `TryFrom<EmptiableRelativeInterval>` on `UnboundedInterval`
+
+- Added methods to convert `EmptyInterval` into either `EmptiableAbsoluteBoundPair` or `EmptiableAbsoluteInterval`
+- Added methods to convert `EmptyInterval` into either `EmptiableRelativeBoundPair` or `EmptiableRelativeInterval`
+- Implemented `TryFrom<EmptiableAbsoluteBoundPair>` on `EmptyInterval`
+- Implemented `TryFrom<EmptiableAbsoluteInterval>` on `EmptyInterval`
+- Implemented `TryFrom<EmptiableRelativeBoundPair>` on `EmptyInterval`
+- Implemented `TryFrom<EmptiableRelativeInterval>` on `EmptyInterval`
 
 - Implemented `to_range_bound_with` on `BoundInclusivity`
 

--- a/branch-changelog.md
+++ b/branch-changelog.md
@@ -5,6 +5,8 @@
 
 ## Added
 
+- Added methods to retrieve individual variants of `AbsoluteInterval` (`bounded`, `half_bounded`, `unbounded`)
+- Added methods to retrieve individual variants of `RelativeInterval` (`bounded`, `half_bounded`, `unbounded`)
 - Implemented `TryFrom<AbsoluteBound>` on `AbsoluteStartBound`
 - Implemented `TryFrom<AbsoluteBound>` on `AbsoluteEndBound`
 - Implemented `TryFrom<RelativeBound>` on `RelativeStartBound`

--- a/branch-changelog.md
+++ b/branch-changelog.md
@@ -3,11 +3,12 @@
 <details>
 <summary><h1>Changelog</h1></summary>
 
-Remove the sections that don't apply to your PR
-
 ## Added
 
-- Things you've added
+- Implemented `TryFrom<AbsoluteBound>` on `AbsoluteStartBound`
+- Implemented `TryFrom<AbsoluteBound>` on `AbsoluteEndBound`
+- Implemented `TryFrom<RelativeBound>` on `RelativeStartBound`
+- Implemented `TryFrom<RelativeBound>` on `RelativeEndBound`
 
 ## Changed
 

--- a/branch-changelog.md
+++ b/branch-changelog.md
@@ -1,11 +1,16 @@
 <!-- CLEAN THIS FILE AFTER CREATING PR -->
 
+# Explanation
+
+Implemented a ton of conversion methods for intervals and converted single-variant enum errors
+to tag struct errors.
+
 # Notes
 
 Find way to handle multiple interval durations to handle correctly mathematical operations
 (addition, subtraction, etc.)
 
-FIXME: Remove implementations of operations where it always returns an error
+Remove implementations of operations where it always returns an error
 
 <details>
 <summary><h1>Changelog</h1></summary>

--- a/branch-changelog.md
+++ b/branch-changelog.md
@@ -5,6 +5,10 @@
 Find way to handle multiple interval durations to handle correctly mathematical operations
 (addition, subtraction, etc.)
 
+FIXME: Conversion errors and descriptions are backwards
+
+FIXME: Remove single-variant errors
+
 <details>
 <summary><h1>Changelog</h1></summary>
 
@@ -16,10 +20,12 @@ Find way to handle multiple interval durations to handle correctly mathematical 
 - Implemented `TryFrom<AbsoluteBound>` on `AbsoluteEndBound`
 - Implemented `TryFrom<EmptiableAbsoluteBoundPair>` on `BoundedAbsoluteInterval`
 - Implemented `TryFrom<EmptiableAbsoluteInterval>` on `BoundedAbsoluteInterval`
+- Implemented `TryFrom<EmptiableAbsoluteInterval>` on `AbsoluteBoundPair`
 - Implemented `TryFrom<RelativeBound>` on `RelativeStartBound`
 - Implemented `TryFrom<RelativeBound>` on `RelativeEndBound`
 - Implemented `TryFrom<EmptiableRelativeBoundPair>` on `BoundedRelativeInterval`
 - Implemented `TryFrom<EmptiableRelativeInterval>` on `BoundedRelativeInterval`
+- Implemented `TryFrom<EmptiableRelativeInterval>` on `RelativeBoundPair`
 - Implemented `to_range_bound_with` on `BoundInclusivity`
 - Implemented `TryFrom<AbsoluteBoundPair>`on ` UnboundedInterval`
 - Implemented `TryFrom<EmptiableAbsoluteBoundPair>`on ` UnboundedInterval`
@@ -33,11 +39,13 @@ Find way to handle multiple interval durations to handle correctly mathematical 
 ## Changed
 
 - `BoundedAbsoluteIntervalFromAbsoluteIntervalError` was converted from a single-variant enum to a tag struct
+- `AbsoluteBoundPairFromEmptiableAbsoluteBoundPairError` was converted from a single-variant enum to a tag struct
 - `TryFrom<AbsoluteInterval>` implementation on `BoundedAbsoluteInterval` was re-expressed using the new
   variant retrieval methods of `AbsoluteInterval`
 - `BoundedAbsoluteInterval::to_emptiable` was renamed `to_emptiable_interval` for explicitness
 - `HalfBoundedAbsoluteInterval::to_emptiable` was renamed `to_emptiable_interval` for explicitness
-- `BoundedAbsoluteIntervalFromRelativeIntervalError` was converted from a single-variant enum to a tag struct
+- `BoundedRelativeIntervalFromRelativeIntervalError` was converted from a single-variant enum to a tag struct
+- `RelativeBoundPairFromEmptiableRelativeBoundPairError` was converted from a single-variant enum to a tag struct
 - `TryFrom<RelativeInterval>` implementation on `BoundedRelativeInterval` was re-expressed using the new
   variant retrieval methods of `RelativeInterval`
 - `BoundedRelativeInterval::to_emptiable` was renamed `to_emptiable_interval` for explicitness

--- a/branch-changelog.md
+++ b/branch-changelog.md
@@ -21,6 +21,14 @@ Find way to handle multiple interval durations to handle correctly mathematical 
 - Implemented `TryFrom<EmptiableRelativeBoundPair>` on `BoundedRelativeInterval`
 - Implemented `TryFrom<EmptiableRelativeInterval>` on `BoundedRelativeInterval`
 - Implemented `to_range_bound_with` on `BoundInclusivity`
+- Implemented `TryFrom<AbsoluteBoundPair>`on ` UnboundedInterval`
+- Implemented `TryFrom<EmptiableAbsoluteBoundPair>`on ` UnboundedInterval`
+- Implemented `TryFrom<AbsoluteInterval>`on ` UnboundedInterval`
+- Implemented `TryFrom<EmptiableAbsoluteInterval>`on ` UnboundedInterval`
+- Implemented `TryFrom<RelativeBoundPair>`on ` UnboundedInterval`
+- Implemented `TryFrom<EmptiableRelativeBoundPair>`on ` UnboundedInterval`
+- Implemented `TryFrom<RelativeInterval>`on ` UnboundedInterval`
+- Implemented `TryFrom<EmptiableRelativeInterval>`on ` UnboundedInterval`
 
 ## Changed
 
@@ -42,7 +50,7 @@ Find way to handle multiple interval durations to handle correctly mathematical 
 
 ## Removed
 
-- Things you've removed
+- Removed `UnboundedIntervalConversionErr` to instead use specific conversion error types
 
 ## Fixed
 

--- a/branch-changelog.md
+++ b/branch-changelog.md
@@ -21,9 +21,13 @@
 - `BoundedAbsoluteIntervalFromAbsoluteIntervalError` was converted from a single-variant enum to a tag struct
 - `TryFrom<AbsoluteInterval>` implementation on `BoundedAbsoluteInterval` was re-expressed using the new
   variant retrieval methods of `AbsoluteInterval`
+- `BoundedAbsoluteInterval::to_emptiable` was renamed `to_emptiable_interval` for explicitness
+- `HalfBoundedAbsoluteInterval::to_emptiable` was renamed `to_emptiable_interval` for explicitness
 - `BoundedAbsoluteIntervalFromRelativeIntervalError` was converted from a single-variant enum to a tag struct
 - `TryFrom<RelativeInterval>` implementation on `BoundedRelativeInterval` was re-expressed using the new
   variant retrieval methods of `RelativeInterval`
+- `BoundedRelativeInterval::to_emptiable` was renamed `to_emptiable_interval` for explicitness
+- `HalfBoundedRelativeInterval::to_emptiable` was renamed `to_emptiable_interval` for explicitness
 
 ## Deprecated
 

--- a/branch-changelog.md
+++ b/branch-changelog.md
@@ -5,8 +5,6 @@
 Find way to handle multiple interval durations to handle correctly mathematical operations
 (addition, subtraction, etc.)
 
-FIXME: Conversion errors and descriptions are backwards
-
 FIXME: Remove implementations of operations where it always returns an error
 
 <details>
@@ -125,13 +123,5 @@ FIXME: Remove implementations of operations where it always returns an error
 ## Removed
 
 - Removed `UnboundedIntervalConversionErr` to instead use specific conversion error types
-
-## Fixed
-
-- Things you've fixed
-
-## Security
-
-- Vulnerabilities you've fixed (add relevant CVE and any other relevant info/links)
 
 </details>

--- a/branch-changelog.md
+++ b/branch-changelog.md
@@ -15,17 +15,25 @@ FIXME: Remove single-variant errors
 ## Added
 
 - Added methods to retrieve individual variants of `AbsoluteInterval` (`bounded`, `half_bounded`, `unbounded`)
-- Added methods to retrieve individual variants of `RelativeInterval` (`bounded`, `half_bounded`, `unbounded`)
+- Implemented `From<BoundedAbsoluteInterval>` on `AbsoluteBoundPair`
+- Implemented `From<HalfBoundedAbsoluteInterval>` on `AbsoluteBoundPair`
+- Implemented `From<UnboundedInterval>` on `AbsoluteBoundPair`
 - Implemented `TryFrom<AbsoluteBound>` on `AbsoluteStartBound`
 - Implemented `TryFrom<AbsoluteBound>` on `AbsoluteEndBound`
 - Implemented `TryFrom<EmptiableAbsoluteBoundPair>` on `BoundedAbsoluteInterval`
 - Implemented `TryFrom<EmptiableAbsoluteInterval>` on `BoundedAbsoluteInterval`
 - Implemented `TryFrom<EmptiableAbsoluteInterval>` on `AbsoluteBoundPair`
+
+- Added methods to retrieve individual variants of `RelativeInterval` (`bounded`, `half_bounded`, `unbounded`)
+- Implemented `From<BoundedRelativeInterval>` on `RelativeBoundPair`
+- Implemented `From<HalfBoundedRelativeInterval>` on `RelativeBoundPair`
+- Implemented `From<UnboundedInterval>` on `RelativeBoundPair`
 - Implemented `TryFrom<RelativeBound>` on `RelativeStartBound`
 - Implemented `TryFrom<RelativeBound>` on `RelativeEndBound`
 - Implemented `TryFrom<EmptiableRelativeBoundPair>` on `BoundedRelativeInterval`
 - Implemented `TryFrom<EmptiableRelativeInterval>` on `BoundedRelativeInterval`
 - Implemented `TryFrom<EmptiableRelativeInterval>` on `RelativeBoundPair`
+
 - Implemented `to_range_bound_with` on `BoundInclusivity`
 - Implemented `TryFrom<AbsoluteBoundPair>`on ` UnboundedInterval`
 - Implemented `TryFrom<EmptiableAbsoluteBoundPair>`on ` UnboundedInterval`

--- a/branch-changelog.md
+++ b/branch-changelog.md
@@ -1,5 +1,10 @@
 <!-- CLEAN THIS FILE AFTER CREATING PR -->
 
+# Notes
+
+Find way to handle multiple interval durations to handle correctly mathematical operations
+(addition, subtraction, etc.)
+
 <details>
 <summary><h1>Changelog</h1></summary>
 
@@ -15,6 +20,7 @@
 - Implemented `TryFrom<RelativeBound>` on `RelativeEndBound`
 - Implemented `TryFrom<EmptiableRelativeBoundPair>` on `BoundedRelativeInterval`
 - Implemented `TryFrom<EmptiableRelativeInterval>` on `BoundedRelativeInterval`
+- Implemented `to_range_bound_with` on `BoundInclusivity`
 
 ## Changed
 
@@ -28,6 +34,7 @@
   variant retrieval methods of `RelativeInterval`
 - `BoundedRelativeInterval::to_emptiable` was renamed `to_emptiable_interval` for explicitness
 - `HalfBoundedRelativeInterval::to_emptiable` was renamed `to_emptiable_interval` for explicitness
+- Renamed `Emptiable` trait to `IsEmpty` for explicitness
 
 ## Deprecated
 

--- a/branch-changelog.md
+++ b/branch-changelog.md
@@ -17,6 +17,7 @@ FIXME: Remove single-variant errors
 - Added methods to retrieve individual variants of `AbsoluteInterval` (`bounded`, `half_bounded`, `unbounded`)
 - Implemented `From<BoundedAbsoluteInterval>` on `AbsoluteBoundPair`
 - Implemented `From<HalfBoundedAbsoluteInterval>` on `AbsoluteBoundPair`
+- Implemented `From<AbsoluteInterval>` on `AbsoluteBoundPair`
 - Implemented `From<UnboundedInterval>` on `AbsoluteBoundPair`
 - Implemented `TryFrom<AbsoluteBound>` on `AbsoluteStartBound`
 - Implemented `TryFrom<AbsoluteBound>` on `AbsoluteEndBound`
@@ -27,6 +28,7 @@ FIXME: Remove single-variant errors
 - Added methods to retrieve individual variants of `RelativeInterval` (`bounded`, `half_bounded`, `unbounded`)
 - Implemented `From<BoundedRelativeInterval>` on `RelativeBoundPair`
 - Implemented `From<HalfBoundedRelativeInterval>` on `RelativeBoundPair`
+- Implemented `From<RelativeInterval>` on `RelativeBoundPair`
 - Implemented `From<UnboundedInterval>` on `RelativeBoundPair`
 - Implemented `TryFrom<RelativeBound>` on `RelativeStartBound`
 - Implemented `TryFrom<RelativeBound>` on `RelativeEndBound`

--- a/branch-changelog.md
+++ b/branch-changelog.md
@@ -48,7 +48,8 @@ FIXME: Remove single-variant errors
 - Implemented `TryFrom<EmptiableRelativeInterval>` on `BoundedRelativeInterval`
 - Implemented `TryFrom<EmptiableRelativeInterval>` on `RelativeBoundPair`
 
-- Implemented `to_range_bound_with` on `BoundInclusivity`
+- Added methods to convert `UnboundedInterval` into either `AbsoluteBoundPair`, `EmptiableAbsoluteBoundPair`,
+  `AbsoluteInterval`, `EmptiableAbsoluteInterval`
 - Implemented `TryFrom<AbsoluteBoundPair>`on ` UnboundedInterval`
 - Implemented `TryFrom<EmptiableAbsoluteBoundPair>`on ` UnboundedInterval`
 - Implemented `TryFrom<AbsoluteInterval>`on ` UnboundedInterval`
@@ -57,6 +58,8 @@ FIXME: Remove single-variant errors
 - Implemented `TryFrom<EmptiableRelativeBoundPair>`on ` UnboundedInterval`
 - Implemented `TryFrom<RelativeInterval>`on ` UnboundedInterval`
 - Implemented `TryFrom<EmptiableRelativeInterval>`on ` UnboundedInterval`
+
+- Implemented `to_range_bound_with` on `BoundInclusivity`
 
 ## Changed
 

--- a/src/intervals/absolute/bound_pair.rs
+++ b/src/intervals/absolute/bound_pair.rs
@@ -25,19 +25,20 @@ use crate::intervals::absolute::{
     AbsoluteEndBound,
     AbsoluteStartBound,
     EmptiableAbsoluteBoundPair,
+    EmptiableAbsoluteInterval,
     check_absolute_bound_pair_for_interval_creation,
     prepare_absolute_bound_pair_for_interval_creation,
 };
 use crate::intervals::meta::{
     BoundInclusivity,
     Duration as IntervalDuration,
-    IsEmpty,
     Epsilon,
     HasBoundInclusivity,
     HasDuration,
     HasOpenness,
     HasRelativity,
     Interval,
+    IsEmpty,
     Openness,
     Relativity,
 };
@@ -496,32 +497,55 @@ impl
     }
 }
 
-/// Errors that can occur when trying to convert [`EmptiableAbsoluteBoundPair`]
+/// Error that can occur when trying to convert [`EmptiableAbsoluteBoundPair`]
 /// into [`AbsoluteBoundPair`]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum AbsoluteBoundPairFromEmptiableAbsoluteBoundPairError {
-    EmptyVariant,
-}
+pub struct AbsoluteBoundPairTryFromEmptiableAbsoluteBoundPairError;
 
-impl Display for AbsoluteBoundPairFromEmptiableAbsoluteBoundPairError {
+impl Display for AbsoluteBoundPairTryFromEmptiableAbsoluteBoundPairError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::EmptyVariant => write!(f, "Provided EmptiableAbsoluteBoundPair was empty"),
-        }
+        write!(
+            f,
+            "An error occurred when trying to convert `EmptiableAbsoluteBoundPair` into `AbsoluteBoundPair`"
+        )
     }
 }
 
-impl Error for AbsoluteBoundPairFromEmptiableAbsoluteBoundPairError {}
+impl Error for AbsoluteBoundPairTryFromEmptiableAbsoluteBoundPairError {}
 
 impl TryFrom<EmptiableAbsoluteBoundPair> for AbsoluteBoundPair {
-    type Error = AbsoluteBoundPairFromEmptiableAbsoluteBoundPairError;
+    type Error = AbsoluteBoundPairTryFromEmptiableAbsoluteBoundPairError;
 
     fn try_from(value: EmptiableAbsoluteBoundPair) -> Result<Self, Self::Error> {
-        match value {
-            EmptiableAbsoluteBoundPair::Empty => {
-                Err(AbsoluteBoundPairFromEmptiableAbsoluteBoundPairError::EmptyVariant)
-            },
-            EmptiableAbsoluteBoundPair::Bound(bounds) => Ok(bounds),
-        }
+        value
+            .bound()
+            .ok_or(AbsoluteBoundPairTryFromEmptiableAbsoluteBoundPairError)
+    }
+}
+
+/// Error that can occur when trying to convert [`EmptiableAbsoluteInterval`]
+/// into [`AbsoluteBoundPair`]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct AbsoluteBoundPairTryFromEmptiableAbsoluteIntervalError;
+
+impl Display for AbsoluteBoundPairTryFromEmptiableAbsoluteIntervalError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "An error occurred when trying to convert `EmptiableAbsoluteInterval` into `AbsoluteBoundPair`"
+        )
+    }
+}
+
+impl Error for AbsoluteBoundPairTryFromEmptiableAbsoluteIntervalError {}
+
+impl TryFrom<EmptiableAbsoluteInterval> for AbsoluteBoundPair {
+    type Error = AbsoluteBoundPairTryFromEmptiableAbsoluteIntervalError;
+
+    fn try_from(value: EmptiableAbsoluteInterval) -> Result<Self, Self::Error> {
+        Ok(value
+            .bound()
+            .ok_or(AbsoluteBoundPairTryFromEmptiableAbsoluteIntervalError)?
+            .abs_bound_pair())
     }
 }

--- a/src/intervals/absolute/bound_pair.rs
+++ b/src/intervals/absolute/bound_pair.rs
@@ -31,7 +31,7 @@ use crate::intervals::absolute::{
 use crate::intervals::meta::{
     BoundInclusivity,
     Duration as IntervalDuration,
-    Emptiable,
+    IsEmpty,
     Epsilon,
     HasBoundInclusivity,
     HasDuration,
@@ -455,7 +455,7 @@ impl Ord for AbsoluteBoundPair {
     }
 }
 
-impl Emptiable for AbsoluteBoundPair {
+impl IsEmpty for AbsoluteBoundPair {
     fn is_empty(&self) -> bool {
         false
     }

--- a/src/intervals/absolute/bound_pair.rs
+++ b/src/intervals/absolute/bound_pair.rs
@@ -23,6 +23,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::intervals::absolute::{
     AbsoluteEndBound,
+    AbsoluteInterval,
     AbsoluteStartBound,
     BoundedAbsoluteInterval,
     EmptiableAbsoluteBoundPair,
@@ -508,6 +509,12 @@ impl From<BoundedAbsoluteInterval> for AbsoluteBoundPair {
 
 impl From<HalfBoundedAbsoluteInterval> for AbsoluteBoundPair {
     fn from(value: HalfBoundedAbsoluteInterval) -> Self {
+        value.abs_bound_pair()
+    }
+}
+
+impl From<AbsoluteInterval> for AbsoluteBoundPair {
+    fn from(value: AbsoluteInterval) -> Self {
         value.abs_bound_pair()
     }
 }

--- a/src/intervals/absolute/bound_pair.rs
+++ b/src/intervals/absolute/bound_pair.rs
@@ -24,8 +24,10 @@ use serde::{Deserialize, Serialize};
 use crate::intervals::absolute::{
     AbsoluteEndBound,
     AbsoluteStartBound,
+    BoundedAbsoluteInterval,
     EmptiableAbsoluteBoundPair,
     EmptiableAbsoluteInterval,
+    HalfBoundedAbsoluteInterval,
     check_absolute_bound_pair_for_interval_creation,
     prepare_absolute_bound_pair_for_interval_creation,
 };
@@ -42,6 +44,7 @@ use crate::intervals::meta::{
     Openness,
     Relativity,
 };
+use crate::intervals::special::UnboundedInterval;
 
 /// Possession of a **non-empty** absolute bound pair
 pub trait HasAbsoluteBoundPair {
@@ -494,6 +497,24 @@ impl
         let start = AbsoluteStartBound::from(start_opt);
         let end = AbsoluteEndBound::from(end_opt);
         Self::new(start, end)
+    }
+}
+
+impl From<BoundedAbsoluteInterval> for AbsoluteBoundPair {
+    fn from(value: BoundedAbsoluteInterval) -> Self {
+        value.abs_bound_pair()
+    }
+}
+
+impl From<HalfBoundedAbsoluteInterval> for AbsoluteBoundPair {
+    fn from(value: HalfBoundedAbsoluteInterval) -> Self {
+        value.abs_bound_pair()
+    }
+}
+
+impl From<UnboundedInterval> for AbsoluteBoundPair {
+    fn from(value: UnboundedInterval) -> Self {
+        value.abs_bound_pair()
     }
 }
 

--- a/src/intervals/absolute/bound_pair_tests.rs
+++ b/src/intervals/absolute/bound_pair_tests.rs
@@ -608,6 +608,6 @@ fn try_from_emptiable_correct_variant() {
 fn try_from_emptiable_wrong_variant() {
     assert_eq!(
         AbsoluteBoundPair::try_from(EmptiableAbsoluteBoundPair::Empty),
-        Err(AbsoluteBoundPairFromEmptiableAbsoluteBoundPairError::EmptyVariant),
+        Err(AbsoluteBoundPairTryFromEmptiableAbsoluteBoundPairError),
     );
 }

--- a/src/intervals/absolute/bounded_interval.rs
+++ b/src/intervals/absolute/bounded_interval.rs
@@ -34,7 +34,7 @@ use crate::intervals::absolute::{
 use crate::intervals::meta::{
     BoundInclusivity,
     Duration as IntervalDuration,
-    Emptiable,
+    IsEmpty,
     Epsilon,
     HasBoundInclusivity,
     HasDuration,
@@ -797,7 +797,7 @@ impl HasAbsoluteBoundPair for BoundedAbsoluteInterval {
     }
 }
 
-impl Emptiable for BoundedAbsoluteInterval {
+impl IsEmpty for BoundedAbsoluteInterval {
     fn is_empty(&self) -> bool {
         false
     }

--- a/src/intervals/absolute/bounded_interval.rs
+++ b/src/intervals/absolute/bounded_interval.rs
@@ -688,7 +688,7 @@ impl BoundedAbsoluteInterval {
 
     /// Wraps the interval in [`EmptiableAbsoluteInterval`]
     #[must_use]
-    pub fn to_emptiable(self) -> EmptiableAbsoluteInterval {
+    pub fn to_emptiable_interval(self) -> EmptiableAbsoluteInterval {
         EmptiableAbsoluteInterval::from(self)
     }
 }

--- a/src/intervals/absolute/bounded_interval.rs
+++ b/src/intervals/absolute/bounded_interval.rs
@@ -27,6 +27,7 @@ use crate::intervals::absolute::{
     AbsoluteFiniteBound,
     AbsoluteInterval,
     AbsoluteStartBound,
+    EmptiableAbsoluteBoundPair,
     EmptiableAbsoluteInterval,
     HasAbsoluteBoundPair,
 };
@@ -876,18 +877,45 @@ impl TryFrom<AbsoluteBoundPair> for BoundedAbsoluteInterval {
     }
 }
 
-/// Errors that can occur when trying to convert [`AbsoluteInterval`] into
+/// Error that can occur when trying to convert [`EmptiableAbsoluteBoundPair`] into [`BoundedAbsoluteInterval`]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct BoundedAbsoluteIntervalTryFromEmptiableAbsoluteBoundPairError;
+
+impl Display for BoundedAbsoluteIntervalTryFromEmptiableAbsoluteBoundPairError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "An error occurred when trying to convert `EmptiableAbsoluteBoundPair` into `BoundedAbsoluteInterval`"
+        )
+    }
+}
+
+impl Error for BoundedAbsoluteIntervalTryFromEmptiableAbsoluteBoundPairError {}
+
+impl TryFrom<EmptiableAbsoluteBoundPair> for BoundedAbsoluteInterval {
+    type Error = BoundedAbsoluteIntervalTryFromEmptiableAbsoluteBoundPairError;
+
+    fn try_from(value: EmptiableAbsoluteBoundPair) -> Result<Self, Self::Error> {
+        Self::try_from(
+            value
+                .bound()
+                .ok_or(BoundedAbsoluteIntervalTryFromEmptiableAbsoluteBoundPairError)?,
+        )
+        .or(Err(BoundedAbsoluteIntervalTryFromEmptiableAbsoluteBoundPairError))
+    }
+}
+
+/// Error that can occur when trying to convert [`AbsoluteInterval`] into
 /// [`BoundedAbsoluteInterval`]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum BoundedAbsoluteIntervalFromAbsoluteIntervalError {
-    WrongVariant,
-}
+pub struct BoundedAbsoluteIntervalFromAbsoluteIntervalError;
 
 impl Display for BoundedAbsoluteIntervalFromAbsoluteIntervalError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::WrongVariant => write!(f, "Wrong variant"),
-        }
+        write!(
+            f,
+            "An error occurred when trying to convert `AbsoluteInterval` into `BoundedAbsoluteInterval"
+        )
     }
 }
 
@@ -897,9 +925,34 @@ impl TryFrom<AbsoluteInterval> for BoundedAbsoluteInterval {
     type Error = BoundedAbsoluteIntervalFromAbsoluteIntervalError;
 
     fn try_from(value: AbsoluteInterval) -> Result<Self, Self::Error> {
-        match value {
-            AbsoluteInterval::Bounded(interval) => Ok(interval),
-            _ => Err(Self::Error::WrongVariant),
-        }
+        value.bounded().ok_or(BoundedAbsoluteIntervalFromAbsoluteIntervalError)
+    }
+}
+
+/// Error that can occur when trying to convert [`EmptiableAbsoluteInterval`] into [`BoundedAbsoluteInterval`]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct BoundedAbsoluteIntervalTryFromEmptiableAbsoluteIntervalError;
+
+impl Display for BoundedAbsoluteIntervalTryFromEmptiableAbsoluteIntervalError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "An error occurred when trying to convert `EmptiableAbsoluteInterval` into `BoundedAbsoluteInterval`"
+        )
+    }
+}
+
+impl Error for BoundedAbsoluteIntervalTryFromEmptiableAbsoluteIntervalError {}
+
+impl TryFrom<EmptiableAbsoluteInterval> for BoundedAbsoluteInterval {
+    type Error = BoundedAbsoluteIntervalTryFromEmptiableAbsoluteIntervalError;
+
+    fn try_from(value: EmptiableAbsoluteInterval) -> Result<Self, Self::Error> {
+        Self::try_from(
+            value
+                .bound()
+                .ok_or(BoundedAbsoluteIntervalTryFromEmptiableAbsoluteIntervalError)?,
+        )
+        .or(Err(BoundedAbsoluteIntervalTryFromEmptiableAbsoluteIntervalError))
     }
 }

--- a/src/intervals/absolute/bounded_interval.rs
+++ b/src/intervals/absolute/bounded_interval.rs
@@ -34,13 +34,13 @@ use crate::intervals::absolute::{
 use crate::intervals::meta::{
     BoundInclusivity,
     Duration as IntervalDuration,
-    IsEmpty,
     Epsilon,
     HasBoundInclusivity,
     HasDuration,
     HasOpenness,
     HasRelativity,
     Interval,
+    IsEmpty,
     Openness,
     Relativity,
 };
@@ -842,25 +842,23 @@ impl From<RangeInclusive<Timestamp>> for BoundedAbsoluteInterval {
     }
 }
 
-/// Errors that can occur when trying to convert [`AbsoluteBoundPair`] into
-/// [`BoundedAbsoluteInterval`]
+/// Error that can occur when trying to convert [`AbsoluteBoundPair`] into [`BoundedAbsoluteInterval`]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum BoundedAbsoluteIntervalFromAbsoluteBoundPairError {
-    NotBoundedInterval,
-}
+pub struct BoundedAbsoluteIntervalTryFromAbsoluteBoundPairError;
 
-impl Display for BoundedAbsoluteIntervalFromAbsoluteBoundPairError {
+impl Display for BoundedAbsoluteIntervalTryFromAbsoluteBoundPairError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::NotBoundedInterval => write!(f, "Not a bounded interval"),
-        }
+        write!(
+            f,
+            "An error occurred when trying to convert `AbsoluteBoundPair` into `BoundedAbsoluteInterval`"
+        )
     }
 }
 
-impl Error for BoundedAbsoluteIntervalFromAbsoluteBoundPairError {}
+impl Error for BoundedAbsoluteIntervalTryFromAbsoluteBoundPairError {}
 
 impl TryFrom<AbsoluteBoundPair> for BoundedAbsoluteInterval {
-    type Error = BoundedAbsoluteIntervalFromAbsoluteBoundPairError;
+    type Error = BoundedAbsoluteIntervalTryFromAbsoluteBoundPairError;
 
     fn try_from(value: AbsoluteBoundPair) -> Result<Self, Self::Error> {
         match (value.start(), value.end()) {
@@ -872,7 +870,7 @@ impl TryFrom<AbsoluteBoundPair> for BoundedAbsoluteInterval {
                     finite_end.inclusivity(),
                 ))
             },
-            _ => Err(Self::Error::NotBoundedInterval),
+            _ => Err(BoundedAbsoluteIntervalTryFromAbsoluteBoundPairError),
         }
     }
 }

--- a/src/intervals/absolute/bounded_interval_tests.rs
+++ b/src/intervals/absolute/bounded_interval_tests.rs
@@ -348,14 +348,14 @@ fn interval_try_from_absolute_interval_correct() -> Result<(), Box<dyn Error>> {
 fn interval_try_from_absolute_interval_wrong() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         BoundedAbsoluteInterval::try_from(AbsoluteInterval::Unbounded(UnboundedInterval)),
-        Err(BoundedAbsoluteIntervalFromAbsoluteIntervalError::WrongVariant),
+        Err(BoundedAbsoluteIntervalFromAbsoluteIntervalError),
     );
     assert_eq!(
         BoundedAbsoluteInterval::try_from(AbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new(
             "2025-01-01 00:00:00Z".parse::<Timestamp>()?,
             OpeningDirection::ToFuture,
         ))),
-        Err(BoundedAbsoluteIntervalFromAbsoluteIntervalError::WrongVariant),
+        Err(BoundedAbsoluteIntervalFromAbsoluteIntervalError),
     );
 
     Ok(())

--- a/src/intervals/absolute/bounded_interval_tests.rs
+++ b/src/intervals/absolute/bounded_interval_tests.rs
@@ -308,21 +308,21 @@ fn interval_try_from_absolute_bounds_wrong() -> Result<(), Box<dyn Error>> {
             AbsoluteStartBound::InfinitePast,
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?)),
         )),
-        Err(BoundedAbsoluteIntervalFromAbsoluteBoundPairError::NotBoundedInterval),
+        Err(BoundedAbsoluteIntervalTryFromAbsoluteBoundPairError),
     );
     assert_eq!(
         BoundedAbsoluteInterval::try_from(AbsoluteBoundPair::new(
             AbsoluteStartBound::Finite(AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?)),
             AbsoluteEndBound::InfiniteFuture,
         )),
-        Err(BoundedAbsoluteIntervalFromAbsoluteBoundPairError::NotBoundedInterval),
+        Err(BoundedAbsoluteIntervalTryFromAbsoluteBoundPairError),
     );
     assert_eq!(
         BoundedAbsoluteInterval::try_from(AbsoluteBoundPair::new(
             AbsoluteStartBound::InfinitePast,
             AbsoluteEndBound::InfiniteFuture,
         )),
-        Err(BoundedAbsoluteIntervalFromAbsoluteBoundPairError::NotBoundedInterval),
+        Err(BoundedAbsoluteIntervalTryFromAbsoluteBoundPairError),
     );
 
     Ok(())

--- a/src/intervals/absolute/emptiable_bound_pair.rs
+++ b/src/intervals/absolute/emptiable_bound_pair.rs
@@ -18,7 +18,7 @@ use crate::intervals::absolute::{AbsoluteBoundPair, AbsoluteEndBound, AbsoluteSt
 use crate::intervals::meta::{
     BoundInclusivity,
     Duration as IntervalDuration,
-    Emptiable,
+    IsEmpty,
     Epsilon,
     HasDuration,
     HasOpenness,
@@ -198,7 +198,7 @@ impl HasEmptiableAbsoluteBoundPair for EmptiableAbsoluteBoundPair {
     }
 }
 
-impl Emptiable for EmptiableAbsoluteBoundPair {
+impl IsEmpty for EmptiableAbsoluteBoundPair {
     fn is_empty(&self) -> bool {
         matches!(self, Self::Empty)
     }

--- a/src/intervals/absolute/emptiable_bound_pair.rs
+++ b/src/intervals/absolute/emptiable_bound_pair.rs
@@ -18,12 +18,12 @@ use crate::intervals::absolute::{AbsoluteBoundPair, AbsoluteEndBound, AbsoluteSt
 use crate::intervals::meta::{
     BoundInclusivity,
     Duration as IntervalDuration,
-    IsEmpty,
     Epsilon,
     HasDuration,
     HasOpenness,
     HasRelativity,
     Interval,
+    IsEmpty,
     Openness,
     Relativity,
 };

--- a/src/intervals/absolute/emptiable_bound_pair.rs
+++ b/src/intervals/absolute/emptiable_bound_pair.rs
@@ -79,8 +79,7 @@ where
 /// [empty intervals](crate::intervals::special::EmptyInterval)
 ///
 /// For more information, check [`AbsoluteBoundPair`],
-/// [`EmptyInterval`](crate::intervals::special::EmptyInterval),
-/// or [`crate::intervals` module documentation](crate::intervals).
+/// [`EmptyInterval`], or [`crate::intervals` module documentation](crate::intervals).
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]

--- a/src/intervals/absolute/emptiable_bound_pair.rs
+++ b/src/intervals/absolute/emptiable_bound_pair.rs
@@ -14,7 +14,16 @@ use jiff::Timestamp;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use crate::intervals::absolute::{AbsoluteBoundPair, AbsoluteEndBound, AbsoluteStartBound, HasAbsoluteBoundPair};
+use crate::intervals::absolute::{
+    AbsoluteBoundPair,
+    AbsoluteEndBound,
+    AbsoluteInterval,
+    AbsoluteStartBound,
+    BoundedAbsoluteInterval,
+    EmptiableAbsoluteInterval,
+    HalfBoundedAbsoluteInterval,
+    HasAbsoluteBoundPair,
+};
 use crate::intervals::meta::{
     BoundInclusivity,
     Duration as IntervalDuration,
@@ -27,6 +36,7 @@ use crate::intervals::meta::{
     Openness,
     Relativity,
 };
+use crate::intervals::special::{EmptyInterval, UnboundedInterval};
 
 /// Possession of possibly empty absolute bound pair
 pub trait HasEmptiableAbsoluteBoundPair {
@@ -312,5 +322,41 @@ impl
 impl From<AbsoluteBoundPair> for EmptiableAbsoluteBoundPair {
     fn from(value: AbsoluteBoundPair) -> Self {
         EmptiableAbsoluteBoundPair::Bound(value)
+    }
+}
+
+impl From<BoundedAbsoluteInterval> for EmptiableAbsoluteBoundPair {
+    fn from(value: BoundedAbsoluteInterval) -> Self {
+        value.emptiable_abs_bound_pair()
+    }
+}
+
+impl From<HalfBoundedAbsoluteInterval> for EmptiableAbsoluteBoundPair {
+    fn from(value: HalfBoundedAbsoluteInterval) -> Self {
+        value.emptiable_abs_bound_pair()
+    }
+}
+
+impl From<AbsoluteInterval> for EmptiableAbsoluteBoundPair {
+    fn from(value: AbsoluteInterval) -> Self {
+        value.emptiable_abs_bound_pair()
+    }
+}
+
+impl From<EmptiableAbsoluteInterval> for EmptiableAbsoluteBoundPair {
+    fn from(value: EmptiableAbsoluteInterval) -> Self {
+        value.emptiable_abs_bound_pair()
+    }
+}
+
+impl From<UnboundedInterval> for EmptiableAbsoluteBoundPair {
+    fn from(value: UnboundedInterval) -> Self {
+        value.emptiable_abs_bound_pair()
+    }
+}
+
+impl From<EmptyInterval> for EmptiableAbsoluteBoundPair {
+    fn from(value: EmptyInterval) -> Self {
+        value.emptiable_abs_bound_pair()
     }
 }

--- a/src/intervals/absolute/emptiable_interval.rs
+++ b/src/intervals/absolute/emptiable_interval.rs
@@ -40,11 +40,11 @@ use crate::intervals::absolute::{
 use crate::intervals::meta::{
     BoundInclusivity,
     Duration as IntervalDuration,
-    IsEmpty,
     HasDuration,
     HasOpenness,
     HasRelativity,
     Interval,
+    IsEmpty,
     Openness,
     Relativity,
 };

--- a/src/intervals/absolute/emptiable_interval.rs
+++ b/src/intervals/absolute/emptiable_interval.rs
@@ -96,7 +96,7 @@ impl EmptiableAbsoluteInterval {
     /// Returns the content of the [`Bound`](EmptiableAbsoluteInterval::Bound) variant
     ///
     /// Consumes `self` and puts the content of the [`Bound`](EmptiableAbsoluteInterval::Bound) variant
-    /// in an [`Option`]. If instead `self` is another variant, the method returns [`None`]
+    /// in an [`Option`]. If instead `self` is another variant, the method returns [`None`].
     ///
     /// # Examples
     ///

--- a/src/intervals/absolute/emptiable_interval.rs
+++ b/src/intervals/absolute/emptiable_interval.rs
@@ -40,7 +40,7 @@ use crate::intervals::absolute::{
 use crate::intervals::meta::{
     BoundInclusivity,
     Duration as IntervalDuration,
-    Emptiable,
+    IsEmpty,
     HasDuration,
     HasOpenness,
     HasRelativity,
@@ -207,7 +207,7 @@ impl HasEmptiableAbsoluteBoundPair for EmptiableAbsoluteInterval {
     }
 }
 
-impl Emptiable for EmptiableAbsoluteInterval {
+impl IsEmpty for EmptiableAbsoluteInterval {
     fn is_empty(&self) -> bool {
         matches!(self, Self::Empty(_))
     }

--- a/src/intervals/absolute/end_bound.rs
+++ b/src/intervals/absolute/end_bound.rs
@@ -6,6 +6,8 @@
 //! the [`InfiniteFuture`](AbsoluteEndBound::InfiniteFuture) variant.
 
 use std::cmp::Ordering;
+use std::error::Error;
+use std::fmt::Display;
 use std::ops::Bound;
 
 #[cfg(feature = "arbitrary")]
@@ -292,5 +294,28 @@ impl From<Bound<Timestamp>> for AbsoluteEndBound {
             )),
             Bound::Unbounded => AbsoluteEndBound::InfiniteFuture,
         }
+    }
+}
+
+/// Error that can occur when trying to convert an [`AbsoluteBound`] into an [`AbsoluteEndBound`]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct AbsoluteEndBoundTryFromAbsoluteBoundError;
+
+impl Display for AbsoluteEndBoundTryFromAbsoluteBoundError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "An error occurred when trying to convert an `AbsoluteBound` into an `AbsoluteEndBound`"
+        )
+    }
+}
+
+impl Error for AbsoluteEndBoundTryFromAbsoluteBoundError {}
+
+impl TryFrom<AbsoluteBound> for AbsoluteEndBound {
+    type Error = AbsoluteEndBoundTryFromAbsoluteBoundError;
+
+    fn try_from(value: AbsoluteBound) -> Result<Self, Self::Error> {
+        value.end().ok_or(AbsoluteEndBoundTryFromAbsoluteBoundError)
     }
 }

--- a/src/intervals/absolute/finite_bound.rs
+++ b/src/intervals/absolute/finite_bound.rs
@@ -185,32 +185,23 @@ impl From<(Timestamp, BoundInclusivity)> for AbsoluteFiniteBound {
     }
 }
 
-/// Errors that can occur when trying to convert a [`Bound<Timestamp>`] into an
-/// [`AbsoluteFiniteBound`]
+/// Error that can occur when trying to convert [`Bound<Timestamp>`] into [`AbsoluteFiniteBound`]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum AbsoluteFiniteBoundFromBoundError {
-    /// The given bound was of the [`Unbounded`](Bound::Unbounded) variant
-    IsUnbounded,
-}
+pub struct AbsoluteFiniteBoundTryFromBoundError;
 
-impl Display for AbsoluteFiniteBoundFromBoundError {
+impl Display for AbsoluteFiniteBoundTryFromBoundError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::IsUnbounded => {
-                write!(
-                    f,
-                    "The given bound was of the `Unbounded` variant, and therefore could not be converted to an \
-                     `AbsoluteFiniteBound`"
-                )
-            },
-        }
+        write!(
+            f,
+            "An error occurred when trying to convert `Bound<Timestamp>` into `AbsoluteFiniteBound`"
+        )
     }
 }
 
-impl Error for AbsoluteFiniteBoundFromBoundError {}
+impl Error for AbsoluteFiniteBoundTryFromBoundError {}
 
 impl TryFrom<Bound<Timestamp>> for AbsoluteFiniteBound {
-    type Error = AbsoluteFiniteBoundFromBoundError;
+    type Error = AbsoluteFiniteBoundTryFromBoundError;
 
     fn try_from(value: Bound<Timestamp>) -> Result<Self, Self::Error> {
         match value {
@@ -222,7 +213,7 @@ impl TryFrom<Bound<Timestamp>> for AbsoluteFiniteBound {
                 time,
                 BoundInclusivity::Exclusive,
             )),
-            Bound::Unbounded => Err(AbsoluteFiniteBoundFromBoundError::IsUnbounded),
+            Bound::Unbounded => Err(AbsoluteFiniteBoundTryFromBoundError),
         }
     }
 }

--- a/src/intervals/absolute/finite_bound_tests.rs
+++ b/src/intervals/absolute/finite_bound_tests.rs
@@ -167,6 +167,6 @@ fn try_from_exclusive_bound() -> Result<(), Box<dyn Error>> {
 fn try_from_unbounded_bound() {
     assert_eq!(
         AbsoluteFiniteBound::try_from(Bound::Unbounded),
-        Err(AbsoluteFiniteBoundFromBoundError::IsUnbounded),
+        Err(AbsoluteFiniteBoundTryFromBoundError),
     );
 }

--- a/src/intervals/absolute/half_bounded_interval.rs
+++ b/src/intervals/absolute/half_bounded_interval.rs
@@ -347,7 +347,7 @@ impl HalfBoundedAbsoluteInterval {
 
     /// Wraps the interval in [`EmptiableAbsoluteInterval`]
     #[must_use]
-    pub fn to_emptiable(self) -> EmptiableAbsoluteInterval {
+    pub fn to_emptiable_interval(self) -> EmptiableAbsoluteInterval {
         EmptiableAbsoluteInterval::from(self)
     }
 }

--- a/src/intervals/absolute/half_bounded_interval.rs
+++ b/src/intervals/absolute/half_bounded_interval.rs
@@ -481,25 +481,23 @@ impl From<RangeToInclusive<Timestamp>> for HalfBoundedAbsoluteInterval {
     }
 }
 
-/// Errors that can occur when trying to convert [`AbsoluteBoundPair`] into
-/// [`HalfBoundedAbsoluteInterval`]
+/// Error that can occur when trying to convert [`AbsoluteBoundPair`] into [`HalfBoundedAbsoluteInterval`]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum HalfBoundedAbsoluteIntervalFromAbsoluteBoundPairError {
-    NotHalfBoundedInterval,
-}
+pub struct HalfBoundedAbsoluteIntervalTryFromAbsoluteBoundPairError;
 
-impl Display for HalfBoundedAbsoluteIntervalFromAbsoluteBoundPairError {
+impl Display for HalfBoundedAbsoluteIntervalTryFromAbsoluteBoundPairError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::NotHalfBoundedInterval => write!(f, "Not a half-bounded interval"),
-        }
+        write!(
+            f,
+            "An error occurred when trying to convert `AbsoluteBoundPair` into `HalfBoundedAbsoluteInterval`"
+        )
     }
 }
 
-impl Error for HalfBoundedAbsoluteIntervalFromAbsoluteBoundPairError {}
+impl Error for HalfBoundedAbsoluteIntervalTryFromAbsoluteBoundPairError {}
 
 impl TryFrom<AbsoluteBoundPair> for HalfBoundedAbsoluteInterval {
-    type Error = HalfBoundedAbsoluteIntervalFromAbsoluteBoundPairError;
+    type Error = HalfBoundedAbsoluteIntervalTryFromAbsoluteBoundPairError;
 
     fn try_from(value: AbsoluteBoundPair) -> Result<Self, Self::Error> {
         match (value.start(), value.end()) {
@@ -517,35 +515,32 @@ impl TryFrom<AbsoluteBoundPair> for HalfBoundedAbsoluteInterval {
                     OpeningDirection::ToFuture,
                 ))
             },
-            _ => Err(Self::Error::NotHalfBoundedInterval),
+            _ => Err(HalfBoundedAbsoluteIntervalTryFromAbsoluteBoundPairError),
         }
     }
 }
 
-/// Errors that can occur when trying to convert [`AbsoluteInterval`] into
-/// [`HalfBoundedAbsoluteInterval`]
+/// Error that can occur when trying to convert [`AbsoluteInterval`] into [`HalfBoundedAbsoluteInterval`]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum HalfBoundedAbsoluteIntervalFromAbsoluteIntervalError {
-    WrongVariant,
-}
+pub struct HalfBoundedAbsoluteIntervalTryFromAbsoluteIntervalError;
 
-impl Display for HalfBoundedAbsoluteIntervalFromAbsoluteIntervalError {
+impl Display for HalfBoundedAbsoluteIntervalTryFromAbsoluteIntervalError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::WrongVariant => write!(f, "Wrong variant"),
-        }
+        write!(
+            f,
+            "An error occurred when trying to convert `AbsoluteInterval` into `HalfBoundedAbsoluteInterval`"
+        )
     }
 }
 
-impl Error for HalfBoundedAbsoluteIntervalFromAbsoluteIntervalError {}
+impl Error for HalfBoundedAbsoluteIntervalTryFromAbsoluteIntervalError {}
 
 impl TryFrom<AbsoluteInterval> for HalfBoundedAbsoluteInterval {
-    type Error = HalfBoundedAbsoluteIntervalFromAbsoluteIntervalError;
+    type Error = HalfBoundedAbsoluteIntervalTryFromAbsoluteIntervalError;
 
     fn try_from(value: AbsoluteInterval) -> Result<Self, Self::Error> {
-        match value {
-            AbsoluteInterval::HalfBounded(interval) => Ok(interval),
-            _ => Err(Self::Error::WrongVariant),
-        }
+        value
+            .half_bounded()
+            .ok_or(HalfBoundedAbsoluteIntervalTryFromAbsoluteIntervalError)
     }
 }

--- a/src/intervals/absolute/half_bounded_interval.rs
+++ b/src/intervals/absolute/half_bounded_interval.rs
@@ -30,12 +30,12 @@ use crate::intervals::absolute::{
 use crate::intervals::meta::{
     BoundInclusivity,
     Duration as IntervalDuration,
-    Emptiable,
     HasBoundInclusivity,
     HasDuration,
     HasOpenness,
     HasRelativity,
     Interval,
+    IsEmpty,
     OpeningDirection,
     Openness,
     Relativity,
@@ -433,7 +433,7 @@ impl HasAbsoluteBoundPair for HalfBoundedAbsoluteInterval {
     }
 }
 
-impl Emptiable for HalfBoundedAbsoluteInterval {
+impl IsEmpty for HalfBoundedAbsoluteInterval {
     fn is_empty(&self) -> bool {
         false
     }

--- a/src/intervals/absolute/half_bounded_interval_tests.rs
+++ b/src/intervals/absolute/half_bounded_interval_tests.rs
@@ -212,14 +212,14 @@ fn try_from_absolute_bounds_wrong() -> Result<(), Box<dyn Error>> {
             AbsoluteStartBound::InfinitePast,
             AbsoluteEndBound::InfiniteFuture,
         )),
-        Err(HalfBoundedAbsoluteIntervalFromAbsoluteBoundPairError::NotHalfBoundedInterval),
+        Err(HalfBoundedAbsoluteIntervalTryFromAbsoluteBoundPairError),
     );
     assert_eq!(
         HalfBoundedAbsoluteInterval::try_from(AbsoluteBoundPair::new(
             AbsoluteStartBound::Finite(AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?)),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new("2025-01-02 00:00:00Z".parse::<Timestamp>()?)),
         )),
-        Err(HalfBoundedAbsoluteIntervalFromAbsoluteBoundPairError::NotHalfBoundedInterval),
+        Err(HalfBoundedAbsoluteIntervalTryFromAbsoluteBoundPairError),
     );
 
     Ok(())
@@ -249,14 +249,14 @@ fn try_from_absolute_interval_correct() -> Result<(), Box<dyn Error>> {
 fn try_from_absolute_interval_wrong() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         HalfBoundedAbsoluteInterval::try_from(AbsoluteInterval::Unbounded(UnboundedInterval)),
-        Err(HalfBoundedAbsoluteIntervalFromAbsoluteIntervalError::WrongVariant),
+        Err(HalfBoundedAbsoluteIntervalTryFromAbsoluteIntervalError),
     );
     assert_eq!(
         HalfBoundedAbsoluteInterval::try_from(AbsoluteInterval::Bounded(BoundedAbsoluteInterval::new(
             "2025-01-01 00:00:00Z".parse::<Timestamp>()?,
             "2025-01-02 00:00:00Z".parse::<Timestamp>()?,
         ))),
-        Err(HalfBoundedAbsoluteIntervalFromAbsoluteIntervalError::WrongVariant),
+        Err(HalfBoundedAbsoluteIntervalTryFromAbsoluteIntervalError),
     );
 
     Ok(())

--- a/src/intervals/absolute/interval.rs
+++ b/src/intervals/absolute/interval.rs
@@ -44,11 +44,11 @@ use crate::intervals::absolute::{
 use crate::intervals::meta::{
     BoundInclusivity,
     Duration as IntervalDuration,
-    Emptiable,
     HasDuration,
     HasOpenness,
     HasRelativity,
     Interval,
+    IsEmpty,
     OpeningDirection,
     Openness,
     Relativity,
@@ -302,7 +302,7 @@ impl Ord for AbsoluteInterval {
     }
 }
 
-impl Emptiable for AbsoluteInterval {
+impl IsEmpty for AbsoluteInterval {
     fn is_empty(&self) -> bool {
         false
     }

--- a/src/intervals/absolute/interval.rs
+++ b/src/intervals/absolute/interval.rs
@@ -215,7 +215,7 @@ impl AbsoluteInterval {
     /// # use periodical::intervals::special::UnboundedInterval;
     /// let interval = AbsoluteInterval::Unbounded(UnboundedInterval);
     ///
-    /// assert_eq!(interval.unbounded(), Some(half_bounded_interval));
+    /// assert_eq!(interval.unbounded(), Some(UnboundedInterval));
     /// ```
     #[must_use]
     pub fn unbounded(self) -> Option<UnboundedInterval> {

--- a/src/intervals/absolute/interval.rs
+++ b/src/intervals/absolute/interval.rs
@@ -138,6 +138,93 @@ impl AbsoluteInterval {
             .ord_by_start_and_inv_length(&other.abs_bound_pair())
     }
 
+    /// Returns the content of the [`Bounded`](AbsoluteInterval::Bounded) variant
+    ///
+    /// Consumes `self` and puts the content of the [`Bounded`](AbsoluteInterval::Bounded) variant
+    /// in an [`Option`]. If instead `self` is another variant, the method returns [`None`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::error::Error;
+    /// # use jiff::Zoned;
+    /// # use periodical::intervals::absolute::BoundedAbsoluteInterval;
+    /// let bounded_interval = BoundedAbsoluteInterval::new(
+    ///     "2026-01-01 08:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
+    ///     "2026-01-01 16:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
+    /// );
+    ///
+    /// let interval = bounded_interval.clone().to_interval();
+    ///
+    /// assert_eq!(interval.bounded(), Some(bounded_interval));
+    /// # Ok::<(), Box<dyn Error>>(())
+    /// ```
+    #[must_use]
+    pub fn bounded(self) -> Option<BoundedAbsoluteInterval> {
+        match self {
+            Self::Bounded(interval) => Some(interval),
+            _ => None,
+        }
+    }
+
+    /// Returns the content of the [`HalfBounded`](AbsoluteInterval::HalfBounded) variant
+    ///
+    /// Consumes `self` and puts the content of the [`HalfBounded`](AbsoluteInterval::HalfBounded) variant
+    /// in an [`Option`]. If instead `self` is another variant, the method returns [`None`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::error::Error;
+    /// # use jiff::Zoned;
+    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// # use periodical::intervals::meta::OpeningDirection;
+    /// let half_bounded_interval = HalfBoundedAbsoluteInterval::new(
+    ///     "2026-01-01 08:00:00[Europe/Oslo]"
+    ///         .parse::<Zoned>()?
+    ///         .timestamp(),
+    ///     OpeningDirection::ToPast,
+    /// );
+    ///
+    /// let interval = half_bounded_interval.clone().to_interval();
+    ///
+    /// assert_eq!(interval.half_bounded(), Some(half_bounded_interval));
+    /// # Ok::<(), Box<dyn Error>>(())
+    /// ```
+    #[must_use]
+    pub fn half_bounded(self) -> Option<HalfBoundedAbsoluteInterval> {
+        match self {
+            Self::HalfBounded(interval) => Some(interval),
+            _ => None,
+        }
+    }
+
+    /// Returns the content of the [`Unbounded`](AbsoluteInterval::Unbounded) variant
+    ///
+    /// Consumes `self` and puts the content of the [`Unbounded`](AbsoluteInterval::Unbounded) variant
+    /// in an [`Option`]. If instead `self` is another variant, the method returns [`None`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use periodical::intervals::absolute::AbsoluteInterval;
+    /// # use periodical::intervals::special::UnboundedInterval;
+    /// let interval = AbsoluteInterval::Unbounded(UnboundedInterval);
+    ///
+    /// assert_eq!(interval.unbounded(), Some(half_bounded_interval));
+    /// ```
+    #[must_use]
+    pub fn unbounded(self) -> Option<UnboundedInterval> {
+        match self {
+            Self::Unbounded(interval) => Some(interval),
+            _ => None,
+        }
+    }
+
     /// Wraps the interval in [`EmptiableAbsoluteInterval`]
     #[must_use]
     pub fn to_emptiable(self) -> EmptiableAbsoluteInterval {

--- a/src/intervals/absolute/start_bound.rs
+++ b/src/intervals/absolute/start_bound.rs
@@ -6,6 +6,8 @@
 //! the [`InfinitePast`](AbsoluteStartBound::InfinitePast) variant.
 
 use std::cmp::Ordering;
+use std::error::Error;
+use std::fmt::Display;
 use std::ops::Bound;
 
 #[cfg(feature = "arbitrary")]
@@ -310,5 +312,28 @@ impl From<Bound<Timestamp>> for AbsoluteStartBound {
             )),
             Bound::Unbounded => AbsoluteStartBound::InfinitePast,
         }
+    }
+}
+
+/// Error that can occur when trying to convert an [`AbsoluteBound`] into an [`AbsoluteStartBound`]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct AbsoluteStartBoundTryFromAbsoluteBoundError;
+
+impl Display for AbsoluteStartBoundTryFromAbsoluteBoundError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "An error occurred when trying to convert an `AbsoluteBound` into an `AbsoluteStartBound`"
+        )
+    }
+}
+
+impl Error for AbsoluteStartBoundTryFromAbsoluteBoundError {}
+
+impl TryFrom<AbsoluteBound> for AbsoluteStartBound {
+    type Error = AbsoluteStartBoundTryFromAbsoluteBoundError;
+
+    fn try_from(value: AbsoluteBound) -> Result<Self, Self::Error> {
+        value.start().ok_or(AbsoluteStartBoundTryFromAbsoluteBoundError)
     }
 }

--- a/src/intervals/meta.rs
+++ b/src/intervals/meta.rs
@@ -246,14 +246,13 @@ impl Epsilon {
     /// # Errors
     ///
     /// If `start_epsilon_duration` + `end_epsilon_duration` overflows,
-    /// the method returns
-    /// [`DurationOverflow`](EpsilonInterpretationDurationError::DurationOverflow).
+    /// the method returns [`EpsilonInterpretationDurationOverflowError`].
     ///
     ///
     /// # Examples
     ///
     /// ```
-    /// # use periodical::intervals::meta::{Epsilon, EpsilonInterpretationDurationError};
+    /// # use periodical::intervals::meta::Epsilon;
     /// let start_epsilon_duration = std::time::Duration::from_secs(1);
     /// let end_epsilon_duration = std::time::Duration::from_secs(2);
     ///
@@ -282,14 +281,14 @@ impl Epsilon {
         &self,
         start_epsilon_duration: StdDuration,
         end_epsilon_duration: StdDuration,
-    ) -> Result<StdDuration, EpsilonInterpretationDurationError> {
+    ) -> Result<StdDuration, EpsilonInterpretationDurationOverflowError> {
         match self {
             Self::None => Ok(StdDuration::ZERO),
             Self::Start => Ok(start_epsilon_duration),
             Self::End => Ok(end_epsilon_duration),
             Self::Both => start_epsilon_duration
                 .checked_add(end_epsilon_duration)
-                .ok_or(EpsilonInterpretationDurationError::DurationOverflow),
+                .ok_or(EpsilonInterpretationDurationOverflowError),
         }
     }
 
@@ -298,14 +297,13 @@ impl Epsilon {
     /// # Errors
     ///
     /// If `epsilon_duration * 2` overflows,
-    /// the method returns
-    /// [`DurationOverflow`](EpsilonInterpretationDurationError::DurationOverflow).
+    /// the method returns [`EpsilonInterpretationDurationOverflowError`].
     ///
     ///
     /// # Examples
     ///
     /// ```
-    /// # use periodical::intervals::meta::{Epsilon, EpsilonInterpretationDurationError};
+    /// # use periodical::intervals::meta::Epsilon;
     /// let epsilon_duration = std::time::Duration::from_secs(1);
     ///
     /// assert_eq!(
@@ -328,7 +326,7 @@ impl Epsilon {
     pub fn interpret_as_duration(
         &self,
         epsilon_duration: StdDuration,
-    ) -> Result<StdDuration, EpsilonInterpretationDurationError> {
+    ) -> Result<StdDuration, EpsilonInterpretationDurationOverflowError> {
         self.interpret_as_duration_bound_specific(epsilon_duration, epsilon_duration)
     }
 }
@@ -375,22 +373,17 @@ impl From<(bool, bool)> for Epsilon {
     }
 }
 
-/// Errors that can occur when [`Epsilon`] is interpreted as a duration
+/// Duration interpretation overflowed when [`Epsilon`] tried to be interpreted as a duration
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum EpsilonInterpretationDurationError {
-    /// Duration interpretation overflowed
-    DurationOverflow,
-}
+pub struct EpsilonInterpretationDurationOverflowError;
 
-impl Display for EpsilonInterpretationDurationError {
+impl Display for EpsilonInterpretationDurationOverflowError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::DurationOverflow => write!(f, "Epsilon interpretation made the duration overflow"),
-        }
+        write!(f, "Epsilon interpretation made the duration overflow")
     }
 }
 
-impl Error for EpsilonInterpretationDurationError {}
+impl Error for EpsilonInterpretationDurationOverflowError {}
 
 /// Interval duration
 ///

--- a/src/intervals/meta.rs
+++ b/src/intervals/meta.rs
@@ -5,6 +5,7 @@
 
 use std::error::Error;
 use std::fmt::Display;
+use std::ops::Bound;
 use std::time::Duration as StdDuration;
 
 #[cfg(feature = "arbitrary")]
@@ -393,12 +394,11 @@ impl Error for EpsilonInterpretationDurationError {}
 
 /// Interval duration
 ///
-/// Represents the duration of an interval. It can either be
+/// Represents the duration of a single interval. It can either be
 /// [`Infinite`](Duration::Infinite), or [`Finite`](Duration::Finite), in which
 /// case the duration is stored as a standard [`Duration`](StdDuration)
 /// and an [`Epsilon`], which serves to represent infinitesimal duration
-/// variations created by the use of [exclusive
-/// bounds](BoundInclusivity::Exclusive).
+/// variations created by the use of [exclusive bounds](BoundInclusivity::Exclusive).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
@@ -567,6 +567,26 @@ impl BoundInclusivity {
             BoundInclusivity::Exclusive => BoundInclusivity::Inclusive,
         }
     }
+
+    /// Creates a [`Bound`] from [`BoundInclusivity`] and a given value
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::ops::Bound;
+    /// # use periodical::intervals::meta::BoundInclusivity;
+    /// assert_eq!(
+    ///     BoundInclusivity::Exclusive.to_range_bound_with(5),
+    ///     Bound::Excluded(5),
+    /// );
+    /// ```
+    #[must_use]
+    pub fn to_range_bound_with<T>(self, value: T) -> Bound<T> {
+        match self {
+            Self::Inclusive => Bound::Included(value),
+            Self::Exclusive => Bound::Excluded(value),
+        }
+    }
 }
 
 impl Display for BoundInclusivity {
@@ -602,7 +622,7 @@ pub trait HasBoundInclusivity {
 }
 
 /// Capacity of an interval to be empty
-pub trait Emptiable {
+pub trait IsEmpty {
     /// Returns whether the interval is empty
     fn is_empty(&self) -> bool;
 }

--- a/src/intervals/ops/fill_gap.rs
+++ b/src/intervals/ops/fill_gap.rs
@@ -63,6 +63,9 @@
 //! # Ok::<(), Box<dyn Error>>(())
 //! ```
 
+use std::error::Error;
+use std::fmt::Display;
+
 use super::grow::{GrowableEndBound, GrowableStartBound};
 use super::overlap::{CanPositionOverlap, DisambiguatedOverlapPosition, OverlapRuleSet};
 use crate::intervals::absolute::{
@@ -94,12 +97,17 @@ use crate::intervals::relative::{
 };
 use crate::intervals::special::{EmptyInterval, UnboundedInterval};
 
-/// Errors that can be produced when using [`GapFillable`]
+/// The two given intervals were overlapping when using [`GapFillable`]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum GapFillError {
-    /// The two given intervals were overlapping
-    Overlap,
+pub struct GapFillOverlapFoundError;
+
+impl Display for GapFillOverlapFoundError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "The two given intervals were overlapping")
+    }
 }
+
+impl Error for GapFillOverlapFoundError {}
 
 /// Capacity to fill gaps between non-overlapping intervals
 ///
@@ -115,8 +123,7 @@ pub trait GapFillable<Rhs = Self> {
     ///
     /// # Errors
     ///
-    /// If the two intervals are overlapping, it result in
-    /// [`GapFillError::Overlap`].
+    /// If the two intervals are overlapping, it result in [`GapFillOverlapFoundError`].
     ///
     /// # Examples
     ///
@@ -176,7 +183,7 @@ pub trait GapFillable<Rhs = Self> {
     /// );
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
-    fn fill_gap(&self, rhs: &Rhs) -> Result<Self::Output, GapFillError>;
+    fn fill_gap(&self, rhs: &Rhs) -> Result<Self::Output, GapFillOverlapFoundError>;
 }
 
 impl<Rhs> GapFillable<Rhs> for AbsoluteBoundPair
@@ -185,7 +192,7 @@ where
 {
     type Output = Self;
 
-    fn fill_gap(&self, rhs: &Rhs) -> Result<Self::Output, GapFillError> {
+    fn fill_gap(&self, rhs: &Rhs) -> Result<Self::Output, GapFillOverlapFoundError> {
         fill_gap_abs_bound_pair_with_emptiable_abs_bound_pair(self, &rhs.emptiable_abs_bound_pair())
     }
 }
@@ -196,7 +203,7 @@ where
 {
     type Output = Self;
 
-    fn fill_gap(&self, rhs: &Rhs) -> Result<Self::Output, GapFillError> {
+    fn fill_gap(&self, rhs: &Rhs) -> Result<Self::Output, GapFillOverlapFoundError> {
         fill_gap_emptiable_abs_bound_pair(self, &rhs.emptiable_abs_bound_pair())
     }
 }
@@ -207,7 +214,7 @@ where
 {
     type Output = Self;
 
-    fn fill_gap(&self, rhs: &Rhs) -> Result<Self::Output, GapFillError> {
+    fn fill_gap(&self, rhs: &Rhs) -> Result<Self::Output, GapFillOverlapFoundError> {
         fill_gap_abs_bound_pair_with_emptiable_abs_bound_pair(&self.abs_bound_pair(), &rhs.emptiable_abs_bound_pair())
             .map(Self::Output::from)
     }
@@ -219,7 +226,7 @@ where
 {
     type Output = Self;
 
-    fn fill_gap(&self, rhs: &Rhs) -> Result<Self::Output, GapFillError> {
+    fn fill_gap(&self, rhs: &Rhs) -> Result<Self::Output, GapFillOverlapFoundError> {
         fill_gap_emptiable_abs_bound_pair(&self.emptiable_abs_bound_pair(), &rhs.emptiable_abs_bound_pair())
             .map(Self::Output::from)
     }
@@ -231,7 +238,7 @@ where
 {
     type Output = AbsoluteInterval;
 
-    fn fill_gap(&self, rhs: &Rhs) -> Result<Self::Output, GapFillError> {
+    fn fill_gap(&self, rhs: &Rhs) -> Result<Self::Output, GapFillOverlapFoundError> {
         fill_gap_abs_bound_pair_with_emptiable_abs_bound_pair(&self.abs_bound_pair(), &rhs.emptiable_abs_bound_pair())
             .map(Self::Output::from)
     }
@@ -243,7 +250,7 @@ where
 {
     type Output = AbsoluteInterval;
 
-    fn fill_gap(&self, rhs: &Rhs) -> Result<Self::Output, GapFillError> {
+    fn fill_gap(&self, rhs: &Rhs) -> Result<Self::Output, GapFillOverlapFoundError> {
         fill_gap_abs_bound_pair_with_emptiable_abs_bound_pair(&self.abs_bound_pair(), &rhs.emptiable_abs_bound_pair())
             .map(Self::Output::from)
     }
@@ -255,7 +262,7 @@ where
 {
     type Output = Self;
 
-    fn fill_gap(&self, rhs: &Rhs) -> Result<Self::Output, GapFillError> {
+    fn fill_gap(&self, rhs: &Rhs) -> Result<Self::Output, GapFillOverlapFoundError> {
         fill_gap_rel_bound_pair_with_emptiable_rel_bound_pair(self, &rhs.emptiable_rel_bound_pair())
     }
 }
@@ -266,7 +273,7 @@ where
 {
     type Output = Self;
 
-    fn fill_gap(&self, rhs: &Rhs) -> Result<Self::Output, GapFillError> {
+    fn fill_gap(&self, rhs: &Rhs) -> Result<Self::Output, GapFillOverlapFoundError> {
         fill_gap_emptiable_rel_bound_pair(self, &rhs.emptiable_rel_bound_pair())
     }
 }
@@ -277,7 +284,7 @@ where
 {
     type Output = Self;
 
-    fn fill_gap(&self, rhs: &Rhs) -> Result<Self::Output, GapFillError> {
+    fn fill_gap(&self, rhs: &Rhs) -> Result<Self::Output, GapFillOverlapFoundError> {
         fill_gap_rel_bound_pair_with_emptiable_rel_bound_pair(&self.rel_bound_pair(), &rhs.emptiable_rel_bound_pair())
             .map(Self::Output::from)
     }
@@ -289,7 +296,7 @@ where
 {
     type Output = Self;
 
-    fn fill_gap(&self, rhs: &Rhs) -> Result<Self::Output, GapFillError> {
+    fn fill_gap(&self, rhs: &Rhs) -> Result<Self::Output, GapFillOverlapFoundError> {
         fill_gap_emptiable_rel_bound_pair(&self.emptiable_rel_bound_pair(), &rhs.emptiable_rel_bound_pair())
             .map(Self::Output::from)
     }
@@ -301,7 +308,7 @@ where
 {
     type Output = RelativeInterval;
 
-    fn fill_gap(&self, rhs: &Rhs) -> Result<Self::Output, GapFillError> {
+    fn fill_gap(&self, rhs: &Rhs) -> Result<Self::Output, GapFillOverlapFoundError> {
         fill_gap_rel_bound_pair_with_emptiable_rel_bound_pair(&self.rel_bound_pair(), &rhs.emptiable_rel_bound_pair())
             .map(Self::Output::from)
     }
@@ -313,7 +320,7 @@ where
 {
     type Output = RelativeInterval;
 
-    fn fill_gap(&self, rhs: &Rhs) -> Result<Self::Output, GapFillError> {
+    fn fill_gap(&self, rhs: &Rhs) -> Result<Self::Output, GapFillOverlapFoundError> {
         fill_gap_rel_bound_pair_with_emptiable_rel_bound_pair(&self.rel_bound_pair(), &rhs.emptiable_rel_bound_pair())
             .map(Self::Output::from)
     }
@@ -325,8 +332,8 @@ where
 {
     type Output = UnboundedInterval;
 
-    fn fill_gap(&self, _rhs: &Rhs) -> Result<Self::Output, GapFillError> {
-        Err(GapFillError::Overlap)
+    fn fill_gap(&self, _rhs: &Rhs) -> Result<Self::Output, GapFillOverlapFoundError> {
+        Err(GapFillOverlapFoundError)
     }
 }
 
@@ -336,7 +343,7 @@ where
 {
     type Output = Rhs;
 
-    fn fill_gap(&self, rhs: &Rhs) -> Result<Self::Output, GapFillError> {
+    fn fill_gap(&self, rhs: &Rhs) -> Result<Self::Output, GapFillOverlapFoundError> {
         Ok(rhs.clone())
     }
 }
@@ -348,11 +355,11 @@ where
 ///
 /// # Errors
 ///
-/// If the given bounds overlap, it results in [`GapFillError::Overlap`]
+/// If the given bounds overlap, it results in [`GapFillOverlapFoundError`]
 pub fn fill_gap_abs_bound_pair(
     a: &AbsoluteBoundPair,
     b: &AbsoluteBoundPair,
-) -> Result<AbsoluteBoundPair, GapFillError> {
+) -> Result<AbsoluteBoundPair, GapFillOverlapFoundError> {
     type Dop = DisambiguatedOverlapPosition;
 
     let Ok(overlap_position) = a.disambiguated_overlap_position(b, OverlapRuleSet::Strict);
@@ -389,7 +396,7 @@ pub fn fill_gap_abs_bound_pair(
 
             Ok(a.grow_start(new_start_bound))
         },
-        _ => Err(GapFillError::Overlap),
+        _ => Err(GapFillOverlapFoundError),
     }
 }
 
@@ -400,11 +407,11 @@ pub fn fill_gap_abs_bound_pair(
 ///
 /// # Errors
 ///
-/// If the given bounds overlap, it results in [`GapFillError::Overlap`]
+/// If the given bounds overlap, it results in [`GapFillOverlapFoundError`]
 pub fn fill_gap_abs_bound_pair_with_emptiable_abs_bound_pair(
     a: &AbsoluteBoundPair,
     b: &EmptiableAbsoluteBoundPair,
-) -> Result<AbsoluteBoundPair, GapFillError> {
+) -> Result<AbsoluteBoundPair, GapFillOverlapFoundError> {
     let EmptiableAbsoluteBoundPair::Bound(b_abs_bound_pair) = b else {
         return Ok(a.clone());
     };
@@ -419,11 +426,11 @@ pub fn fill_gap_abs_bound_pair_with_emptiable_abs_bound_pair(
 ///
 /// # Errors
 ///
-/// If the given bounds overlap, it results in [`GapFillError::Overlap`]
+/// If the given bounds overlap, it results in [`GapFillOverlapFoundError`]
 pub fn fill_gap_emptiable_abs_bound_pair(
     a: &EmptiableAbsoluteBoundPair,
     b: &EmptiableAbsoluteBoundPair,
-) -> Result<EmptiableAbsoluteBoundPair, GapFillError> {
+) -> Result<EmptiableAbsoluteBoundPair, GapFillOverlapFoundError> {
     let EmptiableAbsoluteBoundPair::Bound(a_abs_bound_pair) = a else {
         return Ok(b.clone());
     };
@@ -438,11 +445,11 @@ pub fn fill_gap_emptiable_abs_bound_pair(
 ///
 /// # Errors
 ///
-/// If the given bounds overlap, it results in [`GapFillError::Overlap`]
+/// If the given bounds overlap, it results in [`GapFillOverlapFoundError`]
 pub fn fill_gap_rel_bound_pair(
     a: &RelativeBoundPair,
     b: &RelativeBoundPair,
-) -> Result<RelativeBoundPair, GapFillError> {
+) -> Result<RelativeBoundPair, GapFillOverlapFoundError> {
     type Dop = DisambiguatedOverlapPosition;
 
     let Ok(overlap_position) = a.disambiguated_overlap_position(b, OverlapRuleSet::Strict);
@@ -479,7 +486,7 @@ pub fn fill_gap_rel_bound_pair(
 
             Ok(a.grow_start(new_start_bound))
         },
-        _ => Err(GapFillError::Overlap),
+        _ => Err(GapFillOverlapFoundError),
     }
 }
 
@@ -490,11 +497,11 @@ pub fn fill_gap_rel_bound_pair(
 ///
 /// # Errors
 ///
-/// If the given bounds overlap, it results in [`GapFillError::Overlap`]
+/// If the given bounds overlap, it results in [`GapFillOverlapFoundError`]
 pub fn fill_gap_rel_bound_pair_with_emptiable_rel_bound_pair(
     a: &RelativeBoundPair,
     b: &EmptiableRelativeBoundPair,
-) -> Result<RelativeBoundPair, GapFillError> {
+) -> Result<RelativeBoundPair, GapFillOverlapFoundError> {
     let EmptiableRelativeBoundPair::Bound(b_rel_bound_pair) = b else {
         return Ok(a.clone());
     };
@@ -509,11 +516,11 @@ pub fn fill_gap_rel_bound_pair_with_emptiable_rel_bound_pair(
 ///
 /// # Errors
 ///
-/// If the given bounds overlap, it results in [`GapFillError::Overlap`]
+/// If the given bounds overlap, it results in [`GapFillOverlapFoundError`]
 pub fn fill_gap_emptiable_rel_bound_pair(
     a: &EmptiableRelativeBoundPair,
     b: &EmptiableRelativeBoundPair,
-) -> Result<EmptiableRelativeBoundPair, GapFillError> {
+) -> Result<EmptiableRelativeBoundPair, GapFillOverlapFoundError> {
     let EmptiableRelativeBoundPair::Bound(a_rel_bound_pair) = a else {
         return Ok(b.clone());
     };

--- a/src/intervals/ops/fill_gap_tests.rs
+++ b/src/intervals/ops/fill_gap_tests.rs
@@ -58,7 +58,7 @@ fn two_overlapping_half_bounded() -> Result<(), Box<dyn Error>> {
             "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             OpeningDirection::ToFuture
         )),
-        Err(GapFillError::Overlap),
+        Err(GapFillOverlapFoundError),
     );
 
     Ok(())
@@ -98,7 +98,7 @@ fn two_strictly_adjacent_half_bounded() -> Result<(), Box<dyn Error>> {
             "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             OpeningDirection::ToFuture
         )),
-        Err(GapFillError::Overlap),
+        Err(GapFillOverlapFoundError),
     );
 
     Ok(())

--- a/src/intervals/ops/precision.rs
+++ b/src/intervals/ops/precision.rs
@@ -78,7 +78,7 @@ use crate::intervals::absolute::{
 };
 use crate::intervals::meta::HasBoundInclusivity;
 use crate::intervals::special::EmptyInterval;
-use crate::ops::{Precision, PrecisionError};
+use crate::ops::{Precision, PrecisionOutOfRangeDateError};
 
 /// Ability to precise absolute intervals
 ///
@@ -387,7 +387,7 @@ pub trait PreciseAbsoluteInterval {
 }
 
 impl PreciseAbsoluteInterval for AbsoluteBoundPair {
-    type PrecisedIntervalOutput = Result<Self, PrecisionError>;
+    type PrecisedIntervalOutput = Result<Self, PrecisionOutOfRangeDateError>;
 
     fn precise_interval_with_different_precisions(
         &self,
@@ -421,7 +421,7 @@ impl PreciseAbsoluteInterval for AbsoluteBoundPair {
 }
 
 impl PreciseAbsoluteInterval for EmptiableAbsoluteBoundPair {
-    type PrecisedIntervalOutput = Result<Self, PrecisionError>;
+    type PrecisedIntervalOutput = Result<Self, PrecisionOutOfRangeDateError>;
 
     fn precise_interval_with_different_precisions(
         &self,
@@ -470,7 +470,7 @@ impl PreciseAbsoluteInterval for EmptiableAbsoluteBoundPair {
 }
 
 impl PreciseAbsoluteInterval for AbsoluteInterval {
-    type PrecisedIntervalOutput = Result<Self, PrecisionError>;
+    type PrecisedIntervalOutput = Result<Self, PrecisionOutOfRangeDateError>;
 
     fn precise_interval_with_different_precisions(
         &self,
@@ -509,7 +509,7 @@ impl PreciseAbsoluteInterval for AbsoluteInterval {
 }
 
 impl PreciseAbsoluteInterval for EmptiableAbsoluteInterval {
-    type PrecisedIntervalOutput = Result<Self, PrecisionError>;
+    type PrecisedIntervalOutput = Result<Self, PrecisionOutOfRangeDateError>;
 
     fn precise_interval_with_different_precisions(
         &self,
@@ -685,7 +685,7 @@ pub trait PreciseAbsoluteBound {
 }
 
 impl PreciseAbsoluteBound for AbsoluteFiniteBound {
-    type PrecisedBoundOutput = Result<Self, PrecisionError>;
+    type PrecisedBoundOutput = Result<Self, PrecisionOutOfRangeDateError>;
 
     fn precise_bound(&self, tz: TimeZone, precision: Precision) -> Self::PrecisedBoundOutput {
         precise_abs_finite_bound(self, tz, precision)
@@ -700,7 +700,7 @@ impl PreciseAbsoluteBound for AbsoluteFiniteBound {
 }
 
 impl PreciseAbsoluteBound for AbsoluteStartBound {
-    type PrecisedBoundOutput = Result<Self, PrecisionError>;
+    type PrecisedBoundOutput = Result<Self, PrecisionOutOfRangeDateError>;
 
     fn precise_bound(&self, tz: TimeZone, precision: Precision) -> Self::PrecisedBoundOutput {
         precise_abs_start_bound(self, tz, precision)
@@ -715,7 +715,7 @@ impl PreciseAbsoluteBound for AbsoluteStartBound {
 }
 
 impl PreciseAbsoluteBound for AbsoluteEndBound {
-    type PrecisedBoundOutput = Result<Self, PrecisionError>;
+    type PrecisedBoundOutput = Result<Self, PrecisionOutOfRangeDateError>;
 
     fn precise_bound(&self, tz: TimeZone, precision: Precision) -> Self::PrecisedBoundOutput {
         precise_abs_end_bound(self, tz, precision)
@@ -739,7 +739,7 @@ pub fn precise_abs_bound_pair(
     tz: TimeZone,
     precision_start: Precision,
     precision_end: Precision,
-) -> Result<AbsoluteBoundPair, PrecisionError> {
+) -> Result<AbsoluteBoundPair, PrecisionOutOfRangeDateError> {
     Ok(AbsoluteBoundPair::new(
         precise_abs_start_bound(&bounds.start(), tz.clone(), precision_start)?,
         precise_abs_end_bound(&bounds.end(), tz, precision_end)?,
@@ -755,12 +755,12 @@ pub fn precise_abs_finite_bound(
     bound: &AbsoluteFiniteBound,
     tz: TimeZone,
     precision: Precision,
-) -> Result<AbsoluteFiniteBound, PrecisionError> {
+) -> Result<AbsoluteFiniteBound, PrecisionOutOfRangeDateError> {
     Ok(AbsoluteFiniteBound::new_with_inclusivity(
         precision
             .precise_time(&bound.time().to_zoned(tz))?
             .compatible()
-            .or(Err(PrecisionError::OutOfRangeDate))?
+            .or(Err(PrecisionOutOfRangeDateError))?
             .timestamp(),
         bound.inclusivity(),
     ))
@@ -775,7 +775,7 @@ pub fn precise_abs_start_bound(
     bound: &AbsoluteStartBound,
     tz: TimeZone,
     precision: Precision,
-) -> Result<AbsoluteStartBound, PrecisionError> {
+) -> Result<AbsoluteStartBound, PrecisionOutOfRangeDateError> {
     match bound {
         AbsoluteStartBound::InfinitePast => Ok(*bound),
         AbsoluteStartBound::Finite(finite_bound) => {
@@ -793,7 +793,7 @@ pub fn precise_abs_end_bound(
     bound: &AbsoluteEndBound,
     tz: TimeZone,
     precision: Precision,
-) -> Result<AbsoluteEndBound, PrecisionError> {
+) -> Result<AbsoluteEndBound, PrecisionOutOfRangeDateError> {
     match bound {
         AbsoluteEndBound::InfiniteFuture => Ok(*bound),
         AbsoluteEndBound::Finite(finite_bound) => {
@@ -814,7 +814,7 @@ pub fn precise_abs_bound_pair_with_base_time(
     base_start: Timestamp,
     precision_end: Precision,
     base_end: Timestamp,
-) -> Result<AbsoluteBoundPair, PrecisionError> {
+) -> Result<AbsoluteBoundPair, PrecisionOutOfRangeDateError> {
     Ok(AbsoluteBoundPair::new(
         precise_abs_start_bound_with_base_time(&bounds.start(), tz.clone(), precision_start, base_start)?,
         precise_abs_end_bound_with_base_time(&bounds.end(), tz, precision_end, base_end)?,
@@ -831,7 +831,7 @@ pub fn precise_abs_finite_bound_with_base_time(
     tz: TimeZone,
     precision: Precision,
     base: Timestamp,
-) -> Result<AbsoluteFiniteBound, PrecisionError> {
+) -> Result<AbsoluteFiniteBound, PrecisionOutOfRangeDateError> {
     Ok(AbsoluteFiniteBound::new_with_inclusivity(
         precision
             .precise_time_with_base_time(&bound.time().to_zoned(tz), base)?
@@ -850,7 +850,7 @@ pub fn precise_abs_start_bound_with_base_time(
     tz: TimeZone,
     precision: Precision,
     base: Timestamp,
-) -> Result<AbsoluteStartBound, PrecisionError> {
+) -> Result<AbsoluteStartBound, PrecisionOutOfRangeDateError> {
     match bound {
         AbsoluteStartBound::InfinitePast => Ok(*bound),
         AbsoluteStartBound::Finite(finite_bound) => {
@@ -869,7 +869,7 @@ pub fn precise_abs_end_bound_with_base_time(
     tz: TimeZone,
     precision: Precision,
     base: Timestamp,
-) -> Result<AbsoluteEndBound, PrecisionError> {
+) -> Result<AbsoluteEndBound, PrecisionOutOfRangeDateError> {
     match bound {
         AbsoluteEndBound::InfiniteFuture => Ok(*bound),
         AbsoluteEndBound::Finite(finite_bound) => {

--- a/src/intervals/ops/remove_overlap.rs
+++ b/src/intervals/ops/remove_overlap.rs
@@ -4,6 +4,9 @@
 //! between the two intervals. If the two intervals are not overlapping, the
 //! operation produces an error.
 
+use std::error::Error;
+use std::fmt::Display;
+
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -158,12 +161,17 @@ impl<T> OverlapRemovalResult<T> {
     }
 }
 
-/// Errors that can occur when using [`OverlapRemovable`]
+/// No overlap was found between the intervals when using [`OverlapRemovable`]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum OverlapRemovalErr {
-    /// No overlap was found between the intervals
-    NoOverlap,
+pub struct OverlapRemovalNoOverlapFoundError;
+
+impl Display for OverlapRemovalNoOverlapFoundError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "No overlap was found between the intervals")
+    }
 }
+
+impl Error for OverlapRemovalNoOverlapFoundError {}
 
 /// Capacity to remove overlap between two intervals that strictly overlap
 pub trait OverlapRemovable<Rhs = Self> {
@@ -176,8 +184,11 @@ pub trait OverlapRemovable<Rhs = Self> {
     /// # Errors
     ///
     /// If the given bounds don't overlap, this method returns
-    /// [`OverlapRemovalErr::NoOverlap`].
-    fn remove_overlap(&self, rhs: &Rhs) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalErr>;
+    /// [`OverlapRemovalNoOverlapFoundError`].
+    fn remove_overlap(
+        &self,
+        rhs: &Rhs,
+    ) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalNoOverlapFoundError>;
 }
 
 impl<Rhs> OverlapRemovable<Rhs> for AbsoluteBoundPair
@@ -186,7 +197,10 @@ where
 {
     type Output = EmptiableAbsoluteBoundPair;
 
-    fn remove_overlap(&self, rhs: &Rhs) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalErr> {
+    fn remove_overlap(
+        &self,
+        rhs: &Rhs,
+    ) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalNoOverlapFoundError> {
         remove_overlap_abs_bound_pair_with_emptiable_abs_bound_pair(self, &rhs.emptiable_abs_bound_pair())
     }
 }
@@ -197,7 +211,10 @@ where
 {
     type Output = Self;
 
-    fn remove_overlap(&self, rhs: &Rhs) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalErr> {
+    fn remove_overlap(
+        &self,
+        rhs: &Rhs,
+    ) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalNoOverlapFoundError> {
         remove_overlap_emptiable_abs_bound_pair(self, &rhs.emptiable_abs_bound_pair())
     }
 }
@@ -208,7 +225,10 @@ where
 {
     type Output = EmptiableAbsoluteInterval;
 
-    fn remove_overlap(&self, rhs: &Rhs) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalErr> {
+    fn remove_overlap(
+        &self,
+        rhs: &Rhs,
+    ) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalNoOverlapFoundError> {
         remove_overlap_abs_bound_pair_with_emptiable_abs_bound_pair(
             &self.abs_bound_pair(),
             &rhs.emptiable_abs_bound_pair(),
@@ -223,7 +243,10 @@ where
 {
     type Output = Self;
 
-    fn remove_overlap(&self, rhs: &Rhs) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalErr> {
+    fn remove_overlap(
+        &self,
+        rhs: &Rhs,
+    ) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalNoOverlapFoundError> {
         remove_overlap_emptiable_abs_bound_pair(&self.emptiable_abs_bound_pair(), &rhs.emptiable_abs_bound_pair())
             .map(|overlap_removal_res| overlap_removal_res.map(Self::Output::from))
     }
@@ -235,7 +258,10 @@ where
 {
     type Output = EmptiableAbsoluteInterval;
 
-    fn remove_overlap(&self, rhs: &Rhs) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalErr> {
+    fn remove_overlap(
+        &self,
+        rhs: &Rhs,
+    ) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalNoOverlapFoundError> {
         remove_overlap_emptiable_abs_bound_pair(&self.emptiable_abs_bound_pair(), &rhs.emptiable_abs_bound_pair())
             .map(|overlap_removal_res| overlap_removal_res.map(Self::Output::from))
     }
@@ -247,7 +273,10 @@ where
 {
     type Output = EmptiableAbsoluteInterval;
 
-    fn remove_overlap(&self, rhs: &Rhs) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalErr> {
+    fn remove_overlap(
+        &self,
+        rhs: &Rhs,
+    ) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalNoOverlapFoundError> {
         remove_overlap_emptiable_abs_bound_pair(&self.emptiable_abs_bound_pair(), &rhs.emptiable_abs_bound_pair())
             .map(|overlap_removal_res| overlap_removal_res.map(Self::Output::from))
     }
@@ -259,7 +288,10 @@ where
 {
     type Output = EmptiableRelativeBoundPair;
 
-    fn remove_overlap(&self, rhs: &Rhs) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalErr> {
+    fn remove_overlap(
+        &self,
+        rhs: &Rhs,
+    ) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalNoOverlapFoundError> {
         remove_overlap_rel_bound_pair_with_emptiable_rel_bound_pair(self, &rhs.emptiable_rel_bound_pair())
     }
 }
@@ -270,7 +302,10 @@ where
 {
     type Output = Self;
 
-    fn remove_overlap(&self, rhs: &Rhs) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalErr> {
+    fn remove_overlap(
+        &self,
+        rhs: &Rhs,
+    ) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalNoOverlapFoundError> {
         remove_overlap_emptiable_rel_bound_pair(self, &rhs.emptiable_rel_bound_pair())
     }
 }
@@ -281,7 +316,10 @@ where
 {
     type Output = EmptiableRelativeInterval;
 
-    fn remove_overlap(&self, rhs: &Rhs) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalErr> {
+    fn remove_overlap(
+        &self,
+        rhs: &Rhs,
+    ) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalNoOverlapFoundError> {
         remove_overlap_emptiable_rel_bound_pair(&self.emptiable_rel_bound_pair(), &rhs.emptiable_rel_bound_pair())
             .map(|overlap_removal_res| overlap_removal_res.map(Self::Output::from))
     }
@@ -293,7 +331,10 @@ where
 {
     type Output = Self;
 
-    fn remove_overlap(&self, rhs: &Rhs) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalErr> {
+    fn remove_overlap(
+        &self,
+        rhs: &Rhs,
+    ) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalNoOverlapFoundError> {
         remove_overlap_emptiable_rel_bound_pair(&self.emptiable_rel_bound_pair(), &rhs.emptiable_rel_bound_pair())
             .map(|overlap_removal_res| overlap_removal_res.map(Self::Output::from))
     }
@@ -305,7 +346,10 @@ where
 {
     type Output = EmptiableRelativeInterval;
 
-    fn remove_overlap(&self, rhs: &Rhs) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalErr> {
+    fn remove_overlap(
+        &self,
+        rhs: &Rhs,
+    ) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalNoOverlapFoundError> {
         remove_overlap_emptiable_rel_bound_pair(&self.emptiable_rel_bound_pair(), &rhs.emptiable_rel_bound_pair())
             .map(|overlap_removal_res| overlap_removal_res.map(Self::Output::from))
     }
@@ -317,7 +361,10 @@ where
 {
     type Output = EmptiableRelativeInterval;
 
-    fn remove_overlap(&self, rhs: &Rhs) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalErr> {
+    fn remove_overlap(
+        &self,
+        rhs: &Rhs,
+    ) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalNoOverlapFoundError> {
         remove_overlap_emptiable_rel_bound_pair(&self.emptiable_rel_bound_pair(), &rhs.emptiable_rel_bound_pair())
             .map(|overlap_removal_res| overlap_removal_res.map(Self::Output::from))
     }
@@ -326,7 +373,10 @@ where
 impl OverlapRemovable<AbsoluteBoundPair> for UnboundedInterval {
     type Output = EmptiableAbsoluteInterval;
 
-    fn remove_overlap(&self, rhs: &AbsoluteBoundPair) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalErr> {
+    fn remove_overlap(
+        &self,
+        rhs: &AbsoluteBoundPair,
+    ) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalNoOverlapFoundError> {
         remove_overlap_abs_bound_pair(&self.abs_bound_pair(), &rhs.abs_bound_pair())
             .map(|overlap_removal_res| overlap_removal_res.map(Self::Output::from))
     }
@@ -338,7 +388,7 @@ impl OverlapRemovable<EmptiableAbsoluteBoundPair> for UnboundedInterval {
     fn remove_overlap(
         &self,
         rhs: &EmptiableAbsoluteBoundPair,
-    ) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalErr> {
+    ) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalNoOverlapFoundError> {
         remove_overlap_abs_bound_pair_with_emptiable_abs_bound_pair(
             &self.abs_bound_pair(),
             &rhs.emptiable_abs_bound_pair(),
@@ -350,7 +400,10 @@ impl OverlapRemovable<EmptiableAbsoluteBoundPair> for UnboundedInterval {
 impl OverlapRemovable<AbsoluteInterval> for UnboundedInterval {
     type Output = EmptiableAbsoluteInterval;
 
-    fn remove_overlap(&self, rhs: &AbsoluteInterval) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalErr> {
+    fn remove_overlap(
+        &self,
+        rhs: &AbsoluteInterval,
+    ) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalNoOverlapFoundError> {
         remove_overlap_abs_bound_pair(&self.abs_bound_pair(), &rhs.abs_bound_pair())
             .map(|overlap_removal_res| overlap_removal_res.map(Self::Output::from))
     }
@@ -362,7 +415,7 @@ impl OverlapRemovable<EmptiableAbsoluteInterval> for UnboundedInterval {
     fn remove_overlap(
         &self,
         rhs: &EmptiableAbsoluteInterval,
-    ) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalErr> {
+    ) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalNoOverlapFoundError> {
         remove_overlap_emptiable_abs_bound_pair(&self.emptiable_abs_bound_pair(), &rhs.emptiable_abs_bound_pair())
             .map(|overlap_removal_res| overlap_removal_res.map(Self::Output::from))
     }
@@ -374,7 +427,7 @@ impl OverlapRemovable<BoundedAbsoluteInterval> for UnboundedInterval {
     fn remove_overlap(
         &self,
         rhs: &BoundedAbsoluteInterval,
-    ) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalErr> {
+    ) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalNoOverlapFoundError> {
         remove_overlap_abs_bound_pair(&self.abs_bound_pair(), &rhs.abs_bound_pair())
             .map(|overlap_removal_res| overlap_removal_res.map(Self::Output::from))
     }
@@ -386,7 +439,7 @@ impl OverlapRemovable<HalfBoundedAbsoluteInterval> for UnboundedInterval {
     fn remove_overlap(
         &self,
         rhs: &HalfBoundedAbsoluteInterval,
-    ) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalErr> {
+    ) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalNoOverlapFoundError> {
         remove_overlap_abs_bound_pair(&self.abs_bound_pair(), &rhs.abs_bound_pair())
             .map(|overlap_removal_res| overlap_removal_res.map(Self::Output::from))
     }
@@ -395,7 +448,10 @@ impl OverlapRemovable<HalfBoundedAbsoluteInterval> for UnboundedInterval {
 impl OverlapRemovable<RelativeBoundPair> for UnboundedInterval {
     type Output = EmptiableRelativeInterval;
 
-    fn remove_overlap(&self, rhs: &RelativeBoundPair) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalErr> {
+    fn remove_overlap(
+        &self,
+        rhs: &RelativeBoundPair,
+    ) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalNoOverlapFoundError> {
         remove_overlap_rel_bound_pair(&self.rel_bound_pair(), &rhs.rel_bound_pair())
             .map(|overlap_removal_res| overlap_removal_res.map(Self::Output::from))
     }
@@ -407,7 +463,7 @@ impl OverlapRemovable<EmptiableRelativeBoundPair> for UnboundedInterval {
     fn remove_overlap(
         &self,
         rhs: &EmptiableRelativeBoundPair,
-    ) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalErr> {
+    ) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalNoOverlapFoundError> {
         remove_overlap_rel_bound_pair_with_emptiable_rel_bound_pair(
             &self.rel_bound_pair(),
             &rhs.emptiable_rel_bound_pair(),
@@ -419,7 +475,10 @@ impl OverlapRemovable<EmptiableRelativeBoundPair> for UnboundedInterval {
 impl OverlapRemovable<RelativeInterval> for UnboundedInterval {
     type Output = EmptiableRelativeInterval;
 
-    fn remove_overlap(&self, rhs: &RelativeInterval) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalErr> {
+    fn remove_overlap(
+        &self,
+        rhs: &RelativeInterval,
+    ) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalNoOverlapFoundError> {
         remove_overlap_rel_bound_pair(&self.rel_bound_pair(), &rhs.rel_bound_pair())
             .map(|overlap_removal_res| overlap_removal_res.map(Self::Output::from))
     }
@@ -431,7 +490,7 @@ impl OverlapRemovable<EmptiableRelativeInterval> for UnboundedInterval {
     fn remove_overlap(
         &self,
         rhs: &EmptiableRelativeInterval,
-    ) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalErr> {
+    ) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalNoOverlapFoundError> {
         remove_overlap_rel_bound_pair_with_emptiable_rel_bound_pair(
             &self.rel_bound_pair(),
             &rhs.emptiable_rel_bound_pair(),
@@ -446,7 +505,7 @@ impl OverlapRemovable<BoundedRelativeInterval> for UnboundedInterval {
     fn remove_overlap(
         &self,
         rhs: &BoundedRelativeInterval,
-    ) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalErr> {
+    ) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalNoOverlapFoundError> {
         remove_overlap_rel_bound_pair(&self.rel_bound_pair(), &rhs.rel_bound_pair())
             .map(|overlap_removal_res| overlap_removal_res.map(Self::Output::from))
     }
@@ -458,7 +517,7 @@ impl OverlapRemovable<HalfBoundedRelativeInterval> for UnboundedInterval {
     fn remove_overlap(
         &self,
         rhs: &HalfBoundedRelativeInterval,
-    ) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalErr> {
+    ) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalNoOverlapFoundError> {
         remove_overlap_rel_bound_pair(&self.rel_bound_pair(), &rhs.rel_bound_pair())
             .map(|overlap_removal_res| overlap_removal_res.map(Self::Output::from))
     }
@@ -470,7 +529,7 @@ impl OverlapRemovable<UnboundedInterval> for UnboundedInterval {
     fn remove_overlap(
         &self,
         _rhs: &UnboundedInterval,
-    ) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalErr> {
+    ) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalNoOverlapFoundError> {
         Ok(OverlapRemovalResult::Single(EmptyInterval))
     }
 }
@@ -478,7 +537,10 @@ impl OverlapRemovable<UnboundedInterval> for UnboundedInterval {
 impl OverlapRemovable<EmptyInterval> for UnboundedInterval {
     type Output = UnboundedInterval;
 
-    fn remove_overlap(&self, _rhs: &EmptyInterval) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalErr> {
+    fn remove_overlap(
+        &self,
+        _rhs: &EmptyInterval,
+    ) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalNoOverlapFoundError> {
         Ok(OverlapRemovalResult::Single(*self))
     }
 }
@@ -489,7 +551,10 @@ where
 {
     type Output = EmptyInterval;
 
-    fn remove_overlap(&self, _rhs: &Rhs) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalErr> {
+    fn remove_overlap(
+        &self,
+        _rhs: &Rhs,
+    ) -> Result<OverlapRemovalResult<Self::Output>, OverlapRemovalNoOverlapFoundError> {
         Ok(OverlapRemovalResult::Single(*self))
     }
 }
@@ -502,18 +567,18 @@ where
 /// # Errors
 ///
 /// If the given bounds don't overlap, this method returns
-/// [`OverlapRemovalErr::NoOverlap`].
+/// [`OverlapRemovalNoOverlapFoundError`].
 pub fn remove_overlap_abs_bound_pair(
     a: &AbsoluteBoundPair,
     b: &AbsoluteBoundPair,
-) -> Result<OverlapRemovalResult<EmptiableAbsoluteBoundPair>, OverlapRemovalErr> {
+) -> Result<OverlapRemovalResult<EmptiableAbsoluteBoundPair>, OverlapRemovalNoOverlapFoundError> {
     type Dop = DisambiguatedOverlapPosition;
 
     let Ok(disambiguated_overlap_position) = a.disambiguated_overlap_position(b, OverlapRuleSet::default());
 
     match disambiguated_overlap_position {
         Dop::Outside => unreachable!("Only empty intervals can produce `OverlapPosition::Outside`"),
-        Dop::OutsideBefore | Dop::OutsideAfter => Err(OverlapRemovalErr::NoOverlap),
+        Dop::OutsideBefore | Dop::OutsideAfter => Err(OverlapRemovalNoOverlapFoundError),
         Dop::EndsOnStart => {
             let AbsoluteEndBound::Finite(mut finite_bound) = a.abs_end() else {
                 unreachable!(
@@ -676,11 +741,11 @@ pub fn remove_end_overlap_abs(a: &AbsoluteBoundPair, b: &AbsoluteBoundPair) -> A
 /// # Errors
 ///
 /// If the given bounds don't overlap, this method returns
-/// [`OverlapRemovalErr::NoOverlap`].
+/// [`OverlapRemovalNoOverlapFoundError`].
 pub fn remove_overlap_abs_bound_pair_with_emptiable_abs_bound_pair(
     a: &AbsoluteBoundPair,
     b: &EmptiableAbsoluteBoundPair,
-) -> Result<OverlapRemovalResult<EmptiableAbsoluteBoundPair>, OverlapRemovalErr> {
+) -> Result<OverlapRemovalResult<EmptiableAbsoluteBoundPair>, OverlapRemovalNoOverlapFoundError> {
     let EmptiableAbsoluteBoundPair::Bound(b_abs_bound_pair) = b else {
         return Ok(OverlapRemovalResult::Single(EmptiableAbsoluteBoundPair::from(
             a.clone(),
@@ -698,11 +763,11 @@ pub fn remove_overlap_abs_bound_pair_with_emptiable_abs_bound_pair(
 /// # Errors
 ///
 /// If the given bounds don't overlap, this method returns
-/// [`OverlapRemovalErr::NoOverlap`].
+/// [`OverlapRemovalNoOverlapFoundError`].
 pub fn remove_overlap_emptiable_abs_bound_pair(
     a: &EmptiableAbsoluteBoundPair,
     b: &EmptiableAbsoluteBoundPair,
-) -> Result<OverlapRemovalResult<EmptiableAbsoluteBoundPair>, OverlapRemovalErr> {
+) -> Result<OverlapRemovalResult<EmptiableAbsoluteBoundPair>, OverlapRemovalNoOverlapFoundError> {
     let EmptiableAbsoluteBoundPair::Bound(a_abs_bound_pair) = a else {
         return Ok(OverlapRemovalResult::Single(a.clone()));
     };
@@ -718,18 +783,18 @@ pub fn remove_overlap_emptiable_abs_bound_pair(
 /// # Errors
 ///
 /// If the given bounds don't overlap, this method returns
-/// [`OverlapRemovalErr::NoOverlap`].
+/// [`OverlapRemovalNoOverlapFoundError`].
 pub fn remove_overlap_rel_bound_pair(
     a: &RelativeBoundPair,
     b: &RelativeBoundPair,
-) -> Result<OverlapRemovalResult<EmptiableRelativeBoundPair>, OverlapRemovalErr> {
+) -> Result<OverlapRemovalResult<EmptiableRelativeBoundPair>, OverlapRemovalNoOverlapFoundError> {
     type Dop = DisambiguatedOverlapPosition;
 
     let Ok(disambiguated_overlap_position) = a.disambiguated_overlap_position(b, OverlapRuleSet::default());
 
     match disambiguated_overlap_position {
         Dop::Outside => unreachable!("Only empty intervals can produce `OverlapPosition::Outside`"),
-        Dop::OutsideBefore | Dop::OutsideAfter => Err(OverlapRemovalErr::NoOverlap),
+        Dop::OutsideBefore | Dop::OutsideAfter => Err(OverlapRemovalNoOverlapFoundError),
         Dop::EndsOnStart => {
             let RelativeEndBound::Finite(mut finite_bound) = a.rel_end() else {
                 unreachable!(
@@ -892,11 +957,11 @@ pub fn remove_end_overlap_rel(a: &RelativeBoundPair, b: &RelativeBoundPair) -> R
 /// # Errors
 ///
 /// If the given bounds don't overlap, this method returns
-/// [`OverlapRemovalErr::NoOverlap`].
+/// [`OverlapRemovalNoOverlapFoundError`].
 pub fn remove_overlap_rel_bound_pair_with_emptiable_rel_bound_pair(
     a: &RelativeBoundPair,
     b: &EmptiableRelativeBoundPair,
-) -> Result<OverlapRemovalResult<EmptiableRelativeBoundPair>, OverlapRemovalErr> {
+) -> Result<OverlapRemovalResult<EmptiableRelativeBoundPair>, OverlapRemovalNoOverlapFoundError> {
     let EmptiableRelativeBoundPair::Bound(b_rel_bound_pair) = b else {
         return Ok(OverlapRemovalResult::Single(EmptiableRelativeBoundPair::from(
             a.clone(),
@@ -914,11 +979,11 @@ pub fn remove_overlap_rel_bound_pair_with_emptiable_rel_bound_pair(
 /// # Errors
 ///
 /// If the given bounds don't overlap, this method returns
-/// [`OverlapRemovalErr::NoOverlap`].
+/// [`OverlapRemovalNoOverlapFoundError`].
 pub fn remove_overlap_emptiable_rel_bound_pair(
     a: &EmptiableRelativeBoundPair,
     b: &EmptiableRelativeBoundPair,
-) -> Result<OverlapRemovalResult<EmptiableRelativeBoundPair>, OverlapRemovalErr> {
+) -> Result<OverlapRemovalResult<EmptiableRelativeBoundPair>, OverlapRemovalNoOverlapFoundError> {
     let EmptiableRelativeBoundPair::Bound(a_rel_bound_pair) = a else {
         return Ok(OverlapRemovalResult::Single(a.clone()));
     };

--- a/src/intervals/ops/remove_overlap_tests.rs
+++ b/src/intervals/ops/remove_overlap_tests.rs
@@ -114,7 +114,7 @@ mod remove_overlap {
                     "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 )),
             )),
-            Err(OverlapRemovalErr::NoOverlap),
+            Err(OverlapRemovalNoOverlapFoundError),
         );
 
         Ok(())
@@ -183,7 +183,7 @@ mod remove_overlap {
                     BoundInclusivity::Inclusive,
                 )),
             )),
-            Err(OverlapRemovalErr::NoOverlap),
+            Err(OverlapRemovalNoOverlapFoundError),
         );
 
         Ok(())
@@ -212,7 +212,7 @@ mod remove_overlap {
                     BoundInclusivity::Inclusive,
                 )),
             )),
-            Err(OverlapRemovalErr::NoOverlap),
+            Err(OverlapRemovalNoOverlapFoundError),
         );
 
         Ok(())
@@ -241,7 +241,7 @@ mod remove_overlap {
                     BoundInclusivity::Inclusive,
                 )),
             )),
-            Err(OverlapRemovalErr::NoOverlap),
+            Err(OverlapRemovalNoOverlapFoundError),
         );
 
         Ok(())

--- a/src/intervals/ops/set_ops.rs
+++ b/src/intervals/ops/set_ops.rs
@@ -23,7 +23,11 @@ use crate::intervals::absolute::{
 use crate::intervals::meta::Interval;
 use crate::intervals::ops::Complementable;
 use crate::intervals::ops::overlap::{OverlapRule, OverlapRuleSet};
-use crate::intervals::ops::remove_overlap::{OverlapRemovable, OverlapRemovalErr, OverlapRemovalResult};
+use crate::intervals::ops::remove_overlap::{
+    OverlapRemovable,
+    OverlapRemovalNoOverlapFoundError,
+    OverlapRemovalResult,
+};
 use crate::intervals::relative::{
     BoundedRelativeInterval,
     EmptiableRelativeBoundPair,
@@ -1664,7 +1668,7 @@ pub fn differentiate_abs_bound_pair(
             OverlapRemovalResult::Single(single) => DifferenceResult::Single(single),
             OverlapRemovalResult::Split(s1, s2) => DifferenceResult::Split(s1, s2),
         },
-        Err(OverlapRemovalErr::NoOverlap) => unreachable!("Overlap check already happened earlier"),
+        Err(OverlapRemovalNoOverlapFoundError) => unreachable!("Overlap check already happened earlier"),
     }
 }
 
@@ -1722,7 +1726,7 @@ pub fn differentiate_rel_bound_pair(
             OverlapRemovalResult::Single(single) => DifferenceResult::Single(single),
             OverlapRemovalResult::Split(s1, s2) => DifferenceResult::Split(s1, s2),
         },
-        Err(OverlapRemovalErr::NoOverlap) => unreachable!("Overlap check already happened earlier"),
+        Err(OverlapRemovalNoOverlapFoundError) => unreachable!("Overlap check already happened earlier"),
     }
 }
 
@@ -2335,11 +2339,11 @@ pub fn symmetrically_differentiate_abs_bound_pair(
 
     let diff_a_with_b = match a.remove_overlap(b) {
         Ok(a_removed_b) => a_removed_b,
-        Err(OverlapRemovalErr::NoOverlap) => unreachable!("Overlap check already happened earlier"),
+        Err(OverlapRemovalNoOverlapFoundError) => unreachable!("Overlap check already happened earlier"),
     };
     let diff_b_with_a = match b.remove_overlap(a) {
         Ok(b_removed_a) => b_removed_a,
-        Err(OverlapRemovalErr::NoOverlap) => unreachable!("Overlap check already happened earlier"),
+        Err(OverlapRemovalNoOverlapFoundError) => unreachable!("Overlap check already happened earlier"),
     };
 
     match (diff_a_with_b, diff_b_with_a) {
@@ -2426,11 +2430,11 @@ pub fn symmetrically_differentiate_rel_bound_pair(
 
     let diff_a_with_b = match a.remove_overlap(b) {
         Ok(a_removed_b) => a_removed_b,
-        Err(OverlapRemovalErr::NoOverlap) => unreachable!("Overlap check already happened earlier"),
+        Err(OverlapRemovalNoOverlapFoundError) => unreachable!("Overlap check already happened earlier"),
     };
     let diff_b_with_a = match b.remove_overlap(a) {
         Ok(b_removed_a) => b_removed_a,
-        Err(OverlapRemovalErr::NoOverlap) => unreachable!("Overlap check already happened earlier"),
+        Err(OverlapRemovalNoOverlapFoundError) => unreachable!("Overlap check already happened earlier"),
     };
 
     match (diff_a_with_b, diff_b_with_a) {

--- a/src/intervals/relative/bound_pair.rs
+++ b/src/intervals/relative/bound_pair.rs
@@ -40,6 +40,7 @@ use crate::intervals::relative::{
     EmptiableRelativeInterval,
     HalfBoundedRelativeInterval,
     RelativeEndBound,
+    RelativeInterval,
     RelativeStartBound,
     check_relative_bound_pair_for_interval_creation,
     prepare_relative_bound_pair_for_interval_creation,
@@ -490,6 +491,12 @@ impl From<BoundedRelativeInterval> for RelativeBoundPair {
 
 impl From<HalfBoundedRelativeInterval> for RelativeBoundPair {
     fn from(value: HalfBoundedRelativeInterval) -> Self {
+        value.rel_bound_pair()
+    }
+}
+
+impl From<RelativeInterval> for RelativeBoundPair {
+    fn from(value: RelativeInterval) -> Self {
         value.rel_bound_pair()
     }
 }

--- a/src/intervals/relative/bound_pair.rs
+++ b/src/intervals/relative/bound_pair.rs
@@ -35,13 +35,16 @@ use crate::intervals::meta::{
     Relativity,
 };
 use crate::intervals::relative::{
+    BoundedRelativeInterval,
     EmptiableRelativeBoundPair,
     EmptiableRelativeInterval,
+    HalfBoundedRelativeInterval,
     RelativeEndBound,
     RelativeStartBound,
     check_relative_bound_pair_for_interval_creation,
     prepare_relative_bound_pair_for_interval_creation,
 };
+use crate::intervals::special::UnboundedInterval;
 
 /// Possession of non-empty relative bound pair
 pub trait HasRelativeBoundPair {
@@ -476,6 +479,24 @@ impl
         let start = RelativeStartBound::from(start_opt);
         let end = RelativeEndBound::from(end_opt);
         Self::new(start, end)
+    }
+}
+
+impl From<BoundedRelativeInterval> for RelativeBoundPair {
+    fn from(value: BoundedRelativeInterval) -> Self {
+        value.rel_bound_pair()
+    }
+}
+
+impl From<HalfBoundedRelativeInterval> for RelativeBoundPair {
+    fn from(value: HalfBoundedRelativeInterval) -> Self {
+        value.rel_bound_pair()
+    }
+}
+
+impl From<UnboundedInterval> for RelativeBoundPair {
+    fn from(value: UnboundedInterval) -> Self {
+        value.rel_bound_pair()
     }
 }
 

--- a/src/intervals/relative/bound_pair.rs
+++ b/src/intervals/relative/bound_pair.rs
@@ -24,18 +24,19 @@ use serde::{Deserialize, Serialize};
 use crate::intervals::meta::{
     BoundInclusivity,
     Duration as IntervalDuration,
-    IsEmpty,
     Epsilon,
     HasBoundInclusivity,
     HasDuration,
     HasOpenness,
     HasRelativity,
     Interval,
+    IsEmpty,
     Openness,
     Relativity,
 };
 use crate::intervals::relative::{
     EmptiableRelativeBoundPair,
+    EmptiableRelativeInterval,
     RelativeEndBound,
     RelativeStartBound,
     check_relative_bound_pair_for_interval_creation,
@@ -478,32 +479,55 @@ impl
     }
 }
 
-/// Errors that can occur when trying to convert [`EmptiableRelativeBoundPair`]
+/// Error that can occur when trying to convert [`EmptiableRelativeBoundPair`]
 /// into [`RelativeBoundPair`]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum RelativeBoundPairFromEmptiableRelativeBoundPairError {
-    EmptyVariant,
-}
+pub struct RelativeBoundPairTryFromEmptiableRelativeBoundPairError;
 
-impl Display for RelativeBoundPairFromEmptiableRelativeBoundPairError {
+impl Display for RelativeBoundPairTryFromEmptiableRelativeBoundPairError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::EmptyVariant => write!(f, "Provided EmptiableRelativeBoundPair was empty"),
-        }
+        write!(
+            f,
+            "An error occurred when trying to convert `EmptiableRelativeBoundPair` into `RelativeBoundPair`"
+        )
     }
 }
 
-impl Error for RelativeBoundPairFromEmptiableRelativeBoundPairError {}
+impl Error for RelativeBoundPairTryFromEmptiableRelativeBoundPairError {}
 
 impl TryFrom<EmptiableRelativeBoundPair> for RelativeBoundPair {
-    type Error = RelativeBoundPairFromEmptiableRelativeBoundPairError;
+    type Error = RelativeBoundPairTryFromEmptiableRelativeBoundPairError;
 
     fn try_from(value: EmptiableRelativeBoundPair) -> Result<Self, Self::Error> {
-        match value {
-            EmptiableRelativeBoundPair::Empty => {
-                Err(RelativeBoundPairFromEmptiableRelativeBoundPairError::EmptyVariant)
-            },
-            EmptiableRelativeBoundPair::Bound(bounds) => Ok(bounds),
-        }
+        value
+            .bound()
+            .ok_or(RelativeBoundPairTryFromEmptiableRelativeBoundPairError)
+    }
+}
+
+/// Error that can occur when trying to convert [`EmptiableRelativeInterval`]
+/// into [`RelativeBoundPair`]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct RelativeBoundPairTryFromEmptiableRelativeIntervalError;
+
+impl Display for RelativeBoundPairTryFromEmptiableRelativeIntervalError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "An error occurred when trying to convert `EmptiableRelativeInterval` into `RelativeBoundPair`"
+        )
+    }
+}
+
+impl Error for RelativeBoundPairTryFromEmptiableRelativeIntervalError {}
+
+impl TryFrom<EmptiableRelativeInterval> for RelativeBoundPair {
+    type Error = RelativeBoundPairTryFromEmptiableRelativeIntervalError;
+
+    fn try_from(value: EmptiableRelativeInterval) -> Result<Self, Self::Error> {
+        Ok(value
+            .bound()
+            .ok_or(RelativeBoundPairTryFromEmptiableRelativeIntervalError)?
+            .rel_bound_pair())
     }
 }

--- a/src/intervals/relative/bound_pair.rs
+++ b/src/intervals/relative/bound_pair.rs
@@ -24,7 +24,7 @@ use serde::{Deserialize, Serialize};
 use crate::intervals::meta::{
     BoundInclusivity,
     Duration as IntervalDuration,
-    Emptiable,
+    IsEmpty,
     Epsilon,
     HasBoundInclusivity,
     HasDuration,
@@ -437,7 +437,7 @@ impl Ord for RelativeBoundPair {
     }
 }
 
-impl Emptiable for RelativeBoundPair {
+impl IsEmpty for RelativeBoundPair {
     fn is_empty(&self) -> bool {
         false
     }

--- a/src/intervals/relative/bound_pair_tests.rs
+++ b/src/intervals/relative/bound_pair_tests.rs
@@ -480,6 +480,6 @@ fn try_from_emptiable_correct_variant() {
 fn try_from_emptiable_wrong_variant() {
     assert_eq!(
         RelativeBoundPair::try_from(EmptiableRelativeBoundPair::Empty),
-        Err(RelativeBoundPairFromEmptiableRelativeBoundPairError::EmptyVariant),
+        Err(RelativeBoundPairTryFromEmptiableRelativeBoundPairError),
     );
 }

--- a/src/intervals/relative/bounded_interval.rs
+++ b/src/intervals/relative/bounded_interval.rs
@@ -25,7 +25,7 @@ use serde::{Deserialize, Serialize};
 use crate::intervals::meta::{
     BoundInclusivity,
     Duration as IntervalDuration,
-    Emptiable,
+    IsEmpty,
     Epsilon,
     HasBoundInclusivity,
     HasDuration,
@@ -949,7 +949,7 @@ impl HasRelativeBoundPair for BoundedRelativeInterval {
     }
 }
 
-impl Emptiable for BoundedRelativeInterval {
+impl IsEmpty for BoundedRelativeInterval {
     fn is_empty(&self) -> bool {
         false
     }

--- a/src/intervals/relative/bounded_interval.rs
+++ b/src/intervals/relative/bounded_interval.rs
@@ -25,13 +25,13 @@ use serde::{Deserialize, Serialize};
 use crate::intervals::meta::{
     BoundInclusivity,
     Duration as IntervalDuration,
-    IsEmpty,
     Epsilon,
     HasBoundInclusivity,
     HasDuration,
     HasOpenness,
     HasRelativity,
     Interval,
+    IsEmpty,
     Openness,
     Relativity,
 };
@@ -994,25 +994,23 @@ impl From<RangeInclusive<SignedDuration>> for BoundedRelativeInterval {
     }
 }
 
-/// Errors that can occur when trying to convert [`RelativeBoundPair`] into
-/// [`BoundedRelativeInterval`]
+/// Error that can occur when trying to convert [`RelativeBoundPair`] into [`BoundedRelativeInterval`]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum BoundedRelativeIntervalFromRelativeBoundPairError {
-    NotBoundedInterval,
-}
+pub struct BoundedRelativeIntervalTryFromRelativeBoundPairError;
 
-impl Display for BoundedRelativeIntervalFromRelativeBoundPairError {
+impl Display for BoundedRelativeIntervalTryFromRelativeBoundPairError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::NotBoundedInterval => write!(f, "Not a bounded interval"),
-        }
+        write!(
+            f,
+            "An error occurred when trying to convert `RelativeBoundPair` into `BoundedRelativeInterval`"
+        )
     }
 }
 
-impl Error for BoundedRelativeIntervalFromRelativeBoundPairError {}
+impl Error for BoundedRelativeIntervalTryFromRelativeBoundPairError {}
 
 impl TryFrom<RelativeBoundPair> for BoundedRelativeInterval {
-    type Error = BoundedRelativeIntervalFromRelativeBoundPairError;
+    type Error = BoundedRelativeIntervalTryFromRelativeBoundPairError;
 
     fn try_from(value: RelativeBoundPair) -> Result<Self, Self::Error> {
         match (value.start(), value.end()) {
@@ -1024,7 +1022,7 @@ impl TryFrom<RelativeBoundPair> for BoundedRelativeInterval {
                     finite_end.inclusivity(),
                 ))
             },
-            _ => Err(Self::Error::NotBoundedInterval),
+            _ => Err(BoundedRelativeIntervalTryFromRelativeBoundPairError),
         }
     }
 }

--- a/src/intervals/relative/bounded_interval.rs
+++ b/src/intervals/relative/bounded_interval.rs
@@ -36,6 +36,7 @@ use crate::intervals::meta::{
     Relativity,
 };
 use crate::intervals::relative::{
+    EmptiableRelativeBoundPair,
     EmptiableRelativeInterval,
     HasRelativeBoundPair,
     RelativeBoundPair,
@@ -1028,18 +1029,45 @@ impl TryFrom<RelativeBoundPair> for BoundedRelativeInterval {
     }
 }
 
-/// Errors that can occur when trying to convert [`RelativeInterval`] into
+/// Error that can occur when trying to convert [`EmptiableRelativeBoundPair`] into [`BoundedRelativeInterval`]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct BoundedRelativeIntervalTryFromEmptiableRelativeBoundPairError;
+
+impl Display for BoundedRelativeIntervalTryFromEmptiableRelativeBoundPairError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "An error occurred when trying to convert `EmptiableRelativeBoundPair` into `BoundedRelativeInterval`"
+        )
+    }
+}
+
+impl Error for BoundedRelativeIntervalTryFromEmptiableRelativeBoundPairError {}
+
+impl TryFrom<EmptiableRelativeBoundPair> for BoundedRelativeInterval {
+    type Error = BoundedRelativeIntervalTryFromEmptiableRelativeBoundPairError;
+
+    fn try_from(value: EmptiableRelativeBoundPair) -> Result<Self, Self::Error> {
+        Self::try_from(
+            value
+                .bound()
+                .ok_or(BoundedRelativeIntervalTryFromEmptiableRelativeBoundPairError)?,
+        )
+        .or(Err(BoundedRelativeIntervalTryFromEmptiableRelativeBoundPairError))
+    }
+}
+
+/// Error that can occur when trying to convert [`RelativeInterval`] into
 /// [`BoundedRelativeInterval`]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum BoundedRelativeIntervalFromRelativeIntervalError {
-    WrongVariant,
-}
+pub struct BoundedRelativeIntervalFromRelativeIntervalError;
 
 impl Display for BoundedRelativeIntervalFromRelativeIntervalError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::WrongVariant => write!(f, "Wrong variant"),
-        }
+        write!(
+            f,
+            "An error occurred when trying to convert `RelativeInterval` into `BoundedRelativeInterval"
+        )
     }
 }
 
@@ -1049,9 +1077,34 @@ impl TryFrom<RelativeInterval> for BoundedRelativeInterval {
     type Error = BoundedRelativeIntervalFromRelativeIntervalError;
 
     fn try_from(value: RelativeInterval) -> Result<Self, Self::Error> {
-        match value {
-            RelativeInterval::Bounded(interval) => Ok(interval),
-            _ => Err(Self::Error::WrongVariant),
-        }
+        value.bounded().ok_or(BoundedRelativeIntervalFromRelativeIntervalError)
+    }
+}
+
+/// Error that can occur when trying to convert [`EmptiableRelativeInterval`] into [`BoundedRelativeInterval`]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct BoundedRelativeIntervalTryFromEmptiableRelativeIntervalError;
+
+impl Display for BoundedRelativeIntervalTryFromEmptiableRelativeIntervalError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "An error occurred when trying to convert `EmptiableRelativeInterval` into `BoundedRelativeInterval`"
+        )
+    }
+}
+
+impl Error for BoundedRelativeIntervalTryFromEmptiableRelativeIntervalError {}
+
+impl TryFrom<EmptiableRelativeInterval> for BoundedRelativeInterval {
+    type Error = BoundedRelativeIntervalTryFromEmptiableRelativeIntervalError;
+
+    fn try_from(value: EmptiableRelativeInterval) -> Result<Self, Self::Error> {
+        Self::try_from(
+            value
+                .bound()
+                .ok_or(BoundedRelativeIntervalTryFromEmptiableRelativeIntervalError)?,
+        )
+        .or(Err(BoundedRelativeIntervalTryFromEmptiableRelativeIntervalError))
     }
 }

--- a/src/intervals/relative/bounded_interval.rs
+++ b/src/intervals/relative/bounded_interval.rs
@@ -846,7 +846,7 @@ impl BoundedRelativeInterval {
 
     /// Wraps the interval in [`EmptiableRelativeInterval`]
     #[must_use]
-    pub fn to_emptiable(self) -> EmptiableRelativeInterval {
+    pub fn to_emptiable_interval(self) -> EmptiableRelativeInterval {
         EmptiableRelativeInterval::from(self)
     }
 }

--- a/src/intervals/relative/bounded_interval_tests.rs
+++ b/src/intervals/relative/bounded_interval_tests.rs
@@ -263,13 +263,13 @@ fn try_from_relative_interval_correct() {
 fn try_from_relative_interval_wrong() {
     assert_eq!(
         BoundedRelativeInterval::try_from(RelativeInterval::Unbounded(UnboundedInterval)),
-        Err(BoundedRelativeIntervalFromRelativeIntervalError::WrongVariant),
+        Err(BoundedRelativeIntervalFromRelativeIntervalError),
     );
     assert_eq!(
         BoundedRelativeInterval::try_from(RelativeInterval::HalfBounded(HalfBoundedRelativeInterval::new(
             SignedDuration::from_hours(1),
             OpeningDirection::ToFuture,
         ))),
-        Err(BoundedRelativeIntervalFromRelativeIntervalError::WrongVariant),
+        Err(BoundedRelativeIntervalFromRelativeIntervalError),
     );
 }

--- a/src/intervals/relative/bounded_interval_tests.rs
+++ b/src/intervals/relative/bounded_interval_tests.rs
@@ -227,21 +227,21 @@ fn try_from_relative_bounds_wrong() {
             RelativeStartBound::InfinitePast,
             RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1))),
         )),
-        Err(BoundedRelativeIntervalFromRelativeBoundPairError::NotBoundedInterval),
+        Err(BoundedRelativeIntervalTryFromRelativeBoundPairError),
     );
     assert_eq!(
         BoundedRelativeInterval::try_from(RelativeBoundPair::new(
             RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1))),
             RelativeEndBound::InfiniteFuture,
         )),
-        Err(BoundedRelativeIntervalFromRelativeBoundPairError::NotBoundedInterval),
+        Err(BoundedRelativeIntervalTryFromRelativeBoundPairError),
     );
     assert_eq!(
         BoundedRelativeInterval::try_from(RelativeBoundPair::new(
             RelativeStartBound::InfinitePast,
             RelativeEndBound::InfiniteFuture,
         )),
-        Err(BoundedRelativeIntervalFromRelativeBoundPairError::NotBoundedInterval),
+        Err(BoundedRelativeIntervalTryFromRelativeBoundPairError),
     );
 }
 

--- a/src/intervals/relative/emptiable_bound_pair.rs
+++ b/src/intervals/relative/emptiable_bound_pair.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 use crate::intervals::meta::{
     BoundInclusivity,
     Duration as IntervalDuration,
-    Emptiable,
+    IsEmpty,
     Epsilon,
     HasDuration,
     HasOpenness,
@@ -197,7 +197,7 @@ impl HasEmptiableRelativeBoundPair for EmptiableRelativeBoundPair {
     }
 }
 
-impl Emptiable for EmptiableRelativeBoundPair {
+impl IsEmpty for EmptiableRelativeBoundPair {
     fn is_empty(&self) -> bool {
         matches!(self, Self::Empty)
     }

--- a/src/intervals/relative/emptiable_bound_pair.rs
+++ b/src/intervals/relative/emptiable_bound_pair.rs
@@ -16,16 +16,26 @@ use serde::{Deserialize, Serialize};
 use crate::intervals::meta::{
     BoundInclusivity,
     Duration as IntervalDuration,
-    IsEmpty,
     Epsilon,
     HasDuration,
     HasOpenness,
     HasRelativity,
     Interval,
+    IsEmpty,
     Openness,
     Relativity,
 };
-use crate::intervals::relative::{HasRelativeBoundPair, RelativeBoundPair, RelativeEndBound, RelativeStartBound};
+use crate::intervals::relative::{
+    BoundedRelativeInterval,
+    EmptiableRelativeInterval,
+    HalfBoundedRelativeInterval,
+    HasRelativeBoundPair,
+    RelativeBoundPair,
+    RelativeEndBound,
+    RelativeInterval,
+    RelativeStartBound,
+};
+use crate::intervals::special::{EmptyInterval, UnboundedInterval};
 
 /// Possession of possibly empty relative bound pair
 pub trait HasEmptiableRelativeBoundPair {
@@ -311,5 +321,41 @@ impl
 impl From<RelativeBoundPair> for EmptiableRelativeBoundPair {
     fn from(value: RelativeBoundPair) -> Self {
         EmptiableRelativeBoundPair::Bound(value)
+    }
+}
+
+impl From<BoundedRelativeInterval> for EmptiableRelativeBoundPair {
+    fn from(value: BoundedRelativeInterval) -> Self {
+        value.emptiable_rel_bound_pair()
+    }
+}
+
+impl From<HalfBoundedRelativeInterval> for EmptiableRelativeBoundPair {
+    fn from(value: HalfBoundedRelativeInterval) -> Self {
+        value.emptiable_rel_bound_pair()
+    }
+}
+
+impl From<RelativeInterval> for EmptiableRelativeBoundPair {
+    fn from(value: RelativeInterval) -> Self {
+        value.emptiable_rel_bound_pair()
+    }
+}
+
+impl From<EmptiableRelativeInterval> for EmptiableRelativeBoundPair {
+    fn from(value: EmptiableRelativeInterval) -> Self {
+        value.emptiable_rel_bound_pair()
+    }
+}
+
+impl From<UnboundedInterval> for EmptiableRelativeBoundPair {
+    fn from(value: UnboundedInterval) -> Self {
+        value.emptiable_rel_bound_pair()
+    }
+}
+
+impl From<EmptyInterval> for EmptiableRelativeBoundPair {
+    fn from(value: EmptyInterval) -> Self {
+        value.emptiable_rel_bound_pair()
     }
 }

--- a/src/intervals/relative/emptiable_bound_pair.rs
+++ b/src/intervals/relative/emptiable_bound_pair.rs
@@ -78,8 +78,7 @@ where
 /// [empty intervals](crate::intervals::special::EmptyInterval)
 ///
 /// For more information, check [`RelativeBoundPair`],
-/// [`EmptyInterval`](crate::intervals::special::EmptyInterval),
-/// or [`crate::intervals` module documentation](crate::intervals).
+/// [`EmptyInterval`], or [`crate::intervals` module documentation](crate::intervals).
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]

--- a/src/intervals/relative/emptiable_interval.rs
+++ b/src/intervals/relative/emptiable_interval.rs
@@ -96,7 +96,7 @@ impl EmptiableRelativeInterval {
     /// Returns the content of the [`Bound`](EmptiableRelativeInterval::Bound) variant
     ///
     /// Consumes `self` and puts the content of the [`Bound`](EmptiableRelativeInterval::Bound) variant
-    /// in an [`Option`]. If instead `self` is another variant, the method returns [`None`]
+    /// in an [`Option`]. If instead `self` is another variant, the method returns [`None`].
     ///
     /// # Examples
     ///

--- a/src/intervals/relative/emptiable_interval.rs
+++ b/src/intervals/relative/emptiable_interval.rs
@@ -29,7 +29,7 @@ use serde::{Deserialize, Serialize};
 use crate::intervals::meta::{
     BoundInclusivity,
     Duration as IntervalDuration,
-    Emptiable,
+    IsEmpty,
     HasDuration,
     HasOpenness,
     HasRelativity,
@@ -201,7 +201,7 @@ impl HasEmptiableRelativeBoundPair for EmptiableRelativeInterval {
     }
 }
 
-impl Emptiable for EmptiableRelativeInterval {
+impl IsEmpty for EmptiableRelativeInterval {
     fn is_empty(&self) -> bool {
         matches!(self, Self::Empty(_))
     }

--- a/src/intervals/relative/emptiable_interval.rs
+++ b/src/intervals/relative/emptiable_interval.rs
@@ -29,11 +29,11 @@ use serde::{Deserialize, Serialize};
 use crate::intervals::meta::{
     BoundInclusivity,
     Duration as IntervalDuration,
-    IsEmpty,
     HasDuration,
     HasOpenness,
     HasRelativity,
     Interval,
+    IsEmpty,
     Openness,
     Relativity,
 };

--- a/src/intervals/relative/end_bound.rs
+++ b/src/intervals/relative/end_bound.rs
@@ -6,6 +6,8 @@
 //! variant.
 
 use std::cmp::Ordering;
+use std::error::Error;
+use std::fmt::Display;
 use std::ops::Bound;
 
 #[cfg(feature = "arbitrary")]
@@ -284,5 +286,28 @@ impl From<Bound<SignedDuration>> for RelativeEndBound {
             )),
             Bound::Unbounded => RelativeEndBound::InfiniteFuture,
         }
+    }
+}
+
+/// Error that can occur when trying to convert an [`RelativeBound`] into an [`RelativeEndBound`]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct RelativeEndBoundTryFromRelativeBoundError;
+
+impl Display for RelativeEndBoundTryFromRelativeBoundError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "An error occurred when trying to convert an `RelativeBound` into an `RelativeEndBound`"
+        )
+    }
+}
+
+impl Error for RelativeEndBoundTryFromRelativeBoundError {}
+
+impl TryFrom<RelativeBound> for RelativeEndBound {
+    type Error = RelativeEndBoundTryFromRelativeBoundError;
+
+    fn try_from(value: RelativeBound) -> Result<Self, Self::Error> {
+        value.end().ok_or(RelativeEndBoundTryFromRelativeBoundError)
     }
 }

--- a/src/intervals/relative/finite_bound.rs
+++ b/src/intervals/relative/finite_bound.rs
@@ -169,32 +169,23 @@ impl From<(SignedDuration, BoundInclusivity)> for RelativeFiniteBound {
     }
 }
 
-/// Errors that can occur when trying to convert a [`Bound<SignedDuration>`]
-/// into an [`RelativeFiniteBound`]
+/// Error that can occur when trying to convert [`Bound<SignedDuration>`] into [`RelativeFiniteBound`]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum RelativeFiniteBoundFromBoundError {
-    /// The given bound was of the [`Unbounded`](Bound::Unbounded) variant
-    IsUnbounded,
-}
+pub struct RelativeFiniteBoundTryFromBoundError;
 
-impl Display for RelativeFiniteBoundFromBoundError {
+impl Display for RelativeFiniteBoundTryFromBoundError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::IsUnbounded => {
-                write!(
-                    f,
-                    "The given bound was of the `Unbounded` variant, and therefore could not be converted to an \
-                     `RelativeFiniteBound`"
-                )
-            },
-        }
+        write!(
+            f,
+            "An error occurred when trying to convert `Bound<SignedDuration>` into `RelativeFiniteBound`"
+        )
     }
 }
 
-impl Error for RelativeFiniteBoundFromBoundError {}
+impl Error for RelativeFiniteBoundTryFromBoundError {}
 
 impl TryFrom<Bound<SignedDuration>> for RelativeFiniteBound {
-    type Error = RelativeFiniteBoundFromBoundError;
+    type Error = RelativeFiniteBoundTryFromBoundError;
 
     fn try_from(value: Bound<SignedDuration>) -> Result<Self, Self::Error> {
         match value {
@@ -206,7 +197,7 @@ impl TryFrom<Bound<SignedDuration>> for RelativeFiniteBound {
                 offset,
                 BoundInclusivity::Exclusive,
             )),
-            Bound::Unbounded => Err(RelativeFiniteBoundFromBoundError::IsUnbounded),
+            Bound::Unbounded => Err(RelativeFiniteBoundTryFromBoundError),
         }
     }
 }

--- a/src/intervals/relative/finite_bound_tests.rs
+++ b/src/intervals/relative/finite_bound_tests.rs
@@ -132,6 +132,6 @@ fn try_from_exclusive_bound() {
 fn try_from_unbounded_bound() {
     assert_eq!(
         RelativeFiniteBound::try_from(Bound::Unbounded),
-        Err(RelativeFiniteBoundFromBoundError::IsUnbounded),
+        Err(RelativeFiniteBoundTryFromBoundError),
     );
 }

--- a/src/intervals/relative/half_bounded_interval.rs
+++ b/src/intervals/relative/half_bounded_interval.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 use crate::intervals::meta::{
     BoundInclusivity,
     Duration as IntervalDuration,
-    Emptiable,
+    IsEmpty,
     HasBoundInclusivity,
     HasDuration,
     HasOpenness,
@@ -416,7 +416,7 @@ impl HasRelativeBoundPair for HalfBoundedRelativeInterval {
     }
 }
 
-impl Emptiable for HalfBoundedRelativeInterval {
+impl IsEmpty for HalfBoundedRelativeInterval {
     fn is_empty(&self) -> bool {
         false
     }

--- a/src/intervals/relative/half_bounded_interval.rs
+++ b/src/intervals/relative/half_bounded_interval.rs
@@ -335,7 +335,7 @@ impl HalfBoundedRelativeInterval {
 
     /// Wraps the interval in [`EmptiableRelativeInterval`]
     #[must_use]
-    pub fn to_emptiable(self) -> EmptiableRelativeInterval {
+    pub fn to_emptiable_interval(self) -> EmptiableRelativeInterval {
         EmptiableRelativeInterval::from(self)
     }
 }

--- a/src/intervals/relative/half_bounded_interval.rs
+++ b/src/intervals/relative/half_bounded_interval.rs
@@ -21,12 +21,12 @@ use serde::{Deserialize, Serialize};
 use crate::intervals::meta::{
     BoundInclusivity,
     Duration as IntervalDuration,
-    IsEmpty,
     HasBoundInclusivity,
     HasDuration,
     HasOpenness,
     HasRelativity,
     Interval,
+    IsEmpty,
     OpeningDirection,
     Openness,
     Relativity,
@@ -340,23 +340,6 @@ impl HalfBoundedRelativeInterval {
     }
 }
 
-/// Errors that can occur when trying to convert [`RelativeBoundPair`] into
-/// [`HalfBoundedRelativeInterval`]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum HalfBoundedRelativeIntervalFromRelativeBoundPairError {
-    NotHalfBoundedInterval,
-}
-
-impl Display for HalfBoundedRelativeIntervalFromRelativeBoundPairError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::NotHalfBoundedInterval => write!(f, "Not a half-bounded interval"),
-        }
-    }
-}
-
-impl Error for HalfBoundedRelativeIntervalFromRelativeBoundPairError {}
-
 /// Error that can occur when trying to convert a [`SignedDuration`] range into a [`HalfBoundedRelativeInterval`]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct HalfBoundedRelativeIntervalTryFromRangeError;
@@ -464,8 +447,23 @@ impl From<RangeToInclusive<SignedDuration>> for HalfBoundedRelativeInterval {
     }
 }
 
+/// Error that can occur when trying to convert [`RelativeBoundPair`] into [`HalfBoundedRelativeInterval`]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct HalfBoundedRelativeIntervalTryFromRelativeBoundPairError;
+
+impl Display for HalfBoundedRelativeIntervalTryFromRelativeBoundPairError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "An error occurred when trying to convert `RelativeBoundPair` into `HalfBoundedRelativeInterval`"
+        )
+    }
+}
+
+impl Error for HalfBoundedRelativeIntervalTryFromRelativeBoundPairError {}
+
 impl TryFrom<RelativeBoundPair> for HalfBoundedRelativeInterval {
-    type Error = HalfBoundedRelativeIntervalFromRelativeBoundPairError;
+    type Error = HalfBoundedRelativeIntervalTryFromRelativeBoundPairError;
 
     fn try_from(value: RelativeBoundPair) -> Result<Self, Self::Error> {
         match (value.start(), value.end()) {
@@ -483,35 +481,32 @@ impl TryFrom<RelativeBoundPair> for HalfBoundedRelativeInterval {
                     OpeningDirection::ToFuture,
                 ))
             },
-            _ => Err(Self::Error::NotHalfBoundedInterval),
+            _ => Err(HalfBoundedRelativeIntervalTryFromRelativeBoundPairError),
         }
     }
 }
 
-/// Errors that can occur when trying to convert [`RelativeInterval`] into
-/// [`HalfBoundedRelativeInterval`]
+/// Error that can occur when trying to convert [`RelativeInterval`] into [`HalfBoundedRelativeInterval`]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum HalfBoundedRelativeIntervalFromRelativeIntervalError {
-    WrongVariant,
-}
+pub struct HalfBoundedRelativeIntervalTryFromRelativeIntervalError;
 
-impl Display for HalfBoundedRelativeIntervalFromRelativeIntervalError {
+impl Display for HalfBoundedRelativeIntervalTryFromRelativeIntervalError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::WrongVariant => write!(f, "Wrong variant"),
-        }
+        write!(
+            f,
+            "An error occurred when trying to convert `RelativeInterval` into `HalfBoundedRelativeInterval`"
+        )
     }
 }
 
-impl Error for HalfBoundedRelativeIntervalFromRelativeIntervalError {}
+impl Error for HalfBoundedRelativeIntervalTryFromRelativeIntervalError {}
 
 impl TryFrom<RelativeInterval> for HalfBoundedRelativeInterval {
-    type Error = HalfBoundedRelativeIntervalFromRelativeIntervalError;
+    type Error = HalfBoundedRelativeIntervalTryFromRelativeIntervalError;
 
     fn try_from(value: RelativeInterval) -> Result<Self, Self::Error> {
-        match value {
-            RelativeInterval::HalfBounded(interval) => Ok(interval),
-            _ => Err(Self::Error::WrongVariant),
-        }
+        value
+            .half_bounded()
+            .ok_or(HalfBoundedRelativeIntervalTryFromRelativeIntervalError)
     }
 }

--- a/src/intervals/relative/half_bounded_interval_tests.rs
+++ b/src/intervals/relative/half_bounded_interval_tests.rs
@@ -184,14 +184,14 @@ fn interval_try_from_relative_bounds_wrong() {
             RelativeStartBound::InfinitePast,
             RelativeEndBound::InfiniteFuture,
         )),
-        Err(HalfBoundedRelativeIntervalFromRelativeBoundPairError::NotHalfBoundedInterval),
+        Err(HalfBoundedRelativeIntervalTryFromRelativeBoundPairError),
     );
     assert_eq!(
         HalfBoundedRelativeInterval::try_from(RelativeBoundPair::new(
             RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1))),
             RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(2))),
         )),
-        Err(HalfBoundedRelativeIntervalFromRelativeBoundPairError::NotHalfBoundedInterval),
+        Err(HalfBoundedRelativeIntervalTryFromRelativeBoundPairError),
     );
 }
 
@@ -217,13 +217,13 @@ fn interval_try_from_relative_interval_correct() {
 fn interval_try_from_relative_interval_wrong() {
     assert_eq!(
         HalfBoundedRelativeInterval::try_from(RelativeInterval::Unbounded(UnboundedInterval)),
-        Err(HalfBoundedRelativeIntervalFromRelativeIntervalError::WrongVariant),
+        Err(HalfBoundedRelativeIntervalTryFromRelativeIntervalError),
     );
     assert_eq!(
         HalfBoundedRelativeInterval::try_from(RelativeInterval::Bounded(BoundedRelativeInterval::new(
             SignedDuration::from_hours(1),
             SignedDuration::from_hours(2),
         ))),
-        Err(HalfBoundedRelativeIntervalFromRelativeIntervalError::WrongVariant),
+        Err(HalfBoundedRelativeIntervalTryFromRelativeIntervalError),
     );
 }

--- a/src/intervals/relative/interval.rs
+++ b/src/intervals/relative/interval.rs
@@ -138,6 +138,85 @@ impl RelativeInterval {
             .ord_by_start_and_inv_length(&other.rel_bound_pair())
     }
 
+    /// Returns the content of the [`Bounded`](RelativeInterval::Bounded) variant
+    ///
+    /// Consumes `self` and puts the content of the [`Bounded`](RelativeInterval::Bounded) variant
+    /// in an [`Option`]. If instead `self` is another variant, the method returns [`None`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::error::Error;
+    /// # use jiff::SignedDuration;
+    /// # use periodical::intervals::relative::BoundedRelativeInterval;
+    /// let bounded_interval = BoundedRelativeInterval::new(
+    ///     SignedDuration::from_hours(8),
+    ///     SignedDuration::from_hours(16),
+    /// );
+    ///
+    /// let interval = bounded_interval.clone().to_interval();
+    ///
+    /// assert_eq!(interval.bounded(), Some(bounded_interval));
+    /// # Ok::<(), Box<dyn Error>>(())
+    /// ```
+    #[must_use]
+    pub fn bounded(self) -> Option<BoundedRelativeInterval> {
+        match self {
+            Self::Bounded(interval) => Some(interval),
+            _ => None,
+        }
+    }
+
+    /// Returns the content of the [`HalfBounded`](RelativeInterval::HalfBounded) variant
+    ///
+    /// Consumes `self` and puts the content of the [`HalfBounded`](RelativeInterval::HalfBounded) variant
+    /// in an [`Option`]. If instead `self` is another variant, the method returns [`None`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::error::Error;
+    /// # use jiff::SignedDuration;
+    /// # use periodical::intervals::relative::HalfBoundedRelativeInterval;
+    /// # use periodical::intervals::meta::OpeningDirection;
+    /// let half_bounded_interval =
+    ///     HalfBoundedRelativeInterval::new(SignedDuration::from_hours(8), OpeningDirection::ToPast);
+    ///
+    /// let interval = half_bounded_interval.clone().to_interval();
+    ///
+    /// assert_eq!(interval.half_bounded(), Some(half_bounded_interval));
+    /// # Ok::<(), Box<dyn Error>>(())
+    /// ```
+    #[must_use]
+    pub fn half_bounded(self) -> Option<HalfBoundedRelativeInterval> {
+        match self {
+            Self::HalfBounded(interval) => Some(interval),
+            _ => None,
+        }
+    }
+
+    /// Returns the content of the [`Unbounded`](RelativeInterval::Unbounded) variant
+    ///
+    /// Consumes `self` and puts the content of the [`Unbounded`](RelativeInterval::Unbounded) variant
+    /// in an [`Option`]. If instead `self` is another variant, the method returns [`None`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use periodical::intervals::relative::RelativeInterval;
+    /// # use periodical::intervals::special::UnboundedInterval;
+    /// let interval = RelativeInterval::Unbounded(UnboundedInterval);
+    ///
+    /// assert_eq!(interval.unbounded(), Some(half_bounded_interval));
+    /// ```
+    #[must_use]
+    pub fn unbounded(self) -> Option<UnboundedInterval> {
+        match self {
+            Self::Unbounded(interval) => Some(interval),
+            _ => None,
+        }
+    }
+
     /// Wraps the interval in [`EmptiableRelativeInterval`]
     #[must_use]
     pub fn to_emptiable(self) -> EmptiableRelativeInterval {

--- a/src/intervals/relative/interval.rs
+++ b/src/intervals/relative/interval.rs
@@ -32,11 +32,11 @@ use serde::{Deserialize, Serialize};
 use crate::intervals::meta::{
     BoundInclusivity,
     Duration as IntervalDuration,
-    IsEmpty,
     HasDuration,
     HasOpenness,
     HasRelativity,
     Interval,
+    IsEmpty,
     OpeningDirection,
     Openness,
     Relativity,

--- a/src/intervals/relative/interval.rs
+++ b/src/intervals/relative/interval.rs
@@ -32,7 +32,7 @@ use serde::{Deserialize, Serialize};
 use crate::intervals::meta::{
     BoundInclusivity,
     Duration as IntervalDuration,
-    Emptiable,
+    IsEmpty,
     HasDuration,
     HasOpenness,
     HasRelativity,
@@ -294,7 +294,7 @@ impl Ord for RelativeInterval {
     }
 }
 
-impl Emptiable for RelativeInterval {
+impl IsEmpty for RelativeInterval {
     fn is_empty(&self) -> bool {
         false
     }

--- a/src/intervals/relative/interval.rs
+++ b/src/intervals/relative/interval.rs
@@ -207,7 +207,7 @@ impl RelativeInterval {
     /// # use periodical::intervals::special::UnboundedInterval;
     /// let interval = RelativeInterval::Unbounded(UnboundedInterval);
     ///
-    /// assert_eq!(interval.unbounded(), Some(half_bounded_interval));
+    /// assert_eq!(interval.unbounded(), Some(UnboundedInterval));
     /// ```
     #[must_use]
     pub fn unbounded(self) -> Option<UnboundedInterval> {

--- a/src/intervals/relative/start_bound.rs
+++ b/src/intervals/relative/start_bound.rs
@@ -6,6 +6,8 @@
 //! the [`InfinitePast`](RelativeStartBound::InfinitePast) variant.
 
 use std::cmp::Ordering;
+use std::error::Error;
+use std::fmt::Display;
 use std::ops::Bound;
 
 #[cfg(feature = "arbitrary")]
@@ -302,5 +304,28 @@ impl From<Bound<SignedDuration>> for RelativeStartBound {
             )),
             Bound::Unbounded => RelativeStartBound::InfinitePast,
         }
+    }
+}
+
+/// Error that can occur when trying to convert an [`RelativeBound`] into an [`RelativeStartBound`]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct RelativeStartBoundTryFromRelativeBoundError;
+
+impl Display for RelativeStartBoundTryFromRelativeBoundError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "An error occurred when trying to convert an `RelativeBound` into an `RelativeStartBound`"
+        )
+    }
+}
+
+impl Error for RelativeStartBoundTryFromRelativeBoundError {}
+
+impl TryFrom<RelativeBound> for RelativeStartBound {
+    type Error = RelativeStartBoundTryFromRelativeBoundError;
+
+    fn try_from(value: RelativeBound) -> Result<Self, Self::Error> {
+        value.start().ok_or(RelativeStartBoundTryFromRelativeBoundError)
     }
 }

--- a/src/intervals/special.rs
+++ b/src/intervals/special.rs
@@ -386,6 +386,32 @@ impl TryFrom<EmptiableRelativeInterval> for UnboundedInterval {
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct EmptyInterval;
 
+impl EmptyInterval {
+    /// Converts `self` into [`EmptiableAbsoluteBoundPair`]
+    #[must_use]
+    pub fn to_emptiable_abs_bound_pair(self) -> EmptiableAbsoluteBoundPair {
+        EmptiableAbsoluteBoundPair::Empty
+    }
+
+    /// Converts `self` into [`EmptiableAbsoluteInterval`]
+    #[must_use]
+    pub fn to_emptiable_abs_interval(self) -> EmptiableAbsoluteInterval {
+        EmptiableAbsoluteInterval::Empty(self)
+    }
+
+    /// Converts `self` into [`EmptiableRelativeBoundPair`]
+    #[must_use]
+    pub fn to_emptiable_rel_bound_pair(self) -> EmptiableRelativeBoundPair {
+        EmptiableRelativeBoundPair::Empty
+    }
+
+    /// Converts `self` into [`EmptiableRelativeInterval`]
+    #[must_use]
+    pub fn to_emptiable_rel_interval(self) -> EmptiableRelativeInterval {
+        EmptiableRelativeInterval::Empty(self)
+    }
+}
+
 impl Interval for EmptyInterval {}
 
 impl HasOpenness for EmptyInterval {
@@ -440,44 +466,106 @@ impl IsEmpty for EmptyInterval {
     }
 }
 
-/// Errors that can occur when trying to convert an [`AbsoluteInterval`] or
-/// [`RelativeInterval`] into an [`EmptyInterval`]
+/// Error that can occur when trying to convert [`EmptiableAbsoluteBoundPair`] into [`EmptyInterval`]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum EmptyIntervalConversionErr {
-    WrongVariant,
-}
+pub struct EmptyIntervalTryFromEmptiableAbsoluteBoundPair;
 
-impl Display for EmptyIntervalConversionErr {
+impl Display for EmptyIntervalTryFromEmptiableAbsoluteBoundPair {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::WrongVariant => write!(f, "Wrong variant"),
-        }
+        write!(
+            f,
+            "An error occurred when trying to convert `EmptiableAbsoluteBoundPair` into `EmptyInterval`"
+        )
     }
 }
 
-impl Error for EmptyIntervalConversionErr {}
+impl Error for EmptyIntervalTryFromEmptiableAbsoluteBoundPair {}
 
-/*
-IMPL TRY FROM ON Emptiable VARIANTS OF INTERVALS
-impl TryFrom<AbsoluteInterval> for EmptyInterval {
-    type Error = EmptyIntervalConversionErr;
+impl TryFrom<EmptiableAbsoluteBoundPair> for EmptyInterval {
+    type Error = EmptyIntervalTryFromEmptiableAbsoluteBoundPair;
 
-    fn try_from(value: AbsoluteInterval) -> Result<Self, Self::Error> {
-        match value {
-            AbsoluteInterval::Empty(interval) => Ok(interval),
-            _ => Err(Self::Error::WrongVariant),
-        }
+    fn try_from(value: EmptiableAbsoluteBoundPair) -> Result<Self, Self::Error> {
+        value
+            .is_empty()
+            .then_some(EmptyInterval)
+            .ok_or(EmptyIntervalTryFromEmptiableAbsoluteBoundPair)
     }
 }
 
-impl TryFrom<RelativeInterval> for EmptyInterval {
-    type Error = EmptyIntervalConversionErr;
+/// Error that can occur when trying to convert [`EmptiableAbsoluteInterval`] into [`EmptyInterval`]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct EmptyIntervalTryFromEmptiableAbsoluteInterval;
 
-    fn try_from(value: RelativeInterval) -> Result<Self, Self::Error> {
-        match value {
-            RelativeInterval::Empty(interval) => Ok(interval),
-            _ => Err(Self::Error::WrongVariant),
-        }
+impl Display for EmptyIntervalTryFromEmptiableAbsoluteInterval {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "An error occurred when trying to convert `EmptiableAbsoluteInterval` into `EmptyInterval`"
+        )
     }
 }
-*/
+
+impl Error for EmptyIntervalTryFromEmptiableAbsoluteInterval {}
+
+impl TryFrom<EmptiableAbsoluteInterval> for EmptyInterval {
+    type Error = EmptyIntervalTryFromEmptiableAbsoluteInterval;
+
+    fn try_from(value: EmptiableAbsoluteInterval) -> Result<Self, Self::Error> {
+        value
+            .is_empty()
+            .then_some(EmptyInterval)
+            .ok_or(EmptyIntervalTryFromEmptiableAbsoluteInterval)
+    }
+}
+
+/// Error that can occur when trying to convert [`EmptiableRelativeBoundPair`] into [`EmptyInterval`]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct EmptyIntervalTryFromEmptiableRelativeBoundPair;
+
+impl Display for EmptyIntervalTryFromEmptiableRelativeBoundPair {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "An error occurred when trying to convert `EmptiableRelativeBoundPair` into `EmptyInterval`"
+        )
+    }
+}
+
+impl Error for EmptyIntervalTryFromEmptiableRelativeBoundPair {}
+
+impl TryFrom<EmptiableRelativeBoundPair> for EmptyInterval {
+    type Error = EmptyIntervalTryFromEmptiableRelativeBoundPair;
+
+    fn try_from(value: EmptiableRelativeBoundPair) -> Result<Self, Self::Error> {
+        value
+            .is_empty()
+            .then_some(EmptyInterval)
+            .ok_or(EmptyIntervalTryFromEmptiableRelativeBoundPair)
+    }
+}
+
+/// Error that can occur when trying to convert [`EmptiableRelativeInterval`] into [`EmptyInterval`]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct EmptyIntervalTryFromEmptiableRelativeInterval;
+
+impl Display for EmptyIntervalTryFromEmptiableRelativeInterval {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "An error occurred when trying to convert `EmptiableRelativeInterval` into `EmptyInterval`"
+        )
+    }
+}
+
+impl Error for EmptyIntervalTryFromEmptiableRelativeInterval {}
+
+impl TryFrom<EmptiableRelativeInterval> for EmptyInterval {
+    type Error = EmptyIntervalTryFromEmptiableRelativeInterval;
+
+    fn try_from(value: EmptiableRelativeInterval) -> Result<Self, Self::Error> {
+        value
+            .is_empty()
+            .then_some(EmptyInterval)
+            .ok_or(EmptyIntervalTryFromEmptiableRelativeInterval)
+    }
+}

--- a/src/intervals/special.rs
+++ b/src/intervals/special.rs
@@ -54,13 +54,53 @@ use crate::intervals::meta::{Epsilon, Interval};
 pub struct UnboundedInterval;
 
 impl UnboundedInterval {
-    // /// Converts [`UnboundedInterval`] into an [`AbsoluteBoundPair`]
-    // #[must_use]
-    // pub fn to_abs_bound_pair(self) -> AbsoluteBoundPair {
-    //     AbsoluteBoundPair::from(self)
-    // }
+    /// Converts `self` into an [`AbsoluteBoundPair`]
+    #[must_use]
+    pub fn to_abs_bound_pair(self) -> AbsoluteBoundPair {
+        AbsoluteBoundPair::from(self)
+    }
 
-    // pub fn to_abs_interval(self) -> AbsoluteInterval {}
+    /// Converts `self` into an [`EmptiableAbsoluteBoundPair`]
+    #[must_use]
+    pub fn to_emptiable_abs_bound_pair(self) -> EmptiableAbsoluteBoundPair {
+        EmptiableAbsoluteBoundPair::from(self)
+    }
+
+    /// Converts `self` into an [`AbsoluteInterval`]
+    #[must_use]
+    pub fn to_abs_interval(self) -> AbsoluteInterval {
+        AbsoluteInterval::from(self)
+    }
+
+    /// Converts `self` into an [`EmptiableAbsoluteInterval`]
+    #[must_use]
+    pub fn to_emptiable_abs_interval(self) -> EmptiableAbsoluteInterval {
+        EmptiableAbsoluteInterval::from(self)
+    }
+
+    /// Converts `self` into an [`RelativeBoundPair`]
+    #[must_use]
+    pub fn to_rel_bound_pair(self) -> RelativeBoundPair {
+        RelativeBoundPair::from(self)
+    }
+
+    /// Converts `self` into an [`EmptiableRelativeBoundPair`]
+    #[must_use]
+    pub fn to_emptiable_rel_bound_pair(self) -> EmptiableRelativeBoundPair {
+        EmptiableRelativeBoundPair::from(self)
+    }
+
+    /// Converts `self` into an [`RelativeInterval`]
+    #[must_use]
+    pub fn to_rel_interval(self) -> RelativeInterval {
+        RelativeInterval::from(self)
+    }
+
+    /// Converts `self` into an [`EmptiableRelativeInterval`]
+    #[must_use]
+    pub fn to_emptiable_rel_interval(self) -> EmptiableRelativeInterval {
+        EmptiableRelativeInterval::from(self)
+    }
 }
 
 impl Interval for UnboundedInterval {}

--- a/src/intervals/special.rs
+++ b/src/intervals/special.rs
@@ -19,20 +19,22 @@ use super::absolute::{
     AbsoluteInterval,
     AbsoluteStartBound,
     EmptiableAbsoluteBoundPair,
+    EmptiableAbsoluteInterval,
     HasAbsoluteBoundPair,
     HasEmptiableAbsoluteBoundPair,
 };
 use super::meta::{
     Duration as IntervalDuration,
-    IsEmpty,
     HasDuration,
     HasOpenness,
     HasRelativity,
+    IsEmpty,
     Openness,
     Relativity,
 };
 use super::relative::{
     EmptiableRelativeBoundPair,
+    EmptiableRelativeInterval,
     HasEmptiableRelativeBoundPair,
     HasRelativeBoundPair,
     RelativeBoundPair,
@@ -50,6 +52,16 @@ use crate::intervals::meta::{Epsilon, Interval};
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct UnboundedInterval;
+
+impl UnboundedInterval {
+    // /// Converts [`UnboundedInterval`] into an [`AbsoluteBoundPair`]
+    // #[must_use]
+    // pub fn to_abs_bound_pair(self) -> AbsoluteBoundPair {
+    //     AbsoluteBoundPair::from(self)
+    // }
+
+    // pub fn to_abs_interval(self) -> AbsoluteInterval {}
+}
 
 impl Interval for UnboundedInterval {}
 
@@ -105,42 +117,213 @@ impl From<RangeFull> for UnboundedInterval {
     }
 }
 
-/// Error that can occur when trying to convert an [`AbsoluteInterval`] or
-/// [`RelativeInterval`] into an [`UnboundedInterval`]
+/// Error that can occur when trying to convert [`AbsoluteBoundPair`] into [`UnboundedInterval`]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum UnboundedIntervalConversionErr {
-    WrongVariant,
+pub struct UnboundedIntervalTryFromAbsoluteBoundPairError;
+
+impl Display for UnboundedIntervalTryFromAbsoluteBoundPairError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "An error occurred when trying to convert `AbsoluteBoundPair` into `UnboundedInterval`"
+        )
+    }
 }
 
-impl Display for UnboundedIntervalConversionErr {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::WrongVariant => write!(f, "Wrong variant"),
+impl Error for UnboundedIntervalTryFromAbsoluteBoundPairError {}
+
+impl TryFrom<AbsoluteBoundPair> for UnboundedInterval {
+    type Error = UnboundedIntervalTryFromAbsoluteBoundPairError;
+
+    fn try_from(value: AbsoluteBoundPair) -> Result<Self, Self::Error> {
+        match (value.start(), value.end()) {
+            (AbsoluteStartBound::InfinitePast, AbsoluteEndBound::InfiniteFuture) => Ok(UnboundedInterval),
+            _ => Err(UnboundedIntervalTryFromAbsoluteBoundPairError),
         }
     }
 }
 
-impl Error for UnboundedIntervalConversionErr {}
+/// Error that can occur when trying to convert [`RelativeBoundPair`] into [`UnboundedInterval`]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct UnboundedIntervalTryFromRelativeBoundPairError;
+
+impl Display for UnboundedIntervalTryFromRelativeBoundPairError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "An error occurred when trying to convert `RelativeBoundPair` into `UnboundedInterval`"
+        )
+    }
+}
+
+impl Error for UnboundedIntervalTryFromRelativeBoundPairError {}
+
+impl TryFrom<RelativeBoundPair> for UnboundedInterval {
+    type Error = UnboundedIntervalTryFromRelativeBoundPairError;
+
+    fn try_from(value: RelativeBoundPair) -> Result<Self, Self::Error> {
+        match (value.start(), value.end()) {
+            (RelativeStartBound::InfinitePast, RelativeEndBound::InfiniteFuture) => Ok(UnboundedInterval),
+            _ => Err(UnboundedIntervalTryFromRelativeBoundPairError),
+        }
+    }
+}
+
+/// Error that can occur when trying to convert [`EmptiableAbsoluteBoundPair`] into [`UnboundedInterval`]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct UnboundedIntervalTryFromEmptiableAbsoluteBoundPairError;
+
+impl Display for UnboundedIntervalTryFromEmptiableAbsoluteBoundPairError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "An error occurred when trying to convert `EmptiableAbsoluteBoundPair` into `UnboundedInterval`"
+        )
+    }
+}
+
+impl Error for UnboundedIntervalTryFromEmptiableAbsoluteBoundPairError {}
+
+impl TryFrom<EmptiableAbsoluteBoundPair> for UnboundedInterval {
+    type Error = UnboundedIntervalTryFromEmptiableAbsoluteBoundPairError;
+
+    fn try_from(value: EmptiableAbsoluteBoundPair) -> Result<Self, Self::Error> {
+        Self::try_from(
+            value
+                .bound()
+                .ok_or(UnboundedIntervalTryFromEmptiableAbsoluteBoundPairError)?,
+        )
+        .or(Err(UnboundedIntervalTryFromEmptiableAbsoluteBoundPairError))
+    }
+}
+
+/// Error that can occur when trying to convert [`EmptiableRelativeBoundPair`] into [`UnboundedInterval`]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct UnboundedIntervalTryFromEmptiableRelativeBoundPairError;
+
+impl Display for UnboundedIntervalTryFromEmptiableRelativeBoundPairError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "An error occurred when trying to convert `EmptiableRelativeBoundPair` into `UnboundedInterval`"
+        )
+    }
+}
+
+impl Error for UnboundedIntervalTryFromEmptiableRelativeBoundPairError {}
+
+impl TryFrom<EmptiableRelativeBoundPair> for UnboundedInterval {
+    type Error = UnboundedIntervalTryFromEmptiableRelativeBoundPairError;
+
+    fn try_from(value: EmptiableRelativeBoundPair) -> Result<Self, Self::Error> {
+        Self::try_from(
+            value
+                .bound()
+                .ok_or(UnboundedIntervalTryFromEmptiableRelativeBoundPairError)?,
+        )
+        .or(Err(UnboundedIntervalTryFromEmptiableRelativeBoundPairError))
+    }
+}
+
+/// Error that can occur when trying to convert [`AbsoluteInterval`] into [`UnboundedInterval`]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct UnboundedIntervalTryFromAbsoluteIntervalError;
+
+impl Display for UnboundedIntervalTryFromAbsoluteIntervalError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "An error occurred when trying to convert `AbsoluteInterval` into `UnboundedInterval`"
+        )
+    }
+}
+
+impl Error for UnboundedIntervalTryFromAbsoluteIntervalError {}
 
 impl TryFrom<AbsoluteInterval> for UnboundedInterval {
-    type Error = UnboundedIntervalConversionErr;
+    type Error = UnboundedIntervalTryFromAbsoluteIntervalError;
 
     fn try_from(value: AbsoluteInterval) -> Result<Self, Self::Error> {
-        match value {
-            AbsoluteInterval::Unbounded(interval) => Ok(interval),
-            _ => Err(Self::Error::WrongVariant),
-        }
+        value.unbounded().ok_or(UnboundedIntervalTryFromAbsoluteIntervalError)
     }
 }
 
+/// Error that can occur when trying to convert [`RelativeInterval`] into [`UnboundedInterval`]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct UnboundedIntervalTryFromRelativeIntervalError;
+
+impl Display for UnboundedIntervalTryFromRelativeIntervalError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "An error occurred when trying to convert `RelativeInterval` into `UnboundedInterval`"
+        )
+    }
+}
+
+impl Error for UnboundedIntervalTryFromRelativeIntervalError {}
+
 impl TryFrom<RelativeInterval> for UnboundedInterval {
-    type Error = UnboundedIntervalConversionErr;
+    type Error = UnboundedIntervalTryFromRelativeIntervalError;
 
     fn try_from(value: RelativeInterval) -> Result<Self, Self::Error> {
-        match value {
-            RelativeInterval::Unbounded(interval) => Ok(interval),
-            _ => Err(Self::Error::WrongVariant),
-        }
+        value.unbounded().ok_or(UnboundedIntervalTryFromRelativeIntervalError)
+    }
+}
+
+/// Error that can occur when trying to convert [`EmptiableAbsoluteInterval`] into [`UnboundedInterval`]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct UnboundedIntervalTryFromEmptiableAbsoluteIntervalError;
+
+impl Display for UnboundedIntervalTryFromEmptiableAbsoluteIntervalError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "An error occurred when trying to convert `EmptiableAbsoluteInterval` into `UnboundedInterval`"
+        )
+    }
+}
+
+impl Error for UnboundedIntervalTryFromEmptiableAbsoluteIntervalError {}
+
+impl TryFrom<EmptiableAbsoluteInterval> for UnboundedInterval {
+    type Error = UnboundedIntervalTryFromEmptiableAbsoluteIntervalError;
+
+    fn try_from(value: EmptiableAbsoluteInterval) -> Result<Self, Self::Error> {
+        Self::try_from(
+            value
+                .bound()
+                .ok_or(UnboundedIntervalTryFromEmptiableAbsoluteIntervalError)?,
+        )
+        .or(Err(UnboundedIntervalTryFromEmptiableAbsoluteIntervalError))
+    }
+}
+
+/// Error that can occur when trying to convert [`EmptiableRelativeInterval`] into [`UnboundedInterval`]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct UnboundedIntervalTryFromEmptiableRelativeIntervalError;
+
+impl Display for UnboundedIntervalTryFromEmptiableRelativeIntervalError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "An error occurred when trying to convert `EmptiableRelativeInterval` into `UnboundedInterval`"
+        )
+    }
+}
+
+impl Error for UnboundedIntervalTryFromEmptiableRelativeIntervalError {}
+
+impl TryFrom<EmptiableRelativeInterval> for UnboundedInterval {
+    type Error = UnboundedIntervalTryFromEmptiableRelativeIntervalError;
+
+    fn try_from(value: EmptiableRelativeInterval) -> Result<Self, Self::Error> {
+        Self::try_from(
+            value
+                .bound()
+                .ok_or(UnboundedIntervalTryFromEmptiableRelativeIntervalError)?,
+        )
+        .or(Err(UnboundedIntervalTryFromEmptiableRelativeIntervalError))
     }
 }
 

--- a/src/intervals/special.rs
+++ b/src/intervals/special.rs
@@ -24,7 +24,7 @@ use super::absolute::{
 };
 use super::meta::{
     Duration as IntervalDuration,
-    Emptiable,
+    IsEmpty,
     HasDuration,
     HasOpenness,
     HasRelativity,
@@ -211,7 +211,7 @@ impl HasEmptiableRelativeBoundPair for EmptyInterval {
     }
 }
 
-impl Emptiable for EmptyInterval {
+impl IsEmpty for EmptyInterval {
     fn is_empty(&self) -> bool {
         true
     }

--- a/src/intervals/special_tests.rs
+++ b/src/intervals/special_tests.rs
@@ -16,7 +16,7 @@ use crate::intervals::absolute::{
 };
 use crate::intervals::meta::{
     Duration as IntervalDuration,
-    Emptiable,
+    IsEmpty,
     Epsilon,
     HasDuration,
     HasOpenness,

--- a/src/intervals/special_tests.rs
+++ b/src/intervals/special_tests.rs
@@ -16,11 +16,11 @@ use crate::intervals::absolute::{
 };
 use crate::intervals::meta::{
     Duration as IntervalDuration,
-    IsEmpty,
     Epsilon,
     HasDuration,
     HasOpenness,
     HasRelativity,
+    IsEmpty,
     Openness,
     Relativity,
 };
@@ -101,7 +101,7 @@ fn unbounded_interval_try_from_abs_interval_wrong_variant() -> Result<(), Box<dy
             "2025-01-01 00:00:00Z".parse::<Timestamp>()?,
             "2025-01-02 00:00:00Z".parse::<Timestamp>()?,
         ))),
-        Err(UnboundedIntervalConversionErr::WrongVariant),
+        Err(UnboundedIntervalTryFromAbsoluteIntervalError),
     );
     Ok(())
 }
@@ -121,7 +121,7 @@ fn unbounded_interval_try_from_rel_interval_wrong_variant() {
             SignedDuration::from_hours(1),
             SignedDuration::from_hours(5),
         ))),
-        Err(UnboundedIntervalConversionErr::WrongVariant),
+        Err(UnboundedIntervalTryFromRelativeIntervalError),
     );
 }
 

--- a/src/iter/intervals/remove_empty.rs
+++ b/src/iter/intervals/remove_empty.rs
@@ -1,6 +1,6 @@
 //! Iterator to remove empty intervals
 //!
-//! This iterator uses the [`Emptiable`] trait to determine what is considered
+//! This iterator uses the [`IsEmpty`] trait to determine what is considered
 //! an empty interval.
 //!
 //! # Examples
@@ -85,7 +85,7 @@ where
 {
     /// Filters out empty intervals from the collection
     ///
-    /// Uses the trait [`Emptiable`] under the hood.
+    /// Uses the trait [`IsEmpty`] under the hood.
     ///
     /// # Examples
     ///
@@ -172,7 +172,7 @@ where
 
 /// Empty interval removal iterator
 ///
-/// Uses the trait [`Emptiable`] in order to determine what is an empty
+/// Uses the trait [`IsEmpty`] in order to determine what is an empty
 /// interval.
 #[derive(Debug, Clone, Hash)]
 pub struct RemoveEmptyIntervals<I> {

--- a/src/iter/intervals/remove_empty.rs
+++ b/src/iter/intervals/remove_empty.rs
@@ -75,13 +75,13 @@
 //! # Ok::<(), Box<dyn Error>>(())
 //! ```
 
-use crate::intervals::meta::Emptiable;
+use crate::intervals::meta::IsEmpty;
 
 /// Dispatcher trait for empty interval removal iterator
 pub trait RemoveEmptyIntervalsIteratorDispatcher
 where
     Self: IntoIterator + Sized,
-    Self::Item: Emptiable,
+    Self::Item: IsEmpty,
 {
     /// Filters out empty intervals from the collection
     ///
@@ -166,7 +166,7 @@ where
 impl<I> RemoveEmptyIntervalsIteratorDispatcher for I
 where
     I: IntoIterator + Sized,
-    I::Item: Emptiable,
+    I::Item: IsEmpty,
 {
 }
 
@@ -182,7 +182,7 @@ pub struct RemoveEmptyIntervals<I> {
 impl<I> RemoveEmptyIntervals<I>
 where
     I: Iterator,
-    I::Item: Emptiable,
+    I::Item: IsEmpty,
 {
     /// Creates a new [`RemoveEmptyIntervals`]
     #[must_use]
@@ -196,7 +196,7 @@ where
 impl<I> Iterator for RemoveEmptyIntervals<I>
 where
     I: Iterator,
-    I::Item: Emptiable,
+    I::Item: IsEmpty,
 {
     type Item = I::Item;
 
@@ -218,7 +218,7 @@ where
 impl<I> DoubleEndedIterator for RemoveEmptyIntervals<I>
 where
     I: DoubleEndedIterator,
-    I::Item: Emptiable,
+    I::Item: IsEmpty,
 {
     fn next_back(&mut self) -> Option<Self::Item> {
         loop {

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -47,9 +47,9 @@ impl PrecisionMode {
     ///
     /// # Errors
     ///
-    /// Returns [`PrecisionIsZero`](PrecisionCreationError::PrecisionIsZero) if
+    /// Returns [`PrecisionCreationPrecisionIsZeroError`] if
     /// the given precision is zero.
-    pub fn with_precision(self, precision: StdDuration) -> Result<Precision, PrecisionCreationError> {
+    pub fn with_precision(self, precision: StdDuration) -> Result<Precision, PrecisionCreationPrecisionIsZeroError> {
         Precision::new(precision, self)
     }
 }
@@ -171,11 +171,11 @@ impl Precision {
     ///
     /// # Errors
     ///
-    /// Returns [`PrecisionIsZero`](PrecisionCreationError::PrecisionIsZero) if
+    /// Returns [`PrecisionCreationPrecisionIsZeroError`] if
     /// the given precision is zero.
-    pub fn new(precision: StdDuration, mode: PrecisionMode) -> Result<Self, PrecisionCreationError> {
+    pub fn new(precision: StdDuration, mode: PrecisionMode) -> Result<Self, PrecisionCreationPrecisionIsZeroError> {
         if precision.is_zero() {
-            return Err(PrecisionCreationError::PrecisionIsZero);
+            return Err(PrecisionCreationPrecisionIsZeroError);
         }
 
         Ok(Self::unchecked_new(precision, mode))
@@ -280,7 +280,7 @@ impl Precision {
     ///
     /// # Errors
     ///
-    /// Returns [`OutOfRangeDate`](PrecisionError::OutOfRangeDate) if the
+    /// Returns [`PrecisionOutOfRangeDateError`] if the
     /// computed new duration has an amount of seconds superior to what
     /// [`u64`] can store.
     ///
@@ -303,14 +303,14 @@ impl Precision {
     /// );
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
-    pub fn precise_duration(&self, duration: StdDuration) -> Result<StdDuration, PrecisionError> {
+    pub fn precise_duration(&self, duration: StdDuration) -> Result<StdDuration, PrecisionOutOfRangeDateError> {
         let new_timestamp = self.precise_unsigned_nanos(duration.as_nanos());
 
         // Polyfill for StdDuration::from_nanos_u128() to avoid bumping MSRV
         // & StdDuration::try_from_nanos_u128() doesn't yet exist
         let nanos_per_sec = StdDuration::from_secs(1).as_nanos();
-        let secs_component = u64::try_from(new_timestamp / nanos_per_sec).or(Err(PrecisionError::OutOfRangeDate))?;
-        let nanos_component = u32::try_from(new_timestamp % nanos_per_sec).or(Err(PrecisionError::OutOfRangeDate))?;
+        let secs_component = u64::try_from(new_timestamp / nanos_per_sec).or(Err(PrecisionOutOfRangeDateError))?;
+        let nanos_component = u32::try_from(new_timestamp % nanos_per_sec).or(Err(PrecisionOutOfRangeDateError))?;
 
         Ok(StdDuration::new(secs_component, nanos_component))
     }
@@ -322,7 +322,7 @@ impl Precision {
     ///
     /// # Errors
     ///
-    /// Returns [`OutOfRangeDate`](PrecisionError::OutOfRangeDate) if the
+    /// Returns [`PrecisionOutOfRangeDateError`] if the
     /// computed new duration exceeded what [`i128`] can store.
     ///
     /// # Panics
@@ -345,7 +345,10 @@ impl Precision {
     /// );
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
-    pub fn precise_signed_duration(&self, signed_duration: SignedDuration) -> Result<SignedDuration, PrecisionError> {
+    pub fn precise_signed_duration(
+        &self,
+        signed_duration: SignedDuration,
+    ) -> Result<SignedDuration, PrecisionOutOfRangeDateError> {
         Ok(SignedDuration::from_nanos_i128(
             self.precise_signed_nanos(signed_duration.as_nanos()),
         ))
@@ -382,7 +385,7 @@ impl Precision {
     ///
     /// # Errors
     ///
-    /// Returns [`OutOfRangeDate`](PrecisionError::OutOfRangeDate) if the
+    /// Returns [`PrecisionOutOfRangeDateError`] if the
     /// transfer to UTC would represent a timestamp too small to be stored
     /// correctly or if the resulting time would result in a time that
     /// cannot be stored in [`Zoned`].
@@ -454,21 +457,21 @@ impl Precision {
     /// ```
     ///
     /// [1]: https://en.wikipedia.org/w/index.php?title=Unix_time&useskin=vector
-    pub fn precise_time(&self, time: &Zoned) -> Result<AmbiguousZoned, PrecisionError> {
+    pub fn precise_time(&self, time: &Zoned) -> Result<AmbiguousZoned, PrecisionOutOfRangeDateError> {
         let utc_day_start = time
             .datetime()
             .start_of_day()
             .to_zoned(TimeZone::UTC)
-            .or(Err(PrecisionError::OutOfRangeDate))?;
+            .or(Err(PrecisionOutOfRangeDateError))?;
         let duration_diff = time
             .datetime()
             .to_zoned(TimeZone::UTC)
-            .or(Err(PrecisionError::OutOfRangeDate))?
+            .or(Err(PrecisionOutOfRangeDateError))?
             .timestamp()
             .duration_since(utc_day_start.timestamp());
         let precised_datetime = utc_day_start
             .checked_add(self.precise_signed_duration(duration_diff)?)
-            .or(Err(PrecisionError::OutOfRangeDate))?
+            .or(Err(PrecisionOutOfRangeDateError))?
             .datetime();
 
         Ok(time.time_zone().to_ambiguous_zoned(precised_datetime))
@@ -492,7 +495,7 @@ impl Precision {
     ///
     /// # Errors
     ///
-    /// Returns [`OutOfRangeDate`](PrecisionError::OutOfRangeDate) if the
+    /// Returns [`PrecisionOutOfRangeDateError`] if the
     /// resulting time would result in a time that cannot be stored in
     /// [`Zoned`].
     ///
@@ -540,50 +543,40 @@ impl Precision {
     /// ```
     ///
     /// [1]: https://en.wikipedia.org/w/index.php?title=Unix_time&useskin=vector
-    pub fn precise_time_with_base_time<B>(&self, time: &Zoned, base: B) -> Result<Zoned, PrecisionError>
+    pub fn precise_time_with_base_time<B>(&self, time: &Zoned, base: B) -> Result<Zoned, PrecisionOutOfRangeDateError>
     where
         B: Into<Timestamp>,
     {
         let base = base.into().to_zoned(time.time_zone().clone());
 
         base.checked_add(self.precise_signed_duration(time.duration_since(&base))?)
-            .map_err(|_| PrecisionError::OutOfRangeDate)
+            .map_err(|_| PrecisionOutOfRangeDateError)
     }
 }
 
-/// Errors that can be produced when creating a [`Precision`]
+/// Duration given as a precision was zero when creating a [`Precision`]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum PrecisionCreationError {
-    /// Duration given as a precision is zero
-    PrecisionIsZero,
-}
+pub struct PrecisionCreationPrecisionIsZeroError;
 
-impl Display for PrecisionCreationError {
+impl Display for PrecisionCreationPrecisionIsZeroError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::PrecisionIsZero => write!(f, "Duration given as a precision is zero"),
-        }
+        write!(f, "Duration given as a precision is zero")
     }
 }
 
-impl Error for PrecisionCreationError {}
+impl Error for PrecisionCreationPrecisionIsZeroError {}
 
-/// Errors that can be produced when using [`Precision`]
+/// An operation produced an out-of-range date when using [`Precision`]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum PrecisionError {
-    /// An operation produced an out-of-range date
-    OutOfRangeDate,
-}
+pub struct PrecisionOutOfRangeDateError;
 
-impl Display for PrecisionError {
+impl Display for PrecisionOutOfRangeDateError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::OutOfRangeDate => write!(f, "Operation produced an out-of-range date"),
-        }
+        write!(f, "Operation produced an out-of-range date")
     }
 }
 
-impl Error for PrecisionError {}
+impl Error for PrecisionOutOfRangeDateError {}
 
 /// Represents a running result
 ///

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -14,7 +14,7 @@ pub use crate::intervals::absolute::{
     HasAbsoluteBoundPair,
     HasEmptiableAbsoluteBoundPair,
 };
-pub use crate::intervals::meta::{IsEmpty, HasBoundInclusivity, HasDuration, HasOpenness, HasRelativity};
+pub use crate::intervals::meta::{HasBoundInclusivity, HasDuration, HasOpenness, HasRelativity, IsEmpty};
 pub use crate::intervals::ops::abridge::Abridgable;
 pub use crate::intervals::ops::bound_containment::CanPositionBoundContainment;
 pub use crate::intervals::ops::bound_ord::PartialBoundOrd;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -14,7 +14,7 @@ pub use crate::intervals::absolute::{
     HasAbsoluteBoundPair,
     HasEmptiableAbsoluteBoundPair,
 };
-pub use crate::intervals::meta::{Emptiable, HasBoundInclusivity, HasDuration, HasOpenness, HasRelativity};
+pub use crate::intervals::meta::{IsEmpty, HasBoundInclusivity, HasDuration, HasOpenness, HasRelativity};
 pub use crate::intervals::ops::abridge::Abridgable;
 pub use crate::intervals::ops::bound_containment::CanPositionBoundContainment;
 pub use crate::intervals::ops::bound_ord::PartialBoundOrd;


### PR DESCRIPTION
# Explanation

Implemented a ton of conversion methods for intervals and converted single-variant enum errors
to tag struct errors.

# Notes

Find way to handle multiple interval durations to handle correctly mathematical operations
(addition, subtraction, etc.)

Remove implementations of operations where it always returns an error

<details>
<summary><h1>Changelog</h1></summary>

## Added

- Added methods to retrieve individual variants of `AbsoluteInterval` (`bounded`, `half_bounded`, `unbounded`)
- Implemented `From<BoundedAbsoluteInterval>` on `AbsoluteBoundPair`
- Implemented `From<HalfBoundedAbsoluteInterval>` on `AbsoluteBoundPair`
- Implemented `From<AbsoluteInterval>` on `AbsoluteBoundPair`
- Implemented `From<UnboundedInterval>` on `AbsoluteBoundPair`
- Implemented `From<BoundedAbsoluteInterval>` on `EmptiableAbsoluteBoundPair`
- Implemented `From<HalfBoundedAbsoluteInterval>` on `EmptiableAbsoluteBoundPair`
- Implemented `From<AbsoluteInterval>` on `EmptiableAbsoluteBoundPair`
- Implemented `From<EmptiableAbsoluteInterval>` on `EmptiableAbsoluteBoundPair`
- Implemented `From<UnboundedInterval>` on `EmptiableAbsoluteBoundPair`
- Implemented `From<EmptyInterval>` on `EmptiableAbsoluteBoundPair`
- Implemented `TryFrom<AbsoluteBound>` on `AbsoluteStartBound`
- Implemented `TryFrom<AbsoluteBound>` on `AbsoluteEndBound`
- Implemented `TryFrom<EmptiableAbsoluteBoundPair>` on `BoundedAbsoluteInterval`
- Implemented `TryFrom<EmptiableAbsoluteInterval>` on `BoundedAbsoluteInterval`
- Implemented `TryFrom<EmptiableAbsoluteInterval>` on `AbsoluteBoundPair`

- Added methods to retrieve individual variants of `RelativeInterval` (`bounded`, `half_bounded`, `unbounded`)
- Implemented `From<BoundedRelativeInterval>` on `RelativeBoundPair`
- Implemented `From<HalfBoundedRelativeInterval>` on `RelativeBoundPair`
- Implemented `From<RelativeInterval>` on `RelativeBoundPair`
- Implemented `From<UnboundedInterval>` on `RelativeBoundPair`
- Implemented `From<BoundedRelativeInterval>` on `EmptiableRelativeBoundPair`
- Implemented `From<HalfBoundedRelativeInterval>` on `EmptiableRelativeBoundPair`
- Implemented `From<RelativeInterval>` on `EmptiableRelativeBoundPair`
- Implemented `From<EmptiableRelativeInterval>` on `EmptiableRelativeBoundPair`
- Implemented `From<UnboundedInterval>` on `EmptiableRelativeBoundPair`
- Implemented `From<EmptyInterval>` on `EmptiableRelativeBoundPair`
- Implemented `TryFrom<RelativeBound>` on `RelativeStartBound`
- Implemented `TryFrom<RelativeBound>` on `RelativeEndBound`
- Implemented `TryFrom<EmptiableRelativeBoundPair>` on `BoundedRelativeInterval`
- Implemented `TryFrom<EmptiableRelativeInterval>` on `BoundedRelativeInterval`
- Implemented `TryFrom<EmptiableRelativeInterval>` on `RelativeBoundPair`

- Added methods to convert `UnboundedInterval` into either `AbsoluteBoundPair`, `EmptiableAbsoluteBoundPair`,
  `AbsoluteInterval`, `EmptiableAbsoluteInterval`
- Added methods to convert `UnboundedInterval` into either `RelativeBoundPair`, `EmptiableRelativeBoundPair`,
  `RelativeInterval`, `EmptiableRelativeInterval`
- Implemented `TryFrom<AbsoluteBoundPair>` on `UnboundedInterval`
- Implemented `TryFrom<EmptiableAbsoluteBoundPair>` on `UnboundedInterval`
- Implemented `TryFrom<AbsoluteInterval>` on `UnboundedInterval`
- Implemented `TryFrom<EmptiableAbsoluteInterval>` on `UnboundedInterval`
- Implemented `TryFrom<RelativeBoundPair>` on `UnboundedInterval`
- Implemented `TryFrom<EmptiableRelativeBoundPair>` on `UnboundedInterval`
- Implemented `TryFrom<RelativeInterval>` on `UnboundedInterval`
- Implemented `TryFrom<EmptiableRelativeInterval>` on `UnboundedInterval`

- Added methods to convert `EmptyInterval` into either `EmptiableAbsoluteBoundPair` or `EmptiableAbsoluteInterval`
- Added methods to convert `EmptyInterval` into either `EmptiableRelativeBoundPair` or `EmptiableRelativeInterval`
- Implemented `TryFrom<EmptiableAbsoluteBoundPair>` on `EmptyInterval`
- Implemented `TryFrom<EmptiableAbsoluteInterval>` on `EmptyInterval`
- Implemented `TryFrom<EmptiableRelativeBoundPair>` on `EmptyInterval`
- Implemented `TryFrom<EmptiableRelativeInterval>` on `EmptyInterval`

- Implemented `to_range_bound_with` on `BoundInclusivity`

## Changed

- `BoundedAbsoluteIntervalFromAbsoluteIntervalError` was converted from a single-variant enum to a tag struct
  and renamed to `BoundedAbsoluteIntervalTryFromAbsoluteIntervalError`
- `AbsoluteBoundPairFromEmptiableAbsoluteBoundPairError` was converted from a single-variant enum to a tag struct
  and renamed to `AbsoluteBoundPairTryFromEmptiableAbsoluteBoundPairError`
- `BoundedAbsoluteIntervalFromAbsoluteBoundPairError` was converted from a single-variant enum to a tag struct
  and renamed to `BoundedAbsoluteIntervalTryFromAbsoluteBoundPairError`
- `AbsoluteFiniteBoundFromBoundError` was converted from a single-variant enum to a tag struct
  and renamed to `AbsoluteFiniteBoundTryFromBoundError`
- `HalfBoundedAbsoluteIntervalFromAbsoluteBoundPairError` was converted from a single-variant enum to a tag struct
  and renamed to `HalfBoundedAbsoluteIntervalTryFromAbsoluteBoundPairError`
- `HalfBoundedAbsoluteIntervalFromAbsoluteIntervalError` was converted from a single-variant enum to a tag struct
  and renamed `HalfBoundedAbsoluteIntervalTryFromAbsoluteIntervalError`
- `TryFrom<AbsoluteInterval>` implementation on `BoundedAbsoluteInterval` was re-expressed using the new
  variant retrieval methods of `AbsoluteInterval`
- `BoundedAbsoluteInterval::to_emptiable` was renamed `to_emptiable_interval` for explicitness
- `HalfBoundedAbsoluteInterval::to_emptiable` was renamed `to_emptiable_interval` for explicitness

- `BoundedRelativeIntervalFromRelativeIntervalError` was converted from a single-variant enum to a tag struct
  and renamed to `BoundedRelativeIntervalTryFromRelativeIntervalError`
- `RelativeBoundPairFromEmptiableRelativeBoundPairError` was converted from a single-variant enum to a tag struct
  and renamed to `RelativeBoundPairTryFromEmptiableRelativeBoundPairError`
- `BoundedRelativeIntervalFromRelativeBoundPairError` was converted from a single-variant enum to a tag struct
  and renamed to `BoundedRelativeIntervalTryFromRelativeBoundPairError`
- `RelativeFiniteBoundFromBoundError` was converted from a single-variant enum to a tag struct
  and renamed to `RelativeFiniteBoundTryFromBoundError`
- `HalfBoundedRelativeIntervalFromRelativeBoundPairError` was converted from a single-variant enum to a tag struct
  and renamed to `HalfBoundedRelativeIntervalTryFromRelativeBoundPairError`
- `HalfBoundedRelativeIntervalFromRelativeIntervalError` was converted from a single-variant enum to a tag struct
  and renamed to `HalfBoundedRelativeIntervalTryFromRelativeIntervalError`
- `TryFrom<RelativeInterval>` implementation on `BoundedRelativeInterval` was re-expressed using the new
  variant retrieval methods of `RelativeInterval`
- `BoundedRelativeInterval::to_emptiable` was renamed `to_emptiable_interval` for explicitness
- `HalfBoundedRelativeInterval::to_emptiable` was renamed `to_emptiable_interval` for explicitness
- Renamed `Emptiable` trait to `IsEmpty` for explicitness

- `OverlapRemovalErr` was converted from a single-variant enum to a tag struct and renamed
  to `OverlapRemovalNoOverlapFoundError`
- `GapFillError` was converted from a single-variant enum to a tag struct and renamed
  to `GapFillOverlapFoundError`
- `PrecisionCreationError` was converted from a single-variant enum to a tag struct and renamed
  to `PrecisionCreationPrecisionIsZeroError`
- `PrecisionError` was converted from a single-variant enum to a tag struct
  and renamed to `PrecisionOutOfRangeDateError`
- `EpsilonInterpretationDurationError` was converted from a single-variant enum to a tag struct
  and renamed to `EpsilonInterpretationDurationOverflowError`

## Removed

- Removed `UnboundedIntervalConversionErr` to instead use specific conversion error types

</details>
