### PR TITLE
Improved: Removed usage of `Into<T>` bound for function arguments

### DIFF
--- a/branch-changelog.md
+++ b/branch-changelog.md
@@ -2,124 +2,26 @@
 
 # Explanation
 
-Implemented a ton of conversion methods for intervals and converted single-variant enum errors
-to tag struct errors.
+Link relevant issues and PRs here!
 
-# Notes
-
-Find way to handle multiple interval durations to handle correctly mathematical operations
-(addition, subtraction, etc.)
-
-Remove implementations of operations where it always returns an error
+Explain the motivation for this PR and what it does/solves
 
 <details>
 <summary><h1>Changelog</h1></summary>
 
 ## Added
 
-- Added methods to retrieve individual variants of `AbsoluteInterval` (`bounded`, `half_bounded`, `unbounded`)
-- Implemented `From<BoundedAbsoluteInterval>` on `AbsoluteBoundPair`
-- Implemented `From<HalfBoundedAbsoluteInterval>` on `AbsoluteBoundPair`
-- Implemented `From<AbsoluteInterval>` on `AbsoluteBoundPair`
-- Implemented `From<UnboundedInterval>` on `AbsoluteBoundPair`
-- Implemented `From<BoundedAbsoluteInterval>` on `EmptiableAbsoluteBoundPair`
-- Implemented `From<HalfBoundedAbsoluteInterval>` on `EmptiableAbsoluteBoundPair`
-- Implemented `From<AbsoluteInterval>` on `EmptiableAbsoluteBoundPair`
-- Implemented `From<EmptiableAbsoluteInterval>` on `EmptiableAbsoluteBoundPair`
-- Implemented `From<UnboundedInterval>` on `EmptiableAbsoluteBoundPair`
-- Implemented `From<EmptyInterval>` on `EmptiableAbsoluteBoundPair`
-- Implemented `TryFrom<AbsoluteBound>` on `AbsoluteStartBound`
-- Implemented `TryFrom<AbsoluteBound>` on `AbsoluteEndBound`
-- Implemented `TryFrom<EmptiableAbsoluteBoundPair>` on `BoundedAbsoluteInterval`
-- Implemented `TryFrom<EmptiableAbsoluteInterval>` on `BoundedAbsoluteInterval`
-- Implemented `TryFrom<EmptiableAbsoluteInterval>` on `AbsoluteBoundPair`
-
-- Added methods to retrieve individual variants of `RelativeInterval` (`bounded`, `half_bounded`, `unbounded`)
-- Implemented `From<BoundedRelativeInterval>` on `RelativeBoundPair`
-- Implemented `From<HalfBoundedRelativeInterval>` on `RelativeBoundPair`
-- Implemented `From<RelativeInterval>` on `RelativeBoundPair`
-- Implemented `From<UnboundedInterval>` on `RelativeBoundPair`
-- Implemented `From<BoundedRelativeInterval>` on `EmptiableRelativeBoundPair`
-- Implemented `From<HalfBoundedRelativeInterval>` on `EmptiableRelativeBoundPair`
-- Implemented `From<RelativeInterval>` on `EmptiableRelativeBoundPair`
-- Implemented `From<EmptiableRelativeInterval>` on `EmptiableRelativeBoundPair`
-- Implemented `From<UnboundedInterval>` on `EmptiableRelativeBoundPair`
-- Implemented `From<EmptyInterval>` on `EmptiableRelativeBoundPair`
-- Implemented `TryFrom<RelativeBound>` on `RelativeStartBound`
-- Implemented `TryFrom<RelativeBound>` on `RelativeEndBound`
-- Implemented `TryFrom<EmptiableRelativeBoundPair>` on `BoundedRelativeInterval`
-- Implemented `TryFrom<EmptiableRelativeInterval>` on `BoundedRelativeInterval`
-- Implemented `TryFrom<EmptiableRelativeInterval>` on `RelativeBoundPair`
-
-- Added methods to convert `UnboundedInterval` into either `AbsoluteBoundPair`, `EmptiableAbsoluteBoundPair`,
-  `AbsoluteInterval`, `EmptiableAbsoluteInterval`
-- Added methods to convert `UnboundedInterval` into either `RelativeBoundPair`, `EmptiableRelativeBoundPair`,
-  `RelativeInterval`, `EmptiableRelativeInterval`
-- Implemented `TryFrom<AbsoluteBoundPair>` on `UnboundedInterval`
-- Implemented `TryFrom<EmptiableAbsoluteBoundPair>` on `UnboundedInterval`
-- Implemented `TryFrom<AbsoluteInterval>` on `UnboundedInterval`
-- Implemented `TryFrom<EmptiableAbsoluteInterval>` on `UnboundedInterval`
-- Implemented `TryFrom<RelativeBoundPair>` on `UnboundedInterval`
-- Implemented `TryFrom<EmptiableRelativeBoundPair>` on `UnboundedInterval`
-- Implemented `TryFrom<RelativeInterval>` on `UnboundedInterval`
-- Implemented `TryFrom<EmptiableRelativeInterval>` on `UnboundedInterval`
-
-- Added methods to convert `EmptyInterval` into either `EmptiableAbsoluteBoundPair` or `EmptiableAbsoluteInterval`
-- Added methods to convert `EmptyInterval` into either `EmptiableRelativeBoundPair` or `EmptiableRelativeInterval`
-- Implemented `TryFrom<EmptiableAbsoluteBoundPair>` on `EmptyInterval`
-- Implemented `TryFrom<EmptiableAbsoluteInterval>` on `EmptyInterval`
-- Implemented `TryFrom<EmptiableRelativeBoundPair>` on `EmptyInterval`
-- Implemented `TryFrom<EmptiableRelativeInterval>` on `EmptyInterval`
-
-- Implemented `to_range_bound_with` on `BoundInclusivity`
+- Things you've added
 
 ## Changed
 
-- `BoundedAbsoluteIntervalFromAbsoluteIntervalError` was converted from a single-variant enum to a tag struct
-  and renamed to `BoundedAbsoluteIntervalTryFromAbsoluteIntervalError`
-- `AbsoluteBoundPairFromEmptiableAbsoluteBoundPairError` was converted from a single-variant enum to a tag struct
-  and renamed to `AbsoluteBoundPairTryFromEmptiableAbsoluteBoundPairError`
-- `BoundedAbsoluteIntervalFromAbsoluteBoundPairError` was converted from a single-variant enum to a tag struct
-  and renamed to `BoundedAbsoluteIntervalTryFromAbsoluteBoundPairError`
-- `AbsoluteFiniteBoundFromBoundError` was converted from a single-variant enum to a tag struct
-  and renamed to `AbsoluteFiniteBoundTryFromBoundError`
-- `HalfBoundedAbsoluteIntervalFromAbsoluteBoundPairError` was converted from a single-variant enum to a tag struct
-  and renamed to `HalfBoundedAbsoluteIntervalTryFromAbsoluteBoundPairError`
-- `HalfBoundedAbsoluteIntervalFromAbsoluteIntervalError` was converted from a single-variant enum to a tag struct
-  and renamed `HalfBoundedAbsoluteIntervalTryFromAbsoluteIntervalError`
-- `TryFrom<AbsoluteInterval>` implementation on `BoundedAbsoluteInterval` was re-expressed using the new
-  variant retrieval methods of `AbsoluteInterval`
-- `BoundedAbsoluteInterval::to_emptiable` was renamed `to_emptiable_interval` for explicitness
-- `HalfBoundedAbsoluteInterval::to_emptiable` was renamed `to_emptiable_interval` for explicitness
-
-- `BoundedRelativeIntervalFromRelativeIntervalError` was converted from a single-variant enum to a tag struct
-  and renamed to `BoundedRelativeIntervalTryFromRelativeIntervalError`
-- `RelativeBoundPairFromEmptiableRelativeBoundPairError` was converted from a single-variant enum to a tag struct
-  and renamed to `RelativeBoundPairTryFromEmptiableRelativeBoundPairError`
-- `BoundedRelativeIntervalFromRelativeBoundPairError` was converted from a single-variant enum to a tag struct
-  and renamed to `BoundedRelativeIntervalTryFromRelativeBoundPairError`
-- `RelativeFiniteBoundFromBoundError` was converted from a single-variant enum to a tag struct
-  and renamed to `RelativeFiniteBoundTryFromBoundError`
-- `HalfBoundedRelativeIntervalFromRelativeBoundPairError` was converted from a single-variant enum to a tag struct
-  and renamed to `HalfBoundedRelativeIntervalTryFromRelativeBoundPairError`
-- `HalfBoundedRelativeIntervalFromRelativeIntervalError` was converted from a single-variant enum to a tag struct
-  and renamed to `HalfBoundedRelativeIntervalTryFromRelativeIntervalError`
-- `TryFrom<RelativeInterval>` implementation on `BoundedRelativeInterval` was re-expressed using the new
-  variant retrieval methods of `RelativeInterval`
-- `BoundedRelativeInterval::to_emptiable` was renamed `to_emptiable_interval` for explicitness
-- `HalfBoundedRelativeInterval::to_emptiable` was renamed `to_emptiable_interval` for explicitness
-- Renamed `Emptiable` trait to `IsEmpty` for explicitness
-
-- `OverlapRemovalErr` was converted from a single-variant enum to a tag struct and renamed
-  to `OverlapRemovalNoOverlapFoundError`
-- `GapFillError` was converted from a single-variant enum to a tag struct and renamed
-  to `GapFillOverlapFoundError`
-- `PrecisionCreationError` was converted from a single-variant enum to a tag struct and renamed
-  to `PrecisionCreationPrecisionIsZeroError`
-- `PrecisionError` was converted from a single-variant enum to a tag struct
-  and renamed to `PrecisionOutOfRangeDateError`
-- `EpsilonInterpretationDurationError` was converted from a single-variant enum to a tag struct
-  and renamed to `EpsilonInterpretationDurationOverflowError`
+- Changed `precise_time_with_base_time` to have explicit type requirement instead of allowing `Into<T>`
+- Changed `Cuttable` impls to have an explicit type instead of allowing `Into<T>`
+- Changed `CanPositionPointContainment` impls to have an explicit type instead of allowing `Into<T>`
+- Changed `PreciseAbsoluteInterval::precise_interval_with_different_precisions_with_base_time`
+  to have explicit type requirement instead of allowing `Into<T>`
+- Changed `ToAbsolute::to_absolute` to have an explicit type instead of allowing `Into<T>`
+- Changed `ToRelative::to_relative` to have an explicit type instead of allowing `Into<T>`
 
 ## Deprecated
 
@@ -127,6 +29,14 @@ Remove implementations of operations where it always returns an error
 
 ## Removed
 
-- Removed `UnboundedIntervalConversionErr` to instead use specific conversion error types
+- Things you've removed
+
+## Fixed
+
+- Things you've fixed
+
+## Security
+
+- Vulnerabilities you've fixed (add relevant CVE and any other relevant info/links)
 
 </details>

--- a/src/intervals/ops/cut.rs
+++ b/src/intervals/ops/cut.rs
@@ -40,7 +40,9 @@
 //! );
 //!
 //! let cut_type = CutType::new(BoundInclusivity::Exclusive, BoundInclusivity::Exclusive);
-//! let at = "2025-01-01 12:00:00[Europe/Oslo]".parse::<Zoned>()?;
+//! let at = "2025-01-01 12:00:00[Europe/Oslo]"
+//!     .parse::<Zoned>()?
+//!     .timestamp();
 //!
 //! assert_eq!(
 //!     interval.cut_at(at, cut_type),
@@ -104,7 +106,9 @@
 //! );
 //!
 //! let cut_type = CutType::new(BoundInclusivity::Exclusive, BoundInclusivity::Inclusive);
-//! let at = "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?;
+//! let at = "2025-01-01 16:00:00[Europe/Oslo]"
+//!     .parse::<Zoned>()?
+//!     .timestamp();
 //!
 //! assert_eq!(
 //!     interval.cut_at(at, cut_type),
@@ -167,9 +171,11 @@
 //! );
 //!
 //! let cut_type = CutType::new(BoundInclusivity::Exclusive, BoundInclusivity::Exclusive);
-//! let at = "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?;
+//! let at = "2025-01-01 16:00:00[Europe/Oslo]"
+//!     .parse::<Zoned>()?
+//!     .timestamp();
 //!
-//! assert_eq!(interval.cut_at(at, cut_type), CutResult::Uncut,);
+//! assert_eq!(interval.cut_at(at, cut_type), CutResult::Uncut);
 //! # Ok::<(), Box<dyn Error>>(())
 //! ```
 
@@ -439,7 +445,9 @@ impl<T> CutResult<T> {
 /// );
 ///
 /// let cut_type = CutType::new(BoundInclusivity::Exclusive, BoundInclusivity::Exclusive);
-/// let at = "2025-01-01 12:00:00[Europe/Oslo]".parse::<Zoned>()?;
+/// let at = "2025-01-01 12:00:00[Europe/Oslo]"
+///     .parse::<Zoned>()?
+///     .timestamp();
 ///
 /// assert_eq!(
 ///     interval.cut_at(at, cut_type),
@@ -503,7 +511,9 @@ impl<T> CutResult<T> {
 /// );
 ///
 /// let cut_type = CutType::new(BoundInclusivity::Exclusive, BoundInclusivity::Inclusive);
-/// let at = "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?;
+/// let at = "2025-01-01 16:00:00[Europe/Oslo]"
+///     .parse::<Zoned>()?
+///     .timestamp();
 ///
 /// assert_eq!(
 ///     interval.cut_at(at, cut_type),
@@ -566,7 +576,9 @@ impl<T> CutResult<T> {
 /// );
 ///
 /// let cut_type = CutType::new(BoundInclusivity::Exclusive, BoundInclusivity::Exclusive);
-/// let at = "2025-01-01 16:00:00[Europe/Oslo]".parse::<Zoned>()?;
+/// let at = "2025-01-01 16:00:00[Europe/Oslo]"
+///     .parse::<Zoned>()?
+///     .timestamp();
 ///
 /// assert_eq!(interval.cut_at(at, cut_type), CutResult::Uncut,);
 /// # Ok::<(), Box<dyn Error>>(())
@@ -601,7 +613,9 @@ pub trait Cuttable<P> {
     /// );
     ///
     /// let cut_type = CutType::new(BoundInclusivity::Exclusive, BoundInclusivity::Exclusive);
-    /// let at = "2025-01-01 12:00:00[Europe/Oslo]".parse::<Zoned>()?;
+    /// let at = "2025-01-01 12:00:00[Europe/Oslo]"
+    ///     .parse::<Zoned>()?
+    ///     .timestamp();
     ///
     /// assert_eq!(
     ///     interval.cut_at(at, cut_type),
@@ -643,140 +657,104 @@ pub trait Cuttable<P> {
     fn cut_at(&self, position: P, cut_type: CutType) -> CutResult<Self::Output>;
 }
 
-impl<P> Cuttable<P> for AbsoluteBoundPair
-where
-    P: Into<Timestamp>,
-{
+impl Cuttable<Timestamp> for AbsoluteBoundPair {
     type Output = Self;
 
-    fn cut_at(&self, position: P, cut_type: CutType) -> CutResult<Self::Output> {
-        cut_abs_bound_pair(self, position.into(), cut_type)
+    fn cut_at(&self, position: Timestamp, cut_type: CutType) -> CutResult<Self::Output> {
+        cut_abs_bound_pair(self, position, cut_type)
     }
 }
 
-impl<P> Cuttable<P> for EmptiableAbsoluteBoundPair
-where
-    P: Into<Timestamp>,
-{
+impl Cuttable<Timestamp> for EmptiableAbsoluteBoundPair {
     type Output = Self;
 
-    fn cut_at(&self, position: P, cut_type: CutType) -> CutResult<Self::Output> {
-        cut_emptiable_abs_bound_pair(self, position.into(), cut_type)
+    fn cut_at(&self, position: Timestamp, cut_type: CutType) -> CutResult<Self::Output> {
+        cut_emptiable_abs_bound_pair(self, position, cut_type)
     }
 }
 
-impl<P> Cuttable<P> for AbsoluteInterval
-where
-    P: Into<Timestamp>,
-{
+impl Cuttable<Timestamp> for AbsoluteInterval {
     type Output = Self;
 
-    fn cut_at(&self, position: P, cut_type: CutType) -> CutResult<Self::Output> {
-        cut_abs_bound_pair(&self.abs_bound_pair(), position.into(), cut_type)
+    fn cut_at(&self, position: Timestamp, cut_type: CutType) -> CutResult<Self::Output> {
+        cut_abs_bound_pair(&self.abs_bound_pair(), position, cut_type)
             .map_cut(|c1, c2| (AbsoluteInterval::from(c1), AbsoluteInterval::from(c2)))
     }
 }
 
-impl<P> Cuttable<P> for EmptiableAbsoluteInterval
-where
-    P: Into<Timestamp>,
-{
+impl Cuttable<Timestamp> for EmptiableAbsoluteInterval {
     type Output = Self;
 
-    fn cut_at(&self, position: P, cut_type: CutType) -> CutResult<Self::Output> {
-        cut_emptiable_abs_bound_pair(&self.emptiable_abs_bound_pair(), position.into(), cut_type)
+    fn cut_at(&self, position: Timestamp, cut_type: CutType) -> CutResult<Self::Output> {
+        cut_emptiable_abs_bound_pair(&self.emptiable_abs_bound_pair(), position, cut_type)
             .map_cut(|c1, c2| (EmptiableAbsoluteInterval::from(c1), EmptiableAbsoluteInterval::from(c2)))
     }
 }
 
-impl<P> Cuttable<P> for BoundedAbsoluteInterval
-where
-    P: Into<Timestamp>,
-{
+impl Cuttable<Timestamp> for BoundedAbsoluteInterval {
     type Output = Self;
 
-    fn cut_at(&self, position: P, cut_type: CutType) -> CutResult<Self::Output> {
-        cut_bounded_abs_interval(self, position.into(), cut_type)
+    fn cut_at(&self, position: Timestamp, cut_type: CutType) -> CutResult<Self::Output> {
+        cut_bounded_abs_interval(self, position, cut_type)
     }
 }
 
-impl<P> Cuttable<P> for HalfBoundedAbsoluteInterval
-where
-    P: Into<Timestamp>,
-{
+impl Cuttable<Timestamp> for HalfBoundedAbsoluteInterval {
     type Output = AbsoluteInterval;
 
-    fn cut_at(&self, position: P, cut_type: CutType) -> CutResult<Self::Output> {
-        cut_abs_bound_pair(&self.abs_bound_pair(), position.into(), cut_type)
+    fn cut_at(&self, position: Timestamp, cut_type: CutType) -> CutResult<Self::Output> {
+        cut_abs_bound_pair(&self.abs_bound_pair(), position, cut_type)
             .map_cut(|c1, c2| (AbsoluteInterval::from(c1), AbsoluteInterval::from(c2)))
     }
 }
 
-impl<P> Cuttable<P> for RelativeBoundPair
-where
-    P: Into<SignedDuration>,
-{
+impl Cuttable<SignedDuration> for RelativeBoundPair {
     type Output = Self;
 
-    fn cut_at(&self, position: P, cut_type: CutType) -> CutResult<Self::Output> {
-        cut_rel_bound_pair(self, position.into(), cut_type)
+    fn cut_at(&self, position: SignedDuration, cut_type: CutType) -> CutResult<Self::Output> {
+        cut_rel_bound_pair(self, position, cut_type)
     }
 }
 
-impl<P> Cuttable<P> for EmptiableRelativeBoundPair
-where
-    P: Into<SignedDuration>,
-{
+impl Cuttable<SignedDuration> for EmptiableRelativeBoundPair {
     type Output = Self;
 
-    fn cut_at(&self, position: P, cut_type: CutType) -> CutResult<Self::Output> {
-        cut_emptiable_rel_bound_pair(self, position.into(), cut_type)
+    fn cut_at(&self, position: SignedDuration, cut_type: CutType) -> CutResult<Self::Output> {
+        cut_emptiable_rel_bound_pair(self, position, cut_type)
     }
 }
 
-impl<P> Cuttable<P> for RelativeInterval
-where
-    P: Into<SignedDuration>,
-{
+impl Cuttable<SignedDuration> for RelativeInterval {
     type Output = Self;
 
-    fn cut_at(&self, position: P, cut_type: CutType) -> CutResult<Self::Output> {
-        cut_rel_bound_pair(&self.rel_bound_pair(), position.into(), cut_type)
+    fn cut_at(&self, position: SignedDuration, cut_type: CutType) -> CutResult<Self::Output> {
+        cut_rel_bound_pair(&self.rel_bound_pair(), position, cut_type)
             .map_cut(|c1, c2| (RelativeInterval::from(c1), RelativeInterval::from(c2)))
     }
 }
 
-impl<P> Cuttable<P> for EmptiableRelativeInterval
-where
-    P: Into<SignedDuration>,
-{
+impl Cuttable<SignedDuration> for EmptiableRelativeInterval {
     type Output = Self;
 
-    fn cut_at(&self, position: P, cut_type: CutType) -> CutResult<Self::Output> {
-        cut_emptiable_rel_bound_pair(&self.emptiable_rel_bound_pair(), position.into(), cut_type)
+    fn cut_at(&self, position: SignedDuration, cut_type: CutType) -> CutResult<Self::Output> {
+        cut_emptiable_rel_bound_pair(&self.emptiable_rel_bound_pair(), position, cut_type)
             .map_cut(|c1, c2| (EmptiableRelativeInterval::from(c1), EmptiableRelativeInterval::from(c2)))
     }
 }
 
-impl<P> Cuttable<P> for BoundedRelativeInterval
-where
-    P: Into<SignedDuration>,
-{
+impl Cuttable<SignedDuration> for BoundedRelativeInterval {
     type Output = Self;
 
-    fn cut_at(&self, position: P, cut_type: CutType) -> CutResult<Self::Output> {
-        cut_bounded_rel_interval(self, position.into(), cut_type)
+    fn cut_at(&self, position: SignedDuration, cut_type: CutType) -> CutResult<Self::Output> {
+        cut_bounded_rel_interval(self, position, cut_type)
     }
 }
 
-impl<P> Cuttable<P> for HalfBoundedRelativeInterval
-where
-    P: Into<SignedDuration>,
-{
+impl Cuttable<SignedDuration> for HalfBoundedRelativeInterval {
     type Output = RelativeInterval;
 
-    fn cut_at(&self, position: P, cut_type: CutType) -> CutResult<Self::Output> {
-        cut_rel_bound_pair(&self.rel_bound_pair(), position.into(), cut_type)
+    fn cut_at(&self, position: SignedDuration, cut_type: CutType) -> CutResult<Self::Output> {
+        cut_rel_bound_pair(&self.rel_bound_pair(), position, cut_type)
             .map_cut(|c1, c2| (RelativeInterval::from(c1), RelativeInterval::from(c2)))
     }
 }

--- a/src/intervals/ops/point_containment.rs
+++ b/src/intervals/ops/point_containment.rs
@@ -44,7 +44,9 @@
 //!     .to_end_bound(),
 //! );
 //!
-//! let point = "2025-01-01 10:00:00[Europe/Oslo]".parse::<Zoned>()?;
+//! let point = "2025-01-01 10:00:00[Europe/Oslo]"
+//!     .parse::<Zoned>()?
+//!     .timestamp();
 //!
 //! assert!(interval.simple_contains_point(point));
 //! # Ok::<(), Box<dyn Error>>(())
@@ -518,7 +520,7 @@ pub fn deny_on_bounds_containment_rule_counts_as_contained(
 ///     ).to_end_bound(),
 /// );
 ///
-/// let point = "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?;
+/// let point = "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp();
 ///
 /// assert_eq!(
 ///     interval.disambiguated_point_containment_position(point, PointContainmentRuleSet::Strict),
@@ -545,7 +547,7 @@ pub fn deny_on_bounds_containment_rule_counts_as_contained(
 ///     ).to_end_bound(),
 /// );
 ///
-/// let point = "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?;
+/// let point = "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp();
 ///
 /// assert!(interval.simple_contains_point(point));
 /// # Ok::<(), Box<dyn Error>>(())
@@ -595,7 +597,9 @@ pub trait CanPositionPointContainment<P> {
     ///     .to_end_bound(),
     /// );
     ///
-    /// let point = "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?;
+    /// let point = "2025-01-01 08:00:00[Europe/Oslo]"
+    ///     .parse::<Zoned>()?
+    ///     .timestamp();
     ///
     /// assert_eq!(
     ///     interval.point_containment_position(point),
@@ -637,7 +641,7 @@ pub trait CanPositionPointContainment<P> {
     ///     ).to_end_bound(),
     /// );
     ///
-    /// let point = "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?;
+    /// let point = "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp();
     ///
     /// assert_eq!(
     ///     interval.disambiguated_point_containment_position(point, PointContainmentRuleSet::Strict),
@@ -685,7 +689,9 @@ pub trait CanPositionPointContainment<P> {
     ///     .to_end_bound(),
     /// );
     ///
-    /// let point = "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?;
+    /// let point = "2025-01-01 08:00:00[Europe/Oslo]"
+    ///     .parse::<Zoned>()?
+    ///     .timestamp();
     ///
     /// assert!(interval.simple_contains_point(point));
     /// # Ok::<(), Box<dyn Error>>(())
@@ -746,7 +752,9 @@ pub trait CanPositionPointContainment<P> {
     ///     .to_end_bound(),
     /// );
     ///
-    /// let point = "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?;
+    /// let point = "2025-01-01 08:00:00[Europe/Oslo]"
+    ///     .parse::<Zoned>()?
+    ///     .timestamp();
     ///
     /// assert!(interval.contains_point(
     ///     point,
@@ -808,7 +816,7 @@ pub trait CanPositionPointContainment<P> {
     ///     ).to_end_bound(),
     /// );
     ///
-    /// let point = "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?;
+    /// let point = "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp();
     ///
     /// let containment_closure = |point_pos: PointContainmentPosition| -> bool {
     ///     matches!(
@@ -875,7 +883,7 @@ pub trait CanPositionPointContainment<P> {
     ///     ).to_end_bound(),
     /// );
     ///
-    /// let point = "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?;
+    /// let point = "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp();
     ///
     /// let containment_closure = |point_pos: DisambiguatedPointContainmentPosition| -> bool {
     ///     matches!(point_pos, DisambiguatedPointContainmentPosition::Inside)
@@ -909,140 +917,125 @@ pub trait CanPositionPointContainment<P> {
     }
 }
 
-impl<P> CanPositionPointContainment<P> for AbsoluteBoundPair
-where
-    P: Into<Timestamp>,
-{
+impl CanPositionPointContainment<Timestamp> for AbsoluteBoundPair {
     type Error = Infallible;
 
-    fn point_containment_position(&self, positionable: P) -> Result<PointContainmentPosition, Self::Error> {
-        Ok(point_containment_position_abs_bound_pair(self, positionable.into()))
+    fn point_containment_position(&self, positionable: Timestamp) -> Result<PointContainmentPosition, Self::Error> {
+        Ok(point_containment_position_abs_bound_pair(self, positionable))
     }
 }
 
-impl<P> CanPositionPointContainment<P> for EmptiableAbsoluteBoundPair
-where
-    P: Into<Timestamp>,
-{
+impl CanPositionPointContainment<Timestamp> for EmptiableAbsoluteBoundPair {
     type Error = Infallible;
 
-    fn point_containment_position(&self, positionable: P) -> Result<PointContainmentPosition, Self::Error> {
+    fn point_containment_position(&self, positionable: Timestamp) -> Result<PointContainmentPosition, Self::Error> {
         let EmptiableAbsoluteBoundPair::Bound(bounds) = self else {
             return Ok(PointContainmentPosition::Outside);
         };
 
-        Ok(point_containment_position_abs_bound_pair(bounds, positionable.into()))
+        Ok(point_containment_position_abs_bound_pair(bounds, positionable))
     }
 }
 
-impl<P> CanPositionPointContainment<P> for AbsoluteInterval
-where
-    P: Into<Timestamp>,
-{
+impl CanPositionPointContainment<Timestamp> for AbsoluteInterval {
     type Error = Infallible;
 
-    fn point_containment_position(&self, positionable: P) -> Result<PointContainmentPosition, Self::Error> {
+    fn point_containment_position(&self, positionable: Timestamp) -> Result<PointContainmentPosition, Self::Error> {
         let EmptiableAbsoluteBoundPair::Bound(bounds) = self.emptiable_abs_bound_pair() else {
             return Ok(PointContainmentPosition::Outside);
         };
 
-        Ok(point_containment_position_abs_bound_pair(&bounds, positionable.into()))
+        Ok(point_containment_position_abs_bound_pair(&bounds, positionable))
     }
 }
 
-impl<P> CanPositionPointContainment<P> for BoundedAbsoluteInterval
-where
-    P: Into<Timestamp>,
-{
+impl CanPositionPointContainment<Timestamp> for BoundedAbsoluteInterval {
     type Error = Infallible;
 
-    fn point_containment_position(&self, positionable: P) -> Result<PointContainmentPosition, Self::Error> {
+    fn point_containment_position(&self, positionable: Timestamp) -> Result<PointContainmentPosition, Self::Error> {
         Ok(point_containment_position_abs_bound_pair(
             &self.abs_bound_pair(),
-            positionable.into(),
+            positionable,
         ))
     }
 }
 
-impl<P> CanPositionPointContainment<P> for HalfBoundedAbsoluteInterval
-where
-    P: Into<Timestamp>,
-{
+impl CanPositionPointContainment<Timestamp> for HalfBoundedAbsoluteInterval {
     type Error = Infallible;
 
-    fn point_containment_position(&self, positionable: P) -> Result<PointContainmentPosition, Self::Error> {
+    fn point_containment_position(&self, positionable: Timestamp) -> Result<PointContainmentPosition, Self::Error> {
         Ok(point_containment_position_abs_bound_pair(
             &self.abs_bound_pair(),
-            positionable.into(),
+            positionable,
         ))
     }
 }
 
-impl<P> CanPositionPointContainment<P> for RelativeBoundPair
-where
-    P: Into<SignedDuration>,
-{
+impl CanPositionPointContainment<SignedDuration> for RelativeBoundPair {
     type Error = Infallible;
 
-    fn point_containment_position(&self, positionable: P) -> Result<PointContainmentPosition, Self::Error> {
-        Ok(point_containment_position_rel_bound_pair(self, positionable.into()))
+    fn point_containment_position(
+        &self,
+        positionable: SignedDuration,
+    ) -> Result<PointContainmentPosition, Self::Error> {
+        Ok(point_containment_position_rel_bound_pair(self, positionable))
     }
 }
 
-impl<P> CanPositionPointContainment<P> for EmptiableRelativeBoundPair
-where
-    P: Into<SignedDuration>,
-{
+impl CanPositionPointContainment<SignedDuration> for EmptiableRelativeBoundPair {
     type Error = Infallible;
 
-    fn point_containment_position(&self, positionable: P) -> Result<PointContainmentPosition, Self::Error> {
+    fn point_containment_position(
+        &self,
+        positionable: SignedDuration,
+    ) -> Result<PointContainmentPosition, Self::Error> {
         let EmptiableRelativeBoundPair::Bound(bounds) = self else {
             return Ok(PointContainmentPosition::Outside);
         };
 
-        Ok(point_containment_position_rel_bound_pair(bounds, positionable.into()))
+        Ok(point_containment_position_rel_bound_pair(bounds, positionable))
     }
 }
 
-impl<P> CanPositionPointContainment<P> for RelativeInterval
-where
-    P: Into<SignedDuration>,
-{
+impl CanPositionPointContainment<SignedDuration> for RelativeInterval {
     type Error = Infallible;
 
-    fn point_containment_position(&self, positionable: P) -> Result<PointContainmentPosition, Self::Error> {
+    fn point_containment_position(
+        &self,
+        positionable: SignedDuration,
+    ) -> Result<PointContainmentPosition, Self::Error> {
         let EmptiableRelativeBoundPair::Bound(bounds) = self.emptiable_rel_bound_pair() else {
             return Ok(PointContainmentPosition::Outside);
         };
 
-        Ok(point_containment_position_rel_bound_pair(&bounds, positionable.into()))
+        Ok(point_containment_position_rel_bound_pair(&bounds, positionable))
     }
 }
 
-impl<P> CanPositionPointContainment<P> for BoundedRelativeInterval
-where
-    P: Into<SignedDuration>,
-{
+impl CanPositionPointContainment<SignedDuration> for BoundedRelativeInterval {
     type Error = Infallible;
 
-    fn point_containment_position(&self, positionable: P) -> Result<PointContainmentPosition, Self::Error> {
+    fn point_containment_position(
+        &self,
+        positionable: SignedDuration,
+    ) -> Result<PointContainmentPosition, Self::Error> {
         Ok(point_containment_position_rel_bound_pair(
             &self.rel_bound_pair(),
-            positionable.into(),
+            positionable,
         ))
     }
 }
 
-impl<P> CanPositionPointContainment<P> for HalfBoundedRelativeInterval
-where
-    P: Into<SignedDuration>,
-{
+impl CanPositionPointContainment<SignedDuration> for HalfBoundedRelativeInterval {
     type Error = Infallible;
 
-    fn point_containment_position(&self, positionable: P) -> Result<PointContainmentPosition, Self::Error> {
+    fn point_containment_position(
+        &self,
+        positionable: SignedDuration,
+    ) -> Result<PointContainmentPosition, Self::Error> {
         Ok(point_containment_position_rel_bound_pair(
             &self.rel_bound_pair(),
-            positionable.into(),
+            positionable,
         ))
     }
 }

--- a/src/intervals/ops/precision.rs
+++ b/src/intervals/ops/precision.rs
@@ -307,16 +307,14 @@ pub trait PreciseAbsoluteInterval {
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
     #[must_use]
-    fn precise_interval_with_different_precisions_with_base_time<D>(
+    fn precise_interval_with_different_precisions_with_base_time(
         &self,
         tz: TimeZone,
         precision_start: Precision,
-        base_start: D,
+        base_start: Timestamp,
         precision_end: Precision,
-        base_end: D,
-    ) -> Self::PrecisedIntervalOutput
-    where
-        D: Into<Timestamp>;
+        base_end: Timestamp,
+    ) -> Self::PrecisedIntervalOutput;
 
     /// Precises the start and end bound with the given precision and base time
     ///
@@ -373,15 +371,12 @@ pub trait PreciseAbsoluteInterval {
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
     #[must_use]
-    fn precise_interval_with_base_time<D>(
+    fn precise_interval_with_base_time(
         &self,
         tz: TimeZone,
         precision: Precision,
-        base: D,
-    ) -> Self::PrecisedIntervalOutput
-    where
-        D: Into<Timestamp> + Clone,
-    {
+        base: Timestamp,
+    ) -> Self::PrecisedIntervalOutput {
         self.precise_interval_with_different_precisions_with_base_time(tz, precision, base.clone(), precision, base)
     }
 }
@@ -398,25 +393,15 @@ impl PreciseAbsoluteInterval for AbsoluteBoundPair {
         precise_abs_bound_pair(self, tz, precision_start, precision_end)
     }
 
-    fn precise_interval_with_different_precisions_with_base_time<D>(
+    fn precise_interval_with_different_precisions_with_base_time(
         &self,
         tz: TimeZone,
         precision_start: Precision,
-        base_start: D,
+        base_start: Timestamp,
         precision_end: Precision,
-        base_end: D,
-    ) -> Self::PrecisedIntervalOutput
-    where
-        D: Into<Timestamp>,
-    {
-        precise_abs_bound_pair_with_base_time(
-            self,
-            tz,
-            precision_start,
-            base_start.into(),
-            precision_end,
-            base_end.into(),
-        )
+        base_end: Timestamp,
+    ) -> Self::PrecisedIntervalOutput {
+        precise_abs_bound_pair_with_base_time(self, tz, precision_start, base_start, precision_end, base_end)
     }
 }
 
@@ -441,26 +426,23 @@ impl PreciseAbsoluteInterval for EmptiableAbsoluteBoundPair {
         Ok(EmptiableAbsoluteBoundPair::Empty)
     }
 
-    fn precise_interval_with_different_precisions_with_base_time<D>(
+    fn precise_interval_with_different_precisions_with_base_time(
         &self,
         tz: TimeZone,
         precision_start: Precision,
-        base_start: D,
+        base_start: Timestamp,
         precision_end: Precision,
-        base_end: D,
-    ) -> Self::PrecisedIntervalOutput
-    where
-        D: Into<Timestamp>,
-    {
+        base_end: Timestamp,
+    ) -> Self::PrecisedIntervalOutput {
         if let EmptiableAbsoluteBoundPair::Bound(abs_bound_pair) = self {
             return Ok(EmptiableAbsoluteBoundPair::Bound(
                 precise_abs_bound_pair_with_base_time(
                     abs_bound_pair,
                     tz,
                     precision_start,
-                    base_start.into(),
+                    base_start,
                     precision_end,
-                    base_end.into(),
+                    base_end,
                 )?,
             ));
         }
@@ -486,24 +468,21 @@ impl PreciseAbsoluteInterval for AbsoluteInterval {
         )?))
     }
 
-    fn precise_interval_with_different_precisions_with_base_time<D>(
+    fn precise_interval_with_different_precisions_with_base_time(
         &self,
         tz: TimeZone,
         precision_start: Precision,
-        base_start: D,
+        base_start: Timestamp,
         precision_end: Precision,
-        base_end: D,
-    ) -> Self::PrecisedIntervalOutput
-    where
-        D: Into<Timestamp>,
-    {
+        base_end: Timestamp,
+    ) -> Self::PrecisedIntervalOutput {
         Ok(AbsoluteInterval::from(precise_abs_bound_pair_with_base_time(
             &self.abs_bound_pair(),
             tz,
             precision_start,
-            base_start.into(),
+            base_start,
             precision_end,
-            base_end.into(),
+            base_end,
         )?))
     }
 }
@@ -529,25 +508,22 @@ impl PreciseAbsoluteInterval for EmptiableAbsoluteInterval {
         Ok(EmptiableAbsoluteInterval::Empty(EmptyInterval))
     }
 
-    fn precise_interval_with_different_precisions_with_base_time<D>(
+    fn precise_interval_with_different_precisions_with_base_time(
         &self,
         tz: TimeZone,
         precision_start: Precision,
-        base_start: D,
+        base_start: Timestamp,
         precision_end: Precision,
-        base_end: D,
-    ) -> Self::PrecisedIntervalOutput
-    where
-        D: Into<Timestamp>,
-    {
+        base_end: Timestamp,
+    ) -> Self::PrecisedIntervalOutput {
         if let EmptiableAbsoluteBoundPair::Bound(ref abs_bound_pair) = self.emptiable_abs_bound_pair() {
             return Ok(EmptiableAbsoluteInterval::from(precise_abs_bound_pair_with_base_time(
                 abs_bound_pair,
                 tz,
                 precision_start,
-                base_start.into(),
+                base_start,
                 precision_end,
-                base_end.into(),
+                base_end,
             )?));
         }
 
@@ -679,9 +655,12 @@ pub trait PreciseAbsoluteBound {
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
     #[must_use]
-    fn precise_bound_with_base_time<B>(&self, tz: TimeZone, precision: Precision, base: B) -> Self::PrecisedBoundOutput
-    where
-        B: Into<Timestamp>;
+    fn precise_bound_with_base_time(
+        &self,
+        tz: TimeZone,
+        precision: Precision,
+        base: Timestamp,
+    ) -> Self::PrecisedBoundOutput;
 }
 
 impl PreciseAbsoluteBound for AbsoluteFiniteBound {
@@ -691,11 +670,13 @@ impl PreciseAbsoluteBound for AbsoluteFiniteBound {
         precise_abs_finite_bound(self, tz, precision)
     }
 
-    fn precise_bound_with_base_time<B>(&self, tz: TimeZone, precision: Precision, base: B) -> Self::PrecisedBoundOutput
-    where
-        B: Into<Timestamp>,
-    {
-        precise_abs_finite_bound_with_base_time(self, tz, precision, base.into())
+    fn precise_bound_with_base_time(
+        &self,
+        tz: TimeZone,
+        precision: Precision,
+        base: Timestamp,
+    ) -> Self::PrecisedBoundOutput {
+        precise_abs_finite_bound_with_base_time(self, tz, precision, base)
     }
 }
 
@@ -706,11 +687,13 @@ impl PreciseAbsoluteBound for AbsoluteStartBound {
         precise_abs_start_bound(self, tz, precision)
     }
 
-    fn precise_bound_with_base_time<B>(&self, tz: TimeZone, precision: Precision, base: B) -> Self::PrecisedBoundOutput
-    where
-        B: Into<Timestamp>,
-    {
-        precise_abs_start_bound_with_base_time(self, tz, precision, base.into())
+    fn precise_bound_with_base_time(
+        &self,
+        tz: TimeZone,
+        precision: Precision,
+        base: Timestamp,
+    ) -> Self::PrecisedBoundOutput {
+        precise_abs_start_bound_with_base_time(self, tz, precision, base)
     }
 }
 
@@ -721,11 +704,13 @@ impl PreciseAbsoluteBound for AbsoluteEndBound {
         precise_abs_end_bound(self, tz, precision)
     }
 
-    fn precise_bound_with_base_time<B>(&self, tz: TimeZone, precision: Precision, base: B) -> Self::PrecisedBoundOutput
-    where
-        B: Into<Timestamp>,
-    {
-        precise_abs_end_bound_with_base_time(self, tz, precision, base.into())
+    fn precise_bound_with_base_time(
+        &self,
+        tz: TimeZone,
+        precision: Precision,
+        base: Timestamp,
+    ) -> Self::PrecisedBoundOutput {
+        precise_abs_end_bound_with_base_time(self, tz, precision, base)
     }
 }
 

--- a/src/intervals/ops/relativity_conversion.rs
+++ b/src/intervals/ops/relativity_conversion.rs
@@ -39,10 +39,7 @@ macro_rules! to_absolute_impl_reflective {
             impl ToAbsolute for $implementor {
                 type AbsoluteType = Self;
 
-                fn to_absolute<D>(&self, _reference: D) -> Self::AbsoluteType
-                where
-                    D: Into<Timestamp>,
-                {
+                fn to_absolute(&self, _reference: Timestamp) -> Self::AbsoluteType {
                     self.clone()
                 }
             }
@@ -56,10 +53,7 @@ macro_rules! to_relative_impl_reflective {
             impl ToRelative for $implementor {
                 type RelativeType = Self;
 
-                fn to_relative<D>(&self, _reference: D) -> Self::RelativeType
-                where
-                    D: Into<Timestamp>,
-                {
+                fn to_relative(&self, _reference: Timestamp) -> Self::RelativeType {
                     self.clone()
                 }
             }
@@ -150,9 +144,7 @@ pub trait ToAbsolute {
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
     #[must_use]
-    fn to_absolute<D>(&self, reference: D) -> Self::AbsoluteType
-    where
-        D: Into<Timestamp>;
+    fn to_absolute(&self, reference: Timestamp) -> Self::AbsoluteType;
 }
 
 to_absolute_impl_reflective!([
@@ -172,26 +164,20 @@ to_absolute_impl_reflective!([
 impl ToAbsolute for RelativeFiniteBound {
     type AbsoluteType = AbsoluteFiniteBound;
 
-    fn to_absolute<D>(&self, reference: D) -> Self::AbsoluteType
-    where
-        D: Into<Timestamp>,
-    {
-        AbsoluteFiniteBound::new_with_inclusivity(reference.into() + self.offset(), self.inclusivity())
+    fn to_absolute(&self, reference: Timestamp) -> Self::AbsoluteType {
+        AbsoluteFiniteBound::new_with_inclusivity(reference + self.offset(), self.inclusivity())
     }
 }
 
 impl ToAbsolute for RelativeStartBound {
     type AbsoluteType = AbsoluteStartBound;
 
-    fn to_absolute<D>(&self, reference: D) -> Self::AbsoluteType
-    where
-        D: Into<Timestamp>,
-    {
+    fn to_absolute(&self, reference: Timestamp) -> Self::AbsoluteType {
         match self {
             RelativeStartBound::InfinitePast => AbsoluteStartBound::InfinitePast,
             RelativeStartBound::Finite(relative_finite) => {
                 AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-                    reference.into() + relative_finite.offset(),
+                    reference + relative_finite.offset(),
                     relative_finite.inclusivity(),
                 ))
             },
@@ -202,15 +188,12 @@ impl ToAbsolute for RelativeStartBound {
 impl ToAbsolute for RelativeEndBound {
     type AbsoluteType = AbsoluteEndBound;
 
-    fn to_absolute<D>(&self, reference: D) -> Self::AbsoluteType
-    where
-        D: Into<Timestamp>,
-    {
+    fn to_absolute(&self, reference: Timestamp) -> Self::AbsoluteType {
         match self {
             RelativeEndBound::InfiniteFuture => AbsoluteEndBound::InfiniteFuture,
             RelativeEndBound::Finite(relative_finite) => {
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-                    reference.into() + relative_finite.offset(),
+                    reference + relative_finite.offset(),
                     relative_finite.inclusivity(),
                 ))
             },
@@ -221,11 +204,8 @@ impl ToAbsolute for RelativeEndBound {
 impl ToAbsolute for RelativeBoundPair {
     type AbsoluteType = AbsoluteBoundPair;
 
-    fn to_absolute<D>(&self, reference: D) -> Self::AbsoluteType
-    where
-        D: Into<Timestamp>,
-    {
-        let reference = reference.into();
+    fn to_absolute(&self, reference: Timestamp) -> Self::AbsoluteType {
+        let reference = reference;
 
         AbsoluteBoundPair::new(
             self.rel_start().to_absolute(reference),
@@ -237,10 +217,7 @@ impl ToAbsolute for RelativeBoundPair {
 impl ToAbsolute for EmptiableRelativeBoundPair {
     type AbsoluteType = EmptiableAbsoluteBoundPair;
 
-    fn to_absolute<D>(&self, reference: D) -> Self::AbsoluteType
-    where
-        D: Into<Timestamp>,
-    {
+    fn to_absolute(&self, reference: Timestamp) -> Self::AbsoluteType {
         match self {
             Self::Empty => EmptiableAbsoluteBoundPair::Empty,
             Self::Bound(abs_bound_pair) => EmptiableAbsoluteBoundPair::Bound(abs_bound_pair.to_absolute(reference)),
@@ -251,12 +228,7 @@ impl ToAbsolute for EmptiableRelativeBoundPair {
 impl ToAbsolute for BoundedRelativeInterval {
     type AbsoluteType = BoundedAbsoluteInterval;
 
-    fn to_absolute<D>(&self, reference: D) -> Self::AbsoluteType
-    where
-        D: Into<Timestamp>,
-    {
-        let reference = reference.into();
-
+    fn to_absolute(&self, reference: Timestamp) -> Self::AbsoluteType {
         BoundedAbsoluteInterval::unchecked_new_with_inclusivity(
             reference + self.start(),
             self.start_inclusivity(),
@@ -269,12 +241,9 @@ impl ToAbsolute for BoundedRelativeInterval {
 impl ToAbsolute for HalfBoundedRelativeInterval {
     type AbsoluteType = HalfBoundedAbsoluteInterval;
 
-    fn to_absolute<D>(&self, reference: D) -> Self::AbsoluteType
-    where
-        D: Into<Timestamp>,
-    {
+    fn to_absolute(&self, reference: Timestamp) -> Self::AbsoluteType {
         HalfBoundedAbsoluteInterval::new_with_inclusivity(
-            reference.into() + self.reference(),
+            reference + self.reference(),
             self.reference_inclusivity(),
             self.opening_direction(),
         )
@@ -284,10 +253,7 @@ impl ToAbsolute for HalfBoundedRelativeInterval {
 impl ToAbsolute for RelativeInterval {
     type AbsoluteType = AbsoluteInterval;
 
-    fn to_absolute<D>(&self, reference: D) -> Self::AbsoluteType
-    where
-        D: Into<Timestamp>,
-    {
+    fn to_absolute(&self, reference: Timestamp) -> Self::AbsoluteType {
         match self {
             Self::Bounded(bounded) => AbsoluteInterval::Bounded(bounded.to_absolute(reference)),
             Self::HalfBounded(half_bounded) => AbsoluteInterval::HalfBounded(half_bounded.to_absolute(reference)),
@@ -299,10 +265,7 @@ impl ToAbsolute for RelativeInterval {
 impl ToAbsolute for EmptiableRelativeInterval {
     type AbsoluteType = EmptiableAbsoluteInterval;
 
-    fn to_absolute<D>(&self, reference: D) -> Self::AbsoluteType
-    where
-        D: Into<Timestamp>,
-    {
+    fn to_absolute(&self, reference: Timestamp) -> Self::AbsoluteType {
         match self {
             Self::Bound(interval) => EmptiableAbsoluteInterval::Bound(interval.to_absolute(reference)),
             Self::Empty(empty) => EmptiableAbsoluteInterval::Empty(empty.to_absolute(reference)),
@@ -393,9 +356,7 @@ pub trait ToRelative {
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
     #[must_use]
-    fn to_relative<D>(&self, reference: D) -> Self::RelativeType
-    where
-        D: Into<Timestamp>;
+    fn to_relative(&self, reference: Timestamp) -> Self::RelativeType;
 }
 
 to_relative_impl_reflective!([
@@ -415,26 +376,20 @@ to_relative_impl_reflective!([
 impl ToRelative for AbsoluteFiniteBound {
     type RelativeType = RelativeFiniteBound;
 
-    fn to_relative<D>(&self, reference: D) -> Self::RelativeType
-    where
-        D: Into<Timestamp>,
-    {
-        RelativeFiniteBound::new_with_inclusivity(self.time().duration_since(reference.into()), self.inclusivity())
+    fn to_relative(&self, reference: Timestamp) -> Self::RelativeType {
+        RelativeFiniteBound::new_with_inclusivity(self.time().duration_since(reference), self.inclusivity())
     }
 }
 
 impl ToRelative for AbsoluteStartBound {
     type RelativeType = RelativeStartBound;
 
-    fn to_relative<D>(&self, reference: D) -> Self::RelativeType
-    where
-        D: Into<Timestamp>,
-    {
+    fn to_relative(&self, reference: Timestamp) -> Self::RelativeType {
         match self {
             AbsoluteStartBound::InfinitePast => RelativeStartBound::InfinitePast,
             AbsoluteStartBound::Finite(absolute_finite) => {
                 RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                    absolute_finite.time().duration_since(reference.into()),
+                    absolute_finite.time().duration_since(reference),
                     absolute_finite.inclusivity(),
                 ))
             },
@@ -445,15 +400,12 @@ impl ToRelative for AbsoluteStartBound {
 impl ToRelative for AbsoluteEndBound {
     type RelativeType = RelativeEndBound;
 
-    fn to_relative<D>(&self, reference: D) -> Self::RelativeType
-    where
-        D: Into<Timestamp>,
-    {
+    fn to_relative(&self, reference: Timestamp) -> Self::RelativeType {
         match self {
             AbsoluteEndBound::InfiniteFuture => RelativeEndBound::InfiniteFuture,
             AbsoluteEndBound::Finite(absolute_finite) => {
                 RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                    absolute_finite.time().duration_since(reference.into()),
+                    absolute_finite.time().duration_since(reference),
                     absolute_finite.inclusivity(),
                 ))
             },
@@ -464,11 +416,8 @@ impl ToRelative for AbsoluteEndBound {
 impl ToRelative for AbsoluteBoundPair {
     type RelativeType = RelativeBoundPair;
 
-    fn to_relative<D>(&self, reference: D) -> Self::RelativeType
-    where
-        D: Into<Timestamp>,
-    {
-        let reference = reference.into();
+    fn to_relative(&self, reference: Timestamp) -> Self::RelativeType {
+        let reference = reference;
 
         RelativeBoundPair::new(
             self.abs_start().to_relative(reference),
@@ -480,10 +429,7 @@ impl ToRelative for AbsoluteBoundPair {
 impl ToRelative for EmptiableAbsoluteBoundPair {
     type RelativeType = EmptiableRelativeBoundPair;
 
-    fn to_relative<D>(&self, reference: D) -> Self::RelativeType
-    where
-        D: Into<Timestamp>,
-    {
+    fn to_relative(&self, reference: Timestamp) -> Self::RelativeType {
         match self {
             Self::Empty => EmptiableRelativeBoundPair::Empty,
             Self::Bound(abs_bound_pair) => EmptiableRelativeBoundPair::Bound(abs_bound_pair.to_relative(reference)),
@@ -494,11 +440,8 @@ impl ToRelative for EmptiableAbsoluteBoundPair {
 impl ToRelative for BoundedAbsoluteInterval {
     type RelativeType = BoundedRelativeInterval;
 
-    fn to_relative<D>(&self, reference: D) -> Self::RelativeType
-    where
-        D: Into<Timestamp>,
-    {
-        let reference = reference.into();
+    fn to_relative(&self, reference: Timestamp) -> Self::RelativeType {
+        let reference = reference;
 
         BoundedRelativeInterval::new_with_inclusivity(
             self.start().duration_since(reference),
@@ -512,12 +455,9 @@ impl ToRelative for BoundedAbsoluteInterval {
 impl ToRelative for HalfBoundedAbsoluteInterval {
     type RelativeType = HalfBoundedRelativeInterval;
 
-    fn to_relative<D>(&self, reference: D) -> Self::RelativeType
-    where
-        D: Into<Timestamp>,
-    {
+    fn to_relative(&self, reference: Timestamp) -> Self::RelativeType {
         HalfBoundedRelativeInterval::new_with_inclusivity(
-            self.reference().duration_since(reference.into()),
+            self.reference().duration_since(reference),
             self.reference_inclusivity(),
             self.opening_direction(),
         )
@@ -527,10 +467,7 @@ impl ToRelative for HalfBoundedAbsoluteInterval {
 impl ToRelative for AbsoluteInterval {
     type RelativeType = RelativeInterval;
 
-    fn to_relative<D>(&self, reference: D) -> Self::RelativeType
-    where
-        D: Into<Timestamp>,
-    {
+    fn to_relative(&self, reference: Timestamp) -> Self::RelativeType {
         match self {
             Self::Bounded(bounded) => RelativeInterval::Bounded(bounded.to_relative(reference)),
             Self::HalfBounded(half_bounded) => RelativeInterval::HalfBounded(half_bounded.to_relative(reference)),
@@ -542,10 +479,7 @@ impl ToRelative for AbsoluteInterval {
 impl ToRelative for EmptiableAbsoluteInterval {
     type RelativeType = EmptiableRelativeInterval;
 
-    fn to_relative<D>(&self, reference: D) -> Self::RelativeType
-    where
-        D: Into<Timestamp>,
-    {
+    fn to_relative(&self, reference: Timestamp) -> Self::RelativeType {
         match self {
             Self::Bound(interval) => EmptiableRelativeInterval::Bound(interval.to_relative(reference)),
             Self::Empty(empty) => EmptiableRelativeInterval::Empty(empty.to_relative(reference)),

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -129,7 +129,9 @@ impl PrecisionMode {
 /// # use periodical::ops::{Precision, PrecisionMode};
 /// let round_up_every_35_mins = Precision::new(Duration::from_mins(35), PrecisionMode::ToFuture)?;
 ///
-/// let first_january_2025 = "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?;
+/// let first_january_2025 = "2025-01-01 00:00:00[Europe/Oslo]"
+///     .parse::<Zoned>()?
+///     .timestamp();
 /// let two_minutes_after_eight = "2025-01-01 08:02:11[Europe/Oslo]".parse::<Zoned>()?;
 /// let fourteen_minutes_after_ten = "2025-01-01 10:14:21[Europe/Oslo]".parse::<Zoned>()?;
 ///
@@ -137,7 +139,7 @@ impl PrecisionMode {
 /// // 14 * 35m = 08:10
 /// assert_eq!(
 ///     round_up_every_35_mins
-///         .precise_time_with_base_time(&two_minutes_after_eight, &first_january_2025,)?,
+///         .precise_time_with_base_time(&two_minutes_after_eight, first_january_2025)?,
 ///     "2025-01-01 08:10:00[Europe/Oslo]".parse::<Zoned>()?,
 /// );
 ///
@@ -145,7 +147,7 @@ impl PrecisionMode {
 /// // 18 * 35m = 10:30
 /// assert_eq!(
 ///     round_up_every_35_mins
-///         .precise_time_with_base_time(&fourteen_minutes_after_ten, &first_january_2025,)?,
+///         .precise_time_with_base_time(&fourteen_minutes_after_ten, first_january_2025)?,
 ///     "2025-01-01 10:30:00[Europe/Oslo]".parse::<Zoned>()?,
 /// );
 /// # Ok::<(), Box<dyn Error>>(())
@@ -515,10 +517,10 @@ impl Precision {
     /// # use periodical::ops::{Precision, PrecisionMode};
     /// let precision = Precision::new(Duration::from_hours(2), PrecisionMode::ToFuture)?;
     /// let time = "2026-03-29 07:55:02[Europe/Oslo]".parse::<Zoned>()?;
-    /// let base = time.start_of_day()?;
+    /// let base = time.start_of_day()?.timestamp();
     ///
     /// assert_eq!(
-    ///     precision.precise_time_with_base_time(&time, &base)?,
+    ///     precision.precise_time_with_base_time(&time, base)?,
     ///     "2026-03-29 09:00:00[Europe/Oslo]".parse::<Zoned>()?,
     /// );
     /// # Ok::<(), Box<dyn Error>>(())
@@ -533,21 +535,24 @@ impl Precision {
     /// # use periodical::ops::{Precision, PrecisionMode};
     /// let precision = Precision::new(Duration::from_mins(22), PrecisionMode::ToFuture)?;
     /// let time = "2026-01-02 07:55:02[Europe/Oslo]".parse::<Zoned>()?;
-    /// let base = "2026-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?;
+    /// let base = "2026-01-01 00:00:00[Europe/Oslo]"
+    ///     .parse::<Zoned>()?
+    ///     .timestamp();
     ///
     /// assert_eq!(
-    ///     precision.precise_time_with_base_time(&time, &base)?,
+    ///     precision.precise_time_with_base_time(&time, base)?,
     ///     "2026-01-02 08:16:00[Europe/Oslo]".parse::<Zoned>()?,
     /// );
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
     ///
     /// [1]: https://en.wikipedia.org/w/index.php?title=Unix_time&useskin=vector
-    pub fn precise_time_with_base_time<B>(&self, time: &Zoned, base: B) -> Result<Zoned, PrecisionOutOfRangeDateError>
-    where
-        B: Into<Timestamp>,
-    {
-        let base = base.into().to_zoned(time.time_zone().clone());
+    pub fn precise_time_with_base_time(
+        &self,
+        time: &Zoned,
+        base: Timestamp,
+    ) -> Result<Zoned, PrecisionOutOfRangeDateError> {
+        let base = base.to_zoned(time.time_zone().clone());
 
         base.checked_add(self.precise_signed_duration(time.duration_since(&base))?)
             .map_err(|_| PrecisionOutOfRangeDateError)

--- a/src/ops_tests.rs
+++ b/src/ops_tests.rs
@@ -775,7 +775,7 @@ mod precision {
 
             assert_eq!(
                 Precision::unchecked_new(Duration::from_hours(2), PrecisionMode::ToFuture)
-                    .precise_time_with_base_time(&time, &base)?,
+                    .precise_time_with_base_time(&time, base.timestamp())?,
                 "2026-03-29 09:00:00[Europe/Oslo]".parse::<Zoned>()?,
             );
 
@@ -789,7 +789,7 @@ mod precision {
             let base = "2026-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?;
 
             assert_eq!(
-                precision.precise_time_with_base_time(&time, &base)?,
+                precision.precise_time_with_base_time(&time, base.timestamp())?,
                 "2026-01-02 08:16:00[Europe/Oslo]".parse::<Zoned>()?,
             );
 
@@ -807,7 +807,7 @@ mod precision {
             // as a tangible hour.
             assert_eq!(
                 Precision::unchecked_new(Duration::from_hours(2), PrecisionMode::ToFuture)
-                    .precise_time_with_base_time(&time.with_time_zone(TimeZone::get("UTC")?), &base)?,
+                    .precise_time_with_base_time(&time.with_time_zone(TimeZone::get("UTC")?), base.timestamp())?,
                 "2026-03-29 07:00:00Z[UTC]".parse::<Zoned>()?, // = 09:00:00 in Europe/Oslo
             );
 
@@ -822,7 +822,7 @@ mod precision {
 
             assert_eq!(
                 Precision::unchecked_new(Duration::from_mins(30), PrecisionMode::ToFuture)
-                    .precise_time_with_base_time(&time.with_time_zone(TimeZone::get("UTC")?), &base)?,
+                    .precise_time_with_base_time(&time.with_time_zone(TimeZone::get("UTC")?), base.timestamp())?,
                 "2026-03-29 06:00:00Z[UTC]".parse::<Zoned>()?, // = 08:00:00 in Europe/Oslo
             );
 


### PR DESCRIPTION
# Explanation

Since conversions can be done without this bound, it helps with explicitness
to only allow one specific type and have the caller define how to do the conversion.

<details>
<summary><h1>Changelog</h1></summary>

## Changed

- Changed `precise_time_with_base_time` to have explicit type requirement instead of allowing `Into<T>`
- Changed `Cuttable` impls to have an explicit type instead of allowing `Into<T>`
- Changed `CanPositionPointContainment` impls to have an explicit type instead of allowing `Into<T>`
- Changed `PreciseAbsoluteInterval::precise_interval_with_different_precisions_with_base_time`
  to have explicit type requirement instead of allowing `Into<T>`
- Changed `ToAbsolute::to_absolute` to have an explicit type instead of allowing `Into<T>`
- Changed `ToRelative::to_relative` to have an explicit type instead of allowing `Into<T>`

</details>