### PR TITLE
Improved: Conciseness by using the newer chain calls (e.g. `.to_interval()` instead of `AbsoluteInterval::from()`)

### DIFF
--- a/branch-changelog.md
+++ b/branch-changelog.md
@@ -17,7 +17,7 @@ Remove the sections that don't apply to your PR
 
 ## Changed
 
-- Things you've changed
+- Changed all usage of `AbsoluteStartBound::Finite(x)` to `x.to_start_bound()`
 
 ## Deprecated
 

--- a/branch-changelog.md
+++ b/branch-changelog.md
@@ -13,7 +13,13 @@ Remove the sections that don't apply to your PR
 
 ## Added
 
-- Things you've added
+- Added `to_interval` on `AbsoluteBoundPair`
+- Added `to_emptiable_interval` on `AbsoluteBoundPair`
+- Added `to_emptiable_interval` on `EmptiableAbsoluteBoundPair`
+
+- Added `to_interval` on `RelativeBoundPair`
+- Added `to_emptiable_interval` on `RelativeBoundPair`
+- Added `to_emptiable_interval` on `EmptiableRelativeBoundPair`
 
 ## Changed
 
@@ -21,9 +27,15 @@ Remove the sections that don't apply to your PR
 - Changed all usages of `AbsoluteEndBound::Finite(x)` to `x.to_end_bound()`
 - Changed all usages of `AbsoluteBound::Start(x)` to `x.to_bound()`
 - Changed all usages of `AbsoluteBound::End(x)` to `x.to_bound()`
+- Changed all usages of `AbsoluteInterval::from(x)` to `x.to_interval()`
+- Changed all usages of `EmptiableAbsoluteInterval::from(x)` to `x.to_emptiable_interval()`
 
 - Changed all usages of `RelativeStartBound::Finite(x)` to `x.to_start_bound()`
 - Changed all usages of `RelativeEndBound::Finite(x)` to `x.to_end_bound()`
+- Changed all usages of `RelativeBound::Start(x)` to `x.to_bound()`
+- Changed all usages of `RelativeBound::End(x)` to `x.to_bound()`
+- Changed all usages of `RelativeInterval::from(x)` to `x.to_interval()`
+- Changed all usages of `EmptiableRelativeInterval::from(x)` to `x.to_emptiable_interval()`
 
 ## Deprecated
 

--- a/branch-changelog.md
+++ b/branch-changelog.md
@@ -17,12 +17,13 @@ Remove the sections that don't apply to your PR
 
 ## Changed
 
-- Changed all usage of `AbsoluteStartBound::Finite(x)` to `x.to_start_bound()`
-- Changed all usage of `AbsoluteEndBound::Finite(x)` to `x.to_end_bound()`
-- Changed all usage of `AbsoluteBound::Start(x)` to `x.to_bound()`
-- Changed all usage of `AbsoluteBound::End(x)` to `x.to_bound()`
+- Changed all usages of `AbsoluteStartBound::Finite(x)` to `x.to_start_bound()`
+- Changed all usages of `AbsoluteEndBound::Finite(x)` to `x.to_end_bound()`
+- Changed all usages of `AbsoluteBound::Start(x)` to `x.to_bound()`
+- Changed all usages of `AbsoluteBound::End(x)` to `x.to_bound()`
 
-- Changed all usage of `RelativeStartBound::Finite(x)` to `x.to_start_bound()`
+- Changed all usages of `RelativeStartBound::Finite(x)` to `x.to_start_bound()`
+- Changed all usages of `RelativeEndBound::Finite(x)` to `x.to_end_bound()`
 
 ## Deprecated
 

--- a/branch-changelog.md
+++ b/branch-changelog.md
@@ -22,6 +22,8 @@ Remove the sections that don't apply to your PR
 - Changed all usage of `AbsoluteBound::Start(x)` to `x.to_bound()`
 - Changed all usage of `AbsoluteBound::End(x)` to `x.to_bound()`
 
+- Changed all usage of `RelativeStartBound::Finite(x)` to `x.to_start_bound()`
+
 ## Deprecated
 
 - Things you've marked as deprecated

--- a/branch-changelog.md
+++ b/branch-changelog.md
@@ -19,6 +19,8 @@ Remove the sections that don't apply to your PR
 
 - Changed all usage of `AbsoluteStartBound::Finite(x)` to `x.to_start_bound()`
 - Changed all usage of `AbsoluteEndBound::Finite(x)` to `x.to_end_bound()`
+- Changed all usage of `AbsoluteBound::Start(x)` to `x.to_bound()`
+- Changed all usage of `AbsoluteBound::End(x)` to `x.to_bound()`
 
 ## Deprecated
 

--- a/branch-changelog.md
+++ b/branch-changelog.md
@@ -18,6 +18,7 @@ Remove the sections that don't apply to your PR
 ## Changed
 
 - Changed all usage of `AbsoluteStartBound::Finite(x)` to `x.to_start_bound()`
+- Changed all usage of `AbsoluteEndBound::Finite(x)` to `x.to_end_bound()`
 
 ## Deprecated
 

--- a/fuzz/fuzz_targets/abridge_2nd_degree_complement_of_bounded_interval.rs
+++ b/fuzz/fuzz_targets/abridge_2nd_degree_complement_of_bounded_interval.rs
@@ -23,6 +23,6 @@ fuzz_target!(|bounded_interval: BoundedAbsoluteInterval| {
 
     assert_eq!(
         abridgment_2nd_degree_complements,
-        EmptiableAbsoluteInterval::from(bounded_interval)
+        bounded_interval.to_emptiable_interval()
     );
 });

--- a/src/intervals.rs
+++ b/src/intervals.rs
@@ -107,7 +107,7 @@
 //! );
 //!
 //! // ..For creating an interval
-//! let second_interval = AbsoluteInterval::from(bounds_for_second_interval);
+//! let second_interval = bounds_for_second_interval.to_interval();
 //! # Ok::<(), Box<dyn Error>>(())
 //! ```
 

--- a/src/intervals/absolute.rs
+++ b/src/intervals/absolute.rs
@@ -87,7 +87,7 @@ pub fn swap_absolute_bound_pair(start: &mut AbsoluteStartBound, end: &mut Absolu
     match (&mut *start, &mut *end) {
         (AbsoluteStartBound::InfinitePast, AbsoluteEndBound::InfiniteFuture) => {},
         (AbsoluteStartBound::InfinitePast, AbsoluteEndBound::Finite(finite_end)) => {
-            *start = AbsoluteStartBound::Finite(*finite_end);
+            *start = finite_end.to_start_bound();
             *end = AbsoluteEndBound::InfiniteFuture;
         },
         (AbsoluteStartBound::Finite(finite_start), AbsoluteEndBound::InfiniteFuture) => {

--- a/src/intervals/absolute.rs
+++ b/src/intervals/absolute.rs
@@ -91,7 +91,7 @@ pub fn swap_absolute_bound_pair(start: &mut AbsoluteStartBound, end: &mut Absolu
             *end = AbsoluteEndBound::InfiniteFuture;
         },
         (AbsoluteStartBound::Finite(finite_start), AbsoluteEndBound::InfiniteFuture) => {
-            *end = AbsoluteEndBound::Finite(*finite_start);
+            *end = finite_start.to_end_bound();
             *start = AbsoluteStartBound::InfinitePast;
         },
         (AbsoluteStartBound::Finite(finite_start), AbsoluteEndBound::Finite(finite_end)) => {

--- a/src/intervals/absolute/bound.rs
+++ b/src/intervals/absolute/bound.rs
@@ -39,8 +39,10 @@ impl AbsoluteBound {
     /// let start_time = "2025-01-01 08:00:00Z".parse::<Timestamp>()?;
     /// let end_time = "2025-01-01 16:00:00Z".parse::<Timestamp>()?;
     ///
-    /// let start = AbsoluteBound::Start(AbsoluteFiniteBound::new(start_time).to_start_bound());
-    /// let end = AbsoluteBound::End(AbsoluteFiniteBound::new(end_time).to_end_bound());
+    /// let start = AbsoluteFiniteBound::new(start_time)
+    ///     .to_start_bound()
+    ///     .to_bound();
+    /// let end = AbsoluteFiniteBound::new(end_time).to_end_bound().to_bound();
     ///
     /// assert!(start.is_start());
     /// assert!(!end.is_start());
@@ -62,8 +64,10 @@ impl AbsoluteBound {
     /// let start_time = "2025-01-01 08:00:00Z".parse::<Timestamp>()?;
     /// let end_time = "2025-01-01 16:00:00Z".parse::<Timestamp>()?;
     ///
-    /// let start = AbsoluteBound::Start(AbsoluteFiniteBound::new(start_time).to_start_bound());
-    /// let end = AbsoluteBound::End(AbsoluteFiniteBound::new(end_time).to_end_bound());
+    /// let start = AbsoluteFiniteBound::new(start_time)
+    ///     .to_start_bound()
+    ///     .to_bound();
+    /// let end = AbsoluteFiniteBound::new(end_time).to_end_bound().to_bound();
     ///
     /// assert!(end.is_end());
     /// assert!(!start.is_end());
@@ -91,8 +95,10 @@ impl AbsoluteBound {
     /// let start_time = "2025-01-01 08:00:00Z".parse::<Timestamp>()?;
     /// let end_time = "2025-01-01 16:00:00Z".parse::<Timestamp>()?;
     ///
-    /// let start = AbsoluteBound::Start(AbsoluteFiniteBound::new(start_time).to_start_bound());
-    /// let end = AbsoluteBound::End(AbsoluteFiniteBound::new(end_time).to_end_bound());
+    /// let start = AbsoluteFiniteBound::new(start_time)
+    ///     .to_start_bound()
+    ///     .to_bound();
+    /// let end = AbsoluteFiniteBound::new(end_time).to_end_bound().to_bound();
     ///
     /// assert_eq!(
     ///     start.start(),
@@ -126,8 +132,10 @@ impl AbsoluteBound {
     /// let start_time = "2025-01-01 08:00:00Z".parse::<Timestamp>()?;
     /// let end_time = "2025-01-01 16:00:00Z".parse::<Timestamp>()?;
     ///
-    /// let start = AbsoluteBound::Start(AbsoluteFiniteBound::new(start_time).to_start_bound());
-    /// let end = AbsoluteBound::End(AbsoluteFiniteBound::new(end_time).to_end_bound());
+    /// let start = AbsoluteFiniteBound::new(start_time)
+    ///     .to_start_bound()
+    ///     .to_bound();
+    /// let end = AbsoluteFiniteBound::new(end_time).to_end_bound().to_bound();
     ///
     /// assert_eq!(
     ///     end.end(),

--- a/src/intervals/absolute/bound_pair.rs
+++ b/src/intervals/absolute/bound_pair.rs
@@ -176,12 +176,6 @@ impl AbsoluteBoundPair {
         )
     }
 
-    /// Wraps the [`AbsoluteBoundPair`] in an [`EmptiableAbsoluteBoundPair`]
-    #[must_use]
-    pub fn to_emptiable(self) -> EmptiableAbsoluteBoundPair {
-        EmptiableAbsoluteBoundPair::from(self)
-    }
-
     /// Returns the absolute start bound
     ///
     /// # Examples
@@ -394,6 +388,24 @@ impl AbsoluteBoundPair {
             Ordering::Equal => self.end.cmp(&other.end).reverse(),
             Ordering::Greater => Ordering::Greater,
         }
+    }
+
+    /// Converts the [`AbsoluteBoundPair`] into [`AbsoluteInterval`]
+    #[must_use]
+    pub fn to_interval(self) -> AbsoluteInterval {
+        AbsoluteInterval::from(self)
+    }
+
+    /// Converts the [`AbsoluteBoundPair`] into [`EmptiableAbsoluteInterval`]
+    #[must_use]
+    pub fn to_emptiable_interval(self) -> EmptiableAbsoluteInterval {
+        self.to_interval().to_emptiable()
+    }
+
+    /// Wraps the [`AbsoluteBoundPair`] in an [`EmptiableAbsoluteBoundPair`]
+    #[must_use]
+    pub fn to_emptiable(self) -> EmptiableAbsoluteBoundPair {
+        EmptiableAbsoluteBoundPair::from(self)
     }
 }
 

--- a/src/intervals/absolute/bounded_interval_tests.rs
+++ b/src/intervals/absolute/bounded_interval_tests.rs
@@ -281,10 +281,11 @@ fn interval_from_range_inclusive() -> Result<(), Box<dyn Error>> {
 fn interval_try_from_absolute_bounds_correct() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         BoundedAbsoluteInterval::try_from(AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-01 00:00:00Z".parse::<Timestamp>()?,
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00Z".parse::<Timestamp>()?,
                 BoundInclusivity::Inclusive,
@@ -312,7 +313,7 @@ fn interval_try_from_absolute_bounds_wrong() -> Result<(), Box<dyn Error>> {
     );
     assert_eq!(
         BoundedAbsoluteInterval::try_from(AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?)),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?).to_start_bound(),
             AbsoluteEndBound::InfiniteFuture,
         )),
         Err(BoundedAbsoluteIntervalTryFromAbsoluteBoundPairError),

--- a/src/intervals/absolute/bounded_interval_tests.rs
+++ b/src/intervals/absolute/bounded_interval_tests.rs
@@ -286,10 +286,11 @@ fn interval_try_from_absolute_bounds_correct() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Exclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00Z".parse::<Timestamp>()?,
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_end_bound(),
         )),
         Ok(BoundedAbsoluteInterval::new_with_inclusivity(
             "2025-01-01 00:00:00Z".parse::<Timestamp>()?,
@@ -307,7 +308,7 @@ fn interval_try_from_absolute_bounds_wrong() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         BoundedAbsoluteInterval::try_from(AbsoluteBoundPair::new(
             AbsoluteStartBound::InfinitePast,
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?)),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?).to_end_bound(),
         )),
         Err(BoundedAbsoluteIntervalTryFromAbsoluteBoundPairError),
     );

--- a/src/intervals/absolute/emptiable_bound_pair.rs
+++ b/src/intervals/absolute/emptiable_bound_pair.rs
@@ -120,6 +120,36 @@ impl EmptiableAbsoluteBoundPair {
         AbsoluteBoundPair::from_range(range).to_emptiable()
     }
 
+    /// Compares two [`EmptiableAbsoluteBoundPair`], but if they have the same
+    /// start, order by decreasing length
+    ///
+    /// Uses [`AbsoluteBoundPair::ord_by_start_and_inv_length`] under the hood
+    /// for the [`Bound`](EmptiableAbsoluteBoundPair::Bound) variants and
+    /// [`EmptiableAbsoluteBoundPair::cmp`]
+    /// for the [`Empty`](EmptiableAbsoluteBoundPair::Empty) variants (which
+    /// will just place all empty bounds before any bound bounds).
+    ///
+    /// Don't rely on this method for checking for equality of start, as it will
+    /// produce other [`Ordering`]s if their lengths don't match too.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use periodical::intervals::absolute::EmptiableAbsoluteBoundPair;
+    /// # let mut bounds: [EmptiableAbsoluteBoundPair; 0] = [];
+    /// bounds.sort_by(EmptiableAbsoluteBoundPair::ord_by_start_and_inv_length);
+    /// ```
+    #[must_use]
+    pub fn ord_by_start_and_inv_length(&self, other: &Self) -> Ordering {
+        match (self, other) {
+            (
+                EmptiableAbsoluteBoundPair::Bound(og_abs_bound_pair),
+                EmptiableAbsoluteBoundPair::Bound(other_abs_bound_pair),
+            ) => og_abs_bound_pair.ord_by_start_and_inv_length(other_abs_bound_pair),
+            _ => self.cmp(other),
+        }
+    }
+
     /// Returns the content of the [`Bound`](EmptiableAbsoluteBoundPair::Bound)
     /// variant
     ///
@@ -153,34 +183,10 @@ impl EmptiableAbsoluteBoundPair {
         }
     }
 
-    /// Compares two [`EmptiableAbsoluteBoundPair`], but if they have the same
-    /// start, order by decreasing length
-    ///
-    /// Uses [`AbsoluteBoundPair::ord_by_start_and_inv_length`] under the hood
-    /// for the [`Bound`](EmptiableAbsoluteBoundPair::Bound) variants and
-    /// [`EmptiableAbsoluteBoundPair::cmp`]
-    /// for the [`Empty`](EmptiableAbsoluteBoundPair::Empty) variants (which
-    /// will just place all empty bounds before any bound bounds).
-    ///
-    /// Don't rely on this method for checking for equality of start, as it will
-    /// produce other [`Ordering`]s if their lengths don't match too.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use periodical::intervals::absolute::EmptiableAbsoluteBoundPair;
-    /// # let mut bounds: [EmptiableAbsoluteBoundPair; 0] = [];
-    /// bounds.sort_by(EmptiableAbsoluteBoundPair::ord_by_start_and_inv_length);
-    /// ```
+    /// Converts the [`EmptiableAbsoluteBoundPair`] into [`EmptiableAbsoluteInterval`]
     #[must_use]
-    pub fn ord_by_start_and_inv_length(&self, other: &Self) -> Ordering {
-        match (self, other) {
-            (
-                EmptiableAbsoluteBoundPair::Bound(og_abs_bound_pair),
-                EmptiableAbsoluteBoundPair::Bound(other_abs_bound_pair),
-            ) => og_abs_bound_pair.ord_by_start_and_inv_length(other_abs_bound_pair),
-            _ => self.cmp(other),
-        }
+    pub fn to_emptiable_interval(self) -> EmptiableAbsoluteInterval {
+        EmptiableAbsoluteInterval::from(self)
     }
 }
 

--- a/src/intervals/absolute/emptiable_interval_tests.rs
+++ b/src/intervals/absolute/emptiable_interval_tests.rs
@@ -8,7 +8,6 @@ use crate::intervals::absolute::{
     AbsoluteEndBound,
     AbsoluteFiniteBound,
     AbsoluteInterval,
-    AbsoluteStartBound,
     BoundedAbsoluteInterval,
     EmptiableAbsoluteBoundPair,
     HalfBoundedAbsoluteInterval,
@@ -20,10 +19,11 @@ use crate::intervals::special::{EmptyInterval, UnboundedInterval};
 fn from_absolute_bounds() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         EmptiableAbsoluteInterval::from(AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-01 00:00:00Z".parse::<Timestamp>()?,
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::InfiniteFuture,
         )),
         EmptiableAbsoluteInterval::Bound(AbsoluteInterval::HalfBounded(
@@ -42,10 +42,11 @@ fn from_absolute_bounds() -> Result<(), Box<dyn Error>> {
 fn from_emptiable_absolute_bounds() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         EmptiableAbsoluteInterval::from(EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-01 00:00:00Z".parse::<Timestamp>()?,
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::InfiniteFuture,
         ))),
         EmptiableAbsoluteInterval::Bound(AbsoluteInterval::HalfBounded(

--- a/src/intervals/absolute/end_bound.rs
+++ b/src/intervals/absolute/end_bound.rs
@@ -284,14 +284,14 @@ impl From<Option<(Timestamp, BoundInclusivity)>> for AbsoluteEndBound {
 impl From<Bound<Timestamp>> for AbsoluteEndBound {
     fn from(bound: Bound<Timestamp>) -> Self {
         match bound {
-            Bound::Included(time) => AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            Bound::Included(time) => AbsoluteFiniteBound::new_with_inclusivity(
                 time,
                 BoundInclusivity::Inclusive,
-            )),
-            Bound::Excluded(time) => AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            ).to_end_bound(),
+            Bound::Excluded(time) => AbsoluteFiniteBound::new_with_inclusivity(
                 time,
                 BoundInclusivity::Exclusive,
-            )),
+            ).to_end_bound(),
             Bound::Unbounded => AbsoluteEndBound::InfiniteFuture,
         }
     }

--- a/src/intervals/absolute/end_bound.rs
+++ b/src/intervals/absolute/end_bound.rs
@@ -284,14 +284,12 @@ impl From<Option<(Timestamp, BoundInclusivity)>> for AbsoluteEndBound {
 impl From<Bound<Timestamp>> for AbsoluteEndBound {
     fn from(bound: Bound<Timestamp>) -> Self {
         match bound {
-            Bound::Included(time) => AbsoluteFiniteBound::new_with_inclusivity(
-                time,
-                BoundInclusivity::Inclusive,
-            ).to_end_bound(),
-            Bound::Excluded(time) => AbsoluteFiniteBound::new_with_inclusivity(
-                time,
-                BoundInclusivity::Exclusive,
-            ).to_end_bound(),
+            Bound::Included(time) => {
+                AbsoluteFiniteBound::new_with_inclusivity(time, BoundInclusivity::Inclusive).to_end_bound()
+            },
+            Bound::Excluded(time) => {
+                AbsoluteFiniteBound::new_with_inclusivity(time, BoundInclusivity::Exclusive).to_end_bound()
+            },
             Bound::Unbounded => AbsoluteEndBound::InfiniteFuture,
         }
     }

--- a/src/intervals/absolute/half_bounded_interval_tests.rs
+++ b/src/intervals/absolute/half_bounded_interval_tests.rs
@@ -175,10 +175,11 @@ fn from_range_to_inclusive() -> Result<(), Box<dyn Error>> {
 fn try_from_absolute_bounds_correct() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         HalfBoundedAbsoluteInterval::try_from(AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-01 00:00:00Z".parse::<Timestamp>()?,
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::InfiniteFuture,
         )),
         Ok(HalfBoundedAbsoluteInterval::new_with_inclusivity(
@@ -216,7 +217,7 @@ fn try_from_absolute_bounds_wrong() -> Result<(), Box<dyn Error>> {
     );
     assert_eq!(
         HalfBoundedAbsoluteInterval::try_from(AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?)),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new("2025-01-02 00:00:00Z".parse::<Timestamp>()?)),
         )),
         Err(HalfBoundedAbsoluteIntervalTryFromAbsoluteBoundPairError),

--- a/src/intervals/absolute/half_bounded_interval_tests.rs
+++ b/src/intervals/absolute/half_bounded_interval_tests.rs
@@ -191,10 +191,11 @@ fn try_from_absolute_bounds_correct() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         HalfBoundedAbsoluteInterval::try_from(AbsoluteBoundPair::new(
             AbsoluteStartBound::InfinitePast,
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-01 00:00:00Z".parse::<Timestamp>()?,
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         )),
         Ok(HalfBoundedAbsoluteInterval::new_with_inclusivity(
             "2025-01-01 00:00:00Z".parse::<Timestamp>()?,
@@ -218,7 +219,7 @@ fn try_from_absolute_bounds_wrong() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         HalfBoundedAbsoluteInterval::try_from(AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new("2025-01-02 00:00:00Z".parse::<Timestamp>()?)),
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00Z".parse::<Timestamp>()?).to_end_bound(),
         )),
         Err(HalfBoundedAbsoluteIntervalTryFromAbsoluteBoundPairError),
     );

--- a/src/intervals/absolute/interval_tests.rs
+++ b/src/intervals/absolute/interval_tests.rs
@@ -7,7 +7,6 @@ use crate::intervals::absolute::{
     AbsoluteBoundPair,
     AbsoluteEndBound,
     AbsoluteFiniteBound,
-    AbsoluteStartBound,
     BoundedAbsoluteInterval,
     HalfBoundedAbsoluteInterval,
 };
@@ -18,10 +17,11 @@ use crate::intervals::special::UnboundedInterval;
 fn from_absolute_bounds() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteInterval::from(AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-01 00:00:00Z".parse::<Timestamp>()?,
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::InfiniteFuture,
         )),
         AbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new_with_inclusivity(

--- a/src/intervals/absolute/start_bound.rs
+++ b/src/intervals/absolute/start_bound.rs
@@ -302,14 +302,12 @@ impl From<Option<(Timestamp, BoundInclusivity)>> for AbsoluteStartBound {
 impl From<Bound<Timestamp>> for AbsoluteStartBound {
     fn from(bound: Bound<Timestamp>) -> Self {
         match bound {
-            Bound::Included(time) => AbsoluteFiniteBound::new_with_inclusivity(
-                time,
-                BoundInclusivity::Inclusive,
-            ).to_start_bound(),
-            Bound::Excluded(time) => AbsoluteFiniteBound::new_with_inclusivity(
-                time,
-                BoundInclusivity::Exclusive,
-            ).to_start_bound(),
+            Bound::Included(time) => {
+                AbsoluteFiniteBound::new_with_inclusivity(time, BoundInclusivity::Inclusive).to_start_bound()
+            },
+            Bound::Excluded(time) => {
+                AbsoluteFiniteBound::new_with_inclusivity(time, BoundInclusivity::Exclusive).to_start_bound()
+            },
             Bound::Unbounded => AbsoluteStartBound::InfinitePast,
         }
     }

--- a/src/intervals/absolute/start_bound.rs
+++ b/src/intervals/absolute/start_bound.rs
@@ -302,14 +302,14 @@ impl From<Option<(Timestamp, BoundInclusivity)>> for AbsoluteStartBound {
 impl From<Bound<Timestamp>> for AbsoluteStartBound {
     fn from(bound: Bound<Timestamp>) -> Self {
         match bound {
-            Bound::Included(time) => AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            Bound::Included(time) => AbsoluteFiniteBound::new_with_inclusivity(
                 time,
                 BoundInclusivity::Inclusive,
-            )),
-            Bound::Excluded(time) => AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            ).to_start_bound(),
+            Bound::Excluded(time) => AbsoluteFiniteBound::new_with_inclusivity(
                 time,
                 BoundInclusivity::Exclusive,
-            )),
+            ).to_start_bound(),
             Bound::Unbounded => AbsoluteStartBound::InfinitePast,
         }
     }

--- a/src/intervals/absolute/start_bound_tests.rs
+++ b/src/intervals/absolute/start_bound_tests.rs
@@ -56,10 +56,13 @@ fn opposite_finite() -> Result<(), Box<dyn Error>> {
         AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?)
             .to_start_bound()
             .opposite(),
-        Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-            "2025-01-01 00:00:00Z".parse::<Timestamp>()?,
-            BoundInclusivity::Exclusive,
-        ))),
+        Some(
+            AbsoluteFiniteBound::new_with_inclusivity(
+                "2025-01-01 00:00:00Z".parse::<Timestamp>()?,
+                BoundInclusivity::Exclusive,
+            )
+            .to_end_bound()
+        ),
     );
     Ok(())
 }

--- a/src/intervals/absolute/start_bound_tests.rs
+++ b/src/intervals/absolute/start_bound_tests.rs
@@ -53,7 +53,9 @@ fn finite() -> Result<(), Box<dyn Error>> {
 #[test]
 fn opposite_finite() -> Result<(), Box<dyn Error>> {
     assert_eq!(
-        AbsoluteStartBound::Finite(AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?)).opposite(),
+        AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?)
+            .to_start_bound()
+            .opposite(),
         Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
             "2025-01-01 00:00:00Z".parse::<Timestamp>()?,
             BoundInclusivity::Exclusive,

--- a/src/intervals/absolute_tests.rs
+++ b/src/intervals/absolute_tests.rs
@@ -19,10 +19,11 @@ fn absolute_start_bound_inf_absolute_end_bound_inf_swap() {
 #[test]
 fn absolute_start_bound_inf_absolute_end_bound_finite_swap() -> Result<(), Box<dyn Error>> {
     let mut start = AbsoluteStartBound::InfinitePast;
-    let mut end = AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+    let mut end = AbsoluteFiniteBound::new_with_inclusivity(
         "2025-01-01 00:00:00Z".parse::<Timestamp>()?,
         BoundInclusivity::Exclusive,
-    ));
+    )
+    .to_end_bound();
 
     swap_absolute_bound_pair(&mut start, &mut end);
 
@@ -53,10 +54,11 @@ fn absolute_start_bound_finite_absolute_end_bound_inf_swap() -> Result<(), Box<d
     assert_eq!(start, AbsoluteStartBound::InfinitePast);
     assert_eq!(
         end,
-        AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+        AbsoluteFiniteBound::new_with_inclusivity(
             "2025-01-01 00:00:00Z".parse::<Timestamp>()?,
             BoundInclusivity::Exclusive,
-        ))
+        )
+        .to_end_bound()
     );
 
     Ok(())
@@ -69,10 +71,11 @@ fn absolute_start_bound_finite_absolute_end_bound_finite_swap() -> Result<(), Bo
         BoundInclusivity::Exclusive,
     )
     .to_start_bound();
-    let mut end = AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+    let mut end = AbsoluteFiniteBound::new_with_inclusivity(
         "2025-01-02 00:00:00Z".parse::<Timestamp>()?,
         BoundInclusivity::Inclusive,
-    ));
+    )
+    .to_end_bound();
 
     swap_absolute_bound_pair(&mut start, &mut end);
 
@@ -86,10 +89,11 @@ fn absolute_start_bound_finite_absolute_end_bound_finite_swap() -> Result<(), Bo
     );
     assert_eq!(
         end,
-        AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+        AbsoluteFiniteBound::new_with_inclusivity(
             "2025-01-01 00:00:00Z".parse::<Timestamp>()?,
             BoundInclusivity::Exclusive,
-        ))
+        )
+        .to_end_bound()
     );
 
     Ok(())
@@ -111,7 +115,7 @@ fn check_absolute_bound_pair_for_interval_creation_inf_past_finite() -> Result<(
     assert_eq!(
         check_absolute_bound_pair_for_interval_creation(
             &AbsoluteStartBound::InfinitePast,
-            &AbsoluteEndBound::Finite(AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?)),
+            &AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?).to_end_bound(),
         ),
         Ok(()),
     );
@@ -138,7 +142,7 @@ fn check_absolute_bound_pair_for_interval_creation_finite_finite_different_times
     assert_eq!(
         check_absolute_bound_pair_for_interval_creation(
             &AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?).to_start_bound(),
-            &AbsoluteEndBound::Finite(AbsoluteFiniteBound::new("2025-01-02 00:00:00Z".parse::<Timestamp>()?)),
+            &AbsoluteFiniteBound::new("2025-01-02 00:00:00Z".parse::<Timestamp>()?).to_end_bound(),
         ),
         Ok(()),
     );
@@ -152,7 +156,7 @@ fn check_absolute_bound_pair_for_interval_creation_finite_finite_different_times
     assert_eq!(
         check_absolute_bound_pair_for_interval_creation(
             &AbsoluteFiniteBound::new("2025-01-02 00:00:00Z".parse::<Timestamp>()?).to_start_bound(),
-            &AbsoluteEndBound::Finite(AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?)),
+            &AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?).to_end_bound(),
         ),
         Err(AbsoluteBoundPairCheckForIntervalCreationError::StartPastEnd),
     );
@@ -166,7 +170,7 @@ fn check_absolute_bound_pair_for_interval_creation_finite_finite_same_time_inclu
     assert_eq!(
         check_absolute_bound_pair_for_interval_creation(
             &AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?).to_start_bound(),
-            &AbsoluteEndBound::Finite(AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?)),
+            &AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?).to_end_bound(),
         ),
         Ok(()),
     );
@@ -180,10 +184,11 @@ fn check_absolute_bound_pair_for_interval_creation_finite_finite_same_time_inclu
     assert_eq!(
         check_absolute_bound_pair_for_interval_creation(
             &AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?).to_start_bound(),
-            &AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            &AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-01 00:00:00Z".parse::<Timestamp>()?,
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         ),
         Err(AbsoluteBoundPairCheckForIntervalCreationError::SameTimeButNotDoublyInclusive),
     );
@@ -206,7 +211,7 @@ fn prepare_absolute_bound_pair_for_interval_creation_inf_past_inf_future() {
 #[test]
 fn prepare_absolute_bound_pair_for_interval_creation_inf_past_finite() -> Result<(), Box<dyn Error>> {
     let mut start = AbsoluteStartBound::InfinitePast;
-    let mut end = AbsoluteEndBound::Finite(AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?));
+    let mut end = AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?).to_end_bound();
 
     let was_changed = prepare_absolute_bound_pair_for_interval_creation(&mut start, &mut end);
 
@@ -214,7 +219,7 @@ fn prepare_absolute_bound_pair_for_interval_creation_inf_past_finite() -> Result
     assert_eq!(start, AbsoluteStartBound::InfinitePast);
     assert_eq!(
         end,
-        AbsoluteEndBound::Finite(AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?))
+        AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?).to_end_bound()
     );
 
     Ok(())
@@ -241,7 +246,7 @@ fn prepare_absolute_bound_pair_for_interval_creation_finite_inf_future() -> Resu
 fn prepare_absolute_bound_pair_for_interval_creation_finite_finite_different_times_correct_order()
 -> Result<(), Box<dyn Error>> {
     let mut start = AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?).to_start_bound();
-    let mut end = AbsoluteEndBound::Finite(AbsoluteFiniteBound::new("2025-01-02 00:00:00Z".parse::<Timestamp>()?));
+    let mut end = AbsoluteFiniteBound::new("2025-01-02 00:00:00Z".parse::<Timestamp>()?).to_end_bound();
 
     let was_changed = prepare_absolute_bound_pair_for_interval_creation(&mut start, &mut end);
 
@@ -252,7 +257,7 @@ fn prepare_absolute_bound_pair_for_interval_creation_finite_finite_different_tim
     );
     assert_eq!(
         end,
-        AbsoluteEndBound::Finite(AbsoluteFiniteBound::new("2025-01-02 00:00:00Z".parse::<Timestamp>()?))
+        AbsoluteFiniteBound::new("2025-01-02 00:00:00Z".parse::<Timestamp>()?).to_end_bound()
     );
 
     Ok(())
@@ -262,14 +267,14 @@ fn prepare_absolute_bound_pair_for_interval_creation_finite_finite_different_tim
 fn prepare_absolute_bound_pair_for_interval_creation_finite_finite_different_times_wrong_order()
 -> Result<(), Box<dyn Error>> {
     let mut start = AbsoluteFiniteBound::new("2025-01-02 00:00:00Z".parse::<Timestamp>()?).to_start_bound();
-    let mut end = AbsoluteEndBound::Finite(AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?));
+    let mut end = AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?).to_end_bound();
 
     let was_changed = prepare_absolute_bound_pair_for_interval_creation(&mut start, &mut end);
 
     assert!(was_changed);
     assert_eq!(
         start,
-        AbsoluteEndBound::Finite(AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?))
+        AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?).to_end_bound()
     );
     assert_eq!(
         end,
@@ -283,7 +288,7 @@ fn prepare_absolute_bound_pair_for_interval_creation_finite_finite_different_tim
 fn prepare_absolute_bound_pair_for_interval_creation_finite_finite_same_time_inclusive_inclusive()
 -> Result<(), Box<dyn Error>> {
     let mut start = AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?).to_start_bound();
-    let mut end = AbsoluteEndBound::Finite(AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?));
+    let mut end = AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?).to_end_bound();
 
     let was_changed = prepare_absolute_bound_pair_for_interval_creation(&mut start, &mut end);
 
@@ -294,7 +299,7 @@ fn prepare_absolute_bound_pair_for_interval_creation_finite_finite_same_time_inc
     );
     assert_eq!(
         end,
-        AbsoluteEndBound::Finite(AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?))
+        AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?).to_end_bound()
     );
 
     Ok(())
@@ -304,10 +309,11 @@ fn prepare_absolute_bound_pair_for_interval_creation_finite_finite_same_time_inc
 fn prepare_absolute_bound_pair_for_interval_creation_finite_finite_same_time_inclusive_exclusive()
 -> Result<(), Box<dyn Error>> {
     let mut start = AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?).to_start_bound();
-    let mut end = AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+    let mut end = AbsoluteFiniteBound::new_with_inclusivity(
         "2025-01-01 00:00:00Z".parse::<Timestamp>()?,
         BoundInclusivity::Exclusive,
-    ));
+    )
+    .to_end_bound();
 
     let was_changed = prepare_absolute_bound_pair_for_interval_creation(&mut start, &mut end);
 

--- a/src/intervals/absolute_tests.rs
+++ b/src/intervals/absolute_tests.rs
@@ -28,10 +28,11 @@ fn absolute_start_bound_inf_absolute_end_bound_finite_swap() -> Result<(), Box<d
 
     assert_eq!(
         start,
-        AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+        AbsoluteFiniteBound::new_with_inclusivity(
             "2025-01-01 00:00:00Z".parse::<Timestamp>()?,
             BoundInclusivity::Exclusive,
-        ))
+        )
+        .to_start_bound()
     );
     assert_eq!(end, AbsoluteEndBound::InfiniteFuture);
 
@@ -40,10 +41,11 @@ fn absolute_start_bound_inf_absolute_end_bound_finite_swap() -> Result<(), Box<d
 
 #[test]
 fn absolute_start_bound_finite_absolute_end_bound_inf_swap() -> Result<(), Box<dyn Error>> {
-    let mut start = AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+    let mut start = AbsoluteFiniteBound::new_with_inclusivity(
         "2025-01-01 00:00:00Z".parse::<Timestamp>()?,
         BoundInclusivity::Exclusive,
-    ));
+    )
+    .to_start_bound();
     let mut end = AbsoluteEndBound::InfiniteFuture;
 
     swap_absolute_bound_pair(&mut start, &mut end);
@@ -62,10 +64,11 @@ fn absolute_start_bound_finite_absolute_end_bound_inf_swap() -> Result<(), Box<d
 
 #[test]
 fn absolute_start_bound_finite_absolute_end_bound_finite_swap() -> Result<(), Box<dyn Error>> {
-    let mut start = AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+    let mut start = AbsoluteFiniteBound::new_with_inclusivity(
         "2025-01-01 00:00:00Z".parse::<Timestamp>()?,
         BoundInclusivity::Exclusive,
-    ));
+    )
+    .to_start_bound();
     let mut end = AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
         "2025-01-02 00:00:00Z".parse::<Timestamp>()?,
         BoundInclusivity::Inclusive,
@@ -75,10 +78,11 @@ fn absolute_start_bound_finite_absolute_end_bound_finite_swap() -> Result<(), Bo
 
     assert_eq!(
         start,
-        AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+        AbsoluteFiniteBound::new_with_inclusivity(
             "2025-01-02 00:00:00Z".parse::<Timestamp>()?,
             BoundInclusivity::Inclusive,
-        ))
+        )
+        .to_start_bound()
     );
     assert_eq!(
         end,
@@ -119,7 +123,7 @@ fn check_absolute_bound_pair_for_interval_creation_inf_past_finite() -> Result<(
 fn check_absolute_bound_pair_for_interval_creation_finite_inf_future() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         check_absolute_bound_pair_for_interval_creation(
-            &AbsoluteStartBound::Finite(AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?)),
+            &AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?).to_start_bound(),
             &AbsoluteEndBound::InfiniteFuture,
         ),
         Ok(()),
@@ -133,7 +137,7 @@ fn check_absolute_bound_pair_for_interval_creation_finite_finite_different_times
 -> Result<(), Box<dyn Error>> {
     assert_eq!(
         check_absolute_bound_pair_for_interval_creation(
-            &AbsoluteStartBound::Finite(AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?)),
+            &AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?).to_start_bound(),
             &AbsoluteEndBound::Finite(AbsoluteFiniteBound::new("2025-01-02 00:00:00Z".parse::<Timestamp>()?)),
         ),
         Ok(()),
@@ -147,7 +151,7 @@ fn check_absolute_bound_pair_for_interval_creation_finite_finite_different_times
 -> Result<(), Box<dyn Error>> {
     assert_eq!(
         check_absolute_bound_pair_for_interval_creation(
-            &AbsoluteStartBound::Finite(AbsoluteFiniteBound::new("2025-01-02 00:00:00Z".parse::<Timestamp>()?)),
+            &AbsoluteFiniteBound::new("2025-01-02 00:00:00Z".parse::<Timestamp>()?).to_start_bound(),
             &AbsoluteEndBound::Finite(AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?)),
         ),
         Err(AbsoluteBoundPairCheckForIntervalCreationError::StartPastEnd),
@@ -161,7 +165,7 @@ fn check_absolute_bound_pair_for_interval_creation_finite_finite_same_time_inclu
 -> Result<(), Box<dyn Error>> {
     assert_eq!(
         check_absolute_bound_pair_for_interval_creation(
-            &AbsoluteStartBound::Finite(AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?)),
+            &AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?).to_start_bound(),
             &AbsoluteEndBound::Finite(AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?)),
         ),
         Ok(()),
@@ -175,7 +179,7 @@ fn check_absolute_bound_pair_for_interval_creation_finite_finite_same_time_inclu
 -> Result<(), Box<dyn Error>> {
     assert_eq!(
         check_absolute_bound_pair_for_interval_creation(
-            &AbsoluteStartBound::Finite(AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?)),
+            &AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?).to_start_bound(),
             &AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-01 00:00:00Z".parse::<Timestamp>()?,
                 BoundInclusivity::Exclusive,
@@ -218,7 +222,7 @@ fn prepare_absolute_bound_pair_for_interval_creation_inf_past_finite() -> Result
 
 #[test]
 fn prepare_absolute_bound_pair_for_interval_creation_finite_inf_future() -> Result<(), Box<dyn Error>> {
-    let mut start = AbsoluteStartBound::Finite(AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?));
+    let mut start = AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?).to_start_bound();
     let mut end = AbsoluteEndBound::InfiniteFuture;
 
     let was_changed = prepare_absolute_bound_pair_for_interval_creation(&mut start, &mut end);
@@ -226,7 +230,7 @@ fn prepare_absolute_bound_pair_for_interval_creation_finite_inf_future() -> Resu
     assert!(!was_changed);
     assert_eq!(
         start,
-        AbsoluteStartBound::Finite(AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?))
+        AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?).to_start_bound()
     );
     assert_eq!(end, AbsoluteEndBound::InfiniteFuture);
 
@@ -236,7 +240,7 @@ fn prepare_absolute_bound_pair_for_interval_creation_finite_inf_future() -> Resu
 #[test]
 fn prepare_absolute_bound_pair_for_interval_creation_finite_finite_different_times_correct_order()
 -> Result<(), Box<dyn Error>> {
-    let mut start = AbsoluteStartBound::Finite(AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?));
+    let mut start = AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?).to_start_bound();
     let mut end = AbsoluteEndBound::Finite(AbsoluteFiniteBound::new("2025-01-02 00:00:00Z".parse::<Timestamp>()?));
 
     let was_changed = prepare_absolute_bound_pair_for_interval_creation(&mut start, &mut end);
@@ -244,7 +248,7 @@ fn prepare_absolute_bound_pair_for_interval_creation_finite_finite_different_tim
     assert!(!was_changed);
     assert_eq!(
         start,
-        AbsoluteStartBound::Finite(AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?))
+        AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?).to_start_bound()
     );
     assert_eq!(
         end,
@@ -257,7 +261,7 @@ fn prepare_absolute_bound_pair_for_interval_creation_finite_finite_different_tim
 #[test]
 fn prepare_absolute_bound_pair_for_interval_creation_finite_finite_different_times_wrong_order()
 -> Result<(), Box<dyn Error>> {
-    let mut start = AbsoluteStartBound::Finite(AbsoluteFiniteBound::new("2025-01-02 00:00:00Z".parse::<Timestamp>()?));
+    let mut start = AbsoluteFiniteBound::new("2025-01-02 00:00:00Z".parse::<Timestamp>()?).to_start_bound();
     let mut end = AbsoluteEndBound::Finite(AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?));
 
     let was_changed = prepare_absolute_bound_pair_for_interval_creation(&mut start, &mut end);
@@ -269,7 +273,7 @@ fn prepare_absolute_bound_pair_for_interval_creation_finite_finite_different_tim
     );
     assert_eq!(
         end,
-        AbsoluteStartBound::Finite(AbsoluteFiniteBound::new("2025-01-02 00:00:00Z".parse::<Timestamp>()?))
+        AbsoluteFiniteBound::new("2025-01-02 00:00:00Z".parse::<Timestamp>()?).to_start_bound()
     );
 
     Ok(())
@@ -278,7 +282,7 @@ fn prepare_absolute_bound_pair_for_interval_creation_finite_finite_different_tim
 #[test]
 fn prepare_absolute_bound_pair_for_interval_creation_finite_finite_same_time_inclusive_inclusive()
 -> Result<(), Box<dyn Error>> {
-    let mut start = AbsoluteStartBound::Finite(AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?));
+    let mut start = AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?).to_start_bound();
     let mut end = AbsoluteEndBound::Finite(AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?));
 
     let was_changed = prepare_absolute_bound_pair_for_interval_creation(&mut start, &mut end);
@@ -286,7 +290,7 @@ fn prepare_absolute_bound_pair_for_interval_creation_finite_finite_same_time_inc
     assert!(!was_changed);
     assert_eq!(
         start,
-        AbsoluteStartBound::Finite(AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?))
+        AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?).to_start_bound()
     );
     assert_eq!(
         end,
@@ -299,7 +303,7 @@ fn prepare_absolute_bound_pair_for_interval_creation_finite_finite_same_time_inc
 #[test]
 fn prepare_absolute_bound_pair_for_interval_creation_finite_finite_same_time_inclusive_exclusive()
 -> Result<(), Box<dyn Error>> {
-    let mut start = AbsoluteStartBound::Finite(AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?));
+    let mut start = AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?).to_start_bound();
     let mut end = AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
         "2025-01-01 00:00:00Z".parse::<Timestamp>()?,
         BoundInclusivity::Exclusive,
@@ -310,11 +314,11 @@ fn prepare_absolute_bound_pair_for_interval_creation_finite_finite_same_time_inc
     assert!(was_changed);
     assert_eq!(
         start,
-        AbsoluteStartBound::Finite(AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?))
+        AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?).to_start_bound()
     );
     assert_eq!(
         end,
-        AbsoluteStartBound::Finite(AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?))
+        AbsoluteFiniteBound::new("2025-01-01 00:00:00Z".parse::<Timestamp>()?).to_start_bound()
     );
 
     Ok(())

--- a/src/intervals/bound_position_tests.rs
+++ b/src/intervals/bound_position_tests.rs
@@ -42,7 +42,8 @@ fn get_abs_bound_of_start_inside() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         BoundPosition::Start(2).get_abs_bound(data.iter()),
         Some(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new("2025-05-01 00:00:00Z".parse::<Timestamp>()?))
+            AbsoluteFiniteBound::new("2025-05-01 00:00:00Z".parse::<Timestamp>()?)
+                .to_start_bound()
                 .to_bound()
         ),
     );

--- a/src/intervals/ops/abridge_tests.rs
+++ b/src/intervals/ops/abridge_tests.rs
@@ -51,16 +51,13 @@ fn abs_bounds_unbounded_bounded() -> Result<(), Box<dyn Error>> {
             &AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             )
         ),
         EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         )),
     );
 
@@ -112,9 +109,7 @@ fn abs_bounds_two_half_bounded_same_ref_time() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
             AbsoluteStartBound::InfinitePast,
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            ))
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound()
         )
         .abridge(&AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
@@ -122,9 +117,7 @@ fn abs_bounds_two_half_bounded_same_ref_time() -> Result<(), Box<dyn Error>> {
         )),
         EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         )),
     );
 
@@ -136,9 +129,7 @@ fn abs_bounds_two_half_bounded_with_gap() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
             AbsoluteStartBound::InfinitePast,
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         )
         .abridge(&AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
@@ -150,10 +141,11 @@ fn abs_bounds_two_half_bounded_with_gap() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Exclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         )),
     );
 
@@ -185,9 +177,7 @@ fn abs_bounds_bounded_half_bounded_with_gap() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         )
         .abridge(&AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
@@ -199,10 +189,11 @@ fn abs_bounds_bounded_half_bounded_with_gap() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Exclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         )),
     );
 
@@ -214,15 +205,11 @@ fn abs_bounds_two_bounded_with_gap() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         )
         .abridge(&AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         )),
         EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new_with_inclusivity(
@@ -230,10 +217,11 @@ fn abs_bounds_two_bounded_with_gap() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Exclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound()
         )),
     );
 
@@ -245,21 +233,15 @@ fn abs_bounds_two_bounded_overlapping() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         )
         .abridge(&AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         )),
         EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         )),
     );
 
@@ -297,9 +279,7 @@ fn abs_bounds_abs_bounds_adjacent_inclusive_inclusive() -> Result<(), Box<dyn Er
     assert_eq!(
         AbsoluteBoundPair::new(
             AbsoluteStartBound::InfinitePast,
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         )
         .abridge(&AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
@@ -307,9 +287,7 @@ fn abs_bounds_abs_bounds_adjacent_inclusive_inclusive() -> Result<(), Box<dyn Er
         )),
         EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         )),
     );
 
@@ -321,9 +299,7 @@ fn abs_bounds_abs_bounds_adjacent_inclusive_exclusive() -> Result<(), Box<dyn Er
     assert_eq!(
         AbsoluteBoundPair::new(
             AbsoluteStartBound::InfinitePast,
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         )
         .abridge(&AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new_with_inclusivity(
@@ -344,10 +320,11 @@ fn abs_bounds_abs_bounds_adjacent_exclusive_inclusive() -> Result<(), Box<dyn Er
     assert_eq!(
         AbsoluteBoundPair::new(
             AbsoluteStartBound::InfinitePast,
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         )
         .abridge(&AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
@@ -364,10 +341,11 @@ fn abs_bounds_abs_bounds_adjacent_exclusive_exclusive() -> Result<(), Box<dyn Er
     assert_eq!(
         AbsoluteBoundPair::new(
             AbsoluteStartBound::InfinitePast,
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         )
         .abridge(&AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new_with_inclusivity(
@@ -379,9 +357,7 @@ fn abs_bounds_abs_bounds_adjacent_exclusive_exclusive() -> Result<(), Box<dyn Er
         )),
         EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         )),
     );
 

--- a/src/intervals/ops/abridge_tests.rs
+++ b/src/intervals/ops/abridge_tests.rs
@@ -30,16 +30,13 @@ fn abs_bounds_unbounded_half_bounded() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(AbsoluteStartBound::InfinitePast, AbsoluteEndBound::InfiniteFuture).abridge(
             &AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::InfiniteFuture,
             )
         ),
         EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::InfiniteFuture,
         )),
     );
@@ -52,18 +49,15 @@ fn abs_bounds_unbounded_bounded() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(AbsoluteStartBound::InfinitePast, AbsoluteEndBound::InfiniteFuture).abridge(
             &AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 )),
             )
         ),
         EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             )),
@@ -77,9 +71,7 @@ fn abs_bounds_unbounded_bounded() -> Result<(), Box<dyn Error>> {
 fn abs_bounds_half_bounded_unbounded() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::InfiniteFuture,
         )
         .abridge(&AbsoluteBoundPair::new(
@@ -87,9 +79,7 @@ fn abs_bounds_half_bounded_unbounded() -> Result<(), Box<dyn Error>> {
             AbsoluteEndBound::InfiniteFuture
         )),
         EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::InfiniteFuture,
         )),
     );
@@ -101,21 +91,15 @@ fn abs_bounds_half_bounded_unbounded() -> Result<(), Box<dyn Error>> {
 fn abs_bounds_two_equal_half_bounded() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::InfiniteFuture,
         )
         .abridge(&AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::InfiniteFuture,
         )),
         EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::InfiniteFuture,
         )),
     );
@@ -133,15 +117,11 @@ fn abs_bounds_two_half_bounded_same_ref_time() -> Result<(), Box<dyn Error>> {
             ))
         )
         .abridge(&AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::InfiniteFuture,
         )),
         EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             )),
@@ -161,16 +141,15 @@ fn abs_bounds_two_half_bounded_with_gap() -> Result<(), Box<dyn Error>> {
             )),
         )
         .abridge(&AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::InfiniteFuture,
         )),
         EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
@@ -185,21 +164,15 @@ fn abs_bounds_two_half_bounded_with_gap() -> Result<(), Box<dyn Error>> {
 fn abs_bounds_two_half_bounded_same_direction_different_times() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::InfiniteFuture,
         )
         .abridge(&AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::InfiniteFuture,
         )),
         EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::InfiniteFuture,
         )),
     );
@@ -211,24 +184,21 @@ fn abs_bounds_two_half_bounded_same_direction_different_times() -> Result<(), Bo
 fn abs_bounds_bounded_half_bounded_with_gap() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             )),
         )
         .abridge(&AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::InfiniteFuture,
         )),
         EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
@@ -243,26 +213,23 @@ fn abs_bounds_bounded_half_bounded_with_gap() -> Result<(), Box<dyn Error>> {
 fn abs_bounds_two_bounded_with_gap() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             )),
         )
         .abridge(&AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             )),
         )),
         EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
@@ -277,25 +244,19 @@ fn abs_bounds_two_bounded_with_gap() -> Result<(), Box<dyn Error>> {
 fn abs_bounds_two_bounded_overlapping() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             )),
         )
         .abridge(&AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             )),
         )),
         EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             )),
@@ -341,15 +302,11 @@ fn abs_bounds_abs_bounds_adjacent_inclusive_inclusive() -> Result<(), Box<dyn Er
             )),
         )
         .abridge(&AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::InfiniteFuture,
         )),
         EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             )),
@@ -369,10 +326,11 @@ fn abs_bounds_abs_bounds_adjacent_inclusive_exclusive() -> Result<(), Box<dyn Er
             )),
         )
         .abridge(&AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::InfiniteFuture,
         )),
         EmptiableAbsoluteBoundPair::Empty,
@@ -392,9 +350,7 @@ fn abs_bounds_abs_bounds_adjacent_exclusive_inclusive() -> Result<(), Box<dyn Er
             )),
         )
         .abridge(&AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::InfiniteFuture,
         )),
         EmptiableAbsoluteBoundPair::Empty,
@@ -414,16 +370,15 @@ fn abs_bounds_abs_bounds_adjacent_exclusive_exclusive() -> Result<(), Box<dyn Er
             )),
         )
         .abridge(&AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::InfiniteFuture,
         )),
         EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             )),

--- a/src/intervals/ops/bound_ord.rs
+++ b/src/intervals/ops/bound_ord.rs
@@ -104,14 +104,14 @@ impl BoundOrdering {
     /// # use periodical::intervals::meta::BoundInclusivity;
     /// # use periodical::intervals::ops::bound_ord::PartialBoundOrd;
     /// # use periodical::intervals::ops::bound_overlap_ambiguity::BoundOverlapDisambiguationRuleSet;
-    /// let ref_bound = AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
+    /// let ref_bound = AbsoluteFiniteBound::new(
     ///     "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    /// ));
+    /// ).to_start_bound();
     ///
-    /// let compared_bound = AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+    /// let compared_bound = AbsoluteFiniteBound::new_with_inclusivity(
     ///     "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
     ///     BoundInclusivity::Exclusive,
-    /// ));
+    /// ).to_start_bound();
     ///
     /// assert_eq!(
     ///     compared_bound
@@ -152,23 +152,23 @@ impl BoundOrdering {
     /// # use periodical::intervals::ops::bound_overlap_ambiguity::{
     /// #     BoundOverlapAmbiguity, BoundOverlapDisambiguationRuleSet, DisambiguatedBoundOverlap,
     /// # };
-    /// let ref_bound = AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
+    /// let ref_bound = AbsoluteFiniteBound::new(
     ///     "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    /// ));
+    /// ).to_start_bound();
     ///
-    /// let compared_bound = AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
+    /// let compared_bound = AbsoluteFiniteBound::new(
     ///     "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-    /// ));
+    /// ).to_start_bound();
     ///
-    /// let mut ref_bound_exclusive = AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+    /// let mut ref_bound_exclusive = AbsoluteFiniteBound::new_with_inclusivity(
     ///     "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
     ///     BoundInclusivity::Exclusive,
-    /// ));
+    /// ).to_start_bound();
     ///
-    /// let compared_bound_exclusive = AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+    /// let compared_bound_exclusive = AbsoluteFiniteBound::new_with_inclusivity(
     ///     "2025-01-01 08:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
     ///     BoundInclusivity::Exclusive,
-    /// ));
+    /// ).to_start_bound();
     ///
     /// // Disambiguation closure that only considers exclusive bounds equal
     /// let disambiguation_closure = |ambiguity: BoundOverlapAmbiguity| -> DisambiguatedBoundOverlap {
@@ -237,18 +237,20 @@ impl BoundOrdering {
 /// # use periodical::intervals::meta::BoundInclusivity;
 /// # use periodical::intervals::ops::bound_ord::{BoundOrdering, PartialBoundOrd};
 /// # use periodical::intervals::ops::bound_overlap_ambiguity::BoundOverlapAmbiguity;
-/// let ref_bound = AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
+/// let ref_bound = AbsoluteFiniteBound::new(
 ///     "2025-01-01 08:00:00[Europe/Oslo]"
 ///         .parse::<Zoned>()?
 ///         .timestamp(),
-/// ));
+/// )
+/// .to_start_bound();
 ///
-/// let compared_bound = AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+/// let compared_bound = AbsoluteFiniteBound::new_with_inclusivity(
 ///     "2025-01-01 08:00:00[Europe/Oslo]"
 ///         .parse::<Zoned>()?
 ///         .timestamp(),
 ///     BoundInclusivity::Exclusive,
-/// ));
+/// )
+/// .to_start_bound();
 ///
 /// assert_eq!(
 ///     compared_bound.bound_cmp(&ref_bound),
@@ -273,18 +275,20 @@ pub trait PartialBoundOrd<Rhs = Self> {
     /// # use periodical::intervals::meta::BoundInclusivity;
     /// # use periodical::intervals::ops::bound_ord::{BoundOrdering, PartialBoundOrd};
     /// # use periodical::intervals::ops::bound_overlap_ambiguity::BoundOverlapAmbiguity;
-    /// let ref_bound = AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
+    /// let ref_bound = AbsoluteFiniteBound::new(
     ///     "2025-01-01 08:00:00[Europe/Oslo]"
     ///         .parse::<Zoned>()?
     ///         .timestamp(),
-    /// ));
+    /// )
+    /// .to_start_bound();
     ///
-    /// let compared_bound = AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+    /// let compared_bound = AbsoluteFiniteBound::new_with_inclusivity(
     ///     "2025-01-01 08:00:00[Europe/Oslo]"
     ///         .parse::<Zoned>()?
     ///         .timestamp(),
     ///     BoundInclusivity::Exclusive,
-    /// ));
+    /// )
+    /// .to_start_bound();
     ///
     /// assert_eq!(
     ///     compared_bound.bound_cmp(&ref_bound),
@@ -312,18 +316,20 @@ pub trait PartialBoundOrd<Rhs = Self> {
     /// # use periodical::intervals::ops::bound_overlap_ambiguity::{
     /// #     BoundOverlapAmbiguity, BoundOverlapDisambiguationRuleSet,
     /// # };
-    /// let ref_bound = AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
+    /// let ref_bound = AbsoluteFiniteBound::new(
     ///     "2025-01-01 08:00:00[Europe/Oslo]"
     ///         .parse::<Zoned>()?
     ///         .timestamp(),
-    /// ));
+    /// )
+    /// .to_start_bound();
     ///
-    /// let compared_bound = AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+    /// let compared_bound = AbsoluteFiniteBound::new_with_inclusivity(
     ///     "2025-01-01 08:00:00[Europe/Oslo]"
     ///         .parse::<Zoned>()?
     ///         .timestamp(),
     ///     BoundInclusivity::Exclusive,
-    /// ));
+    /// )
+    /// .to_start_bound();
     ///
     /// assert!(!compared_bound.bound_lt(&ref_bound, BoundOverlapDisambiguationRuleSet::Strict));
     /// # Ok::<(), Box<dyn Error>>(())
@@ -356,18 +362,20 @@ pub trait PartialBoundOrd<Rhs = Self> {
     /// # use periodical::intervals::ops::bound_overlap_ambiguity::{
     /// #     BoundOverlapAmbiguity, BoundOverlapDisambiguationRuleSet,
     /// # };
-    /// let ref_bound = AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
+    /// let ref_bound = AbsoluteFiniteBound::new(
     ///     "2025-01-01 08:00:00[Europe/Oslo]"
     ///         .parse::<Zoned>()?
     ///         .timestamp(),
-    /// ));
+    /// )
+    /// .to_start_bound();
     ///
-    /// let compared_bound = AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+    /// let compared_bound = AbsoluteFiniteBound::new_with_inclusivity(
     ///     "2025-01-01 08:00:00[Europe/Oslo]"
     ///         .parse::<Zoned>()?
     ///         .timestamp(),
     ///     BoundInclusivity::Exclusive,
-    /// ));
+    /// )
+    /// .to_start_bound();
     ///
     /// assert!(!compared_bound.bound_le(&ref_bound, BoundOverlapDisambiguationRuleSet::Strict));
     /// # Ok::<(), Box<dyn Error>>(())
@@ -400,18 +408,20 @@ pub trait PartialBoundOrd<Rhs = Self> {
     /// # use periodical::intervals::ops::bound_overlap_ambiguity::{
     /// #     BoundOverlapAmbiguity, BoundOverlapDisambiguationRuleSet,
     /// # };
-    /// let ref_bound = AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
+    /// let ref_bound = AbsoluteFiniteBound::new(
     ///     "2025-01-01 08:00:00[Europe/Oslo]"
     ///         .parse::<Zoned>()?
     ///         .timestamp(),
-    /// ));
+    /// )
+    /// .to_start_bound();
     ///
-    /// let compared_bound = AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+    /// let compared_bound = AbsoluteFiniteBound::new_with_inclusivity(
     ///     "2025-01-01 08:00:00[Europe/Oslo]"
     ///         .parse::<Zoned>()?
     ///         .timestamp(),
     ///     BoundInclusivity::Exclusive,
-    /// ));
+    /// )
+    /// .to_start_bound();
     ///
     /// assert!(compared_bound.bound_gt(&ref_bound, BoundOverlapDisambiguationRuleSet::Strict));
     /// # Ok::<(), Box<dyn Error>>(())
@@ -444,18 +454,20 @@ pub trait PartialBoundOrd<Rhs = Self> {
     /// # use periodical::intervals::ops::bound_overlap_ambiguity::{
     /// #     BoundOverlapAmbiguity, BoundOverlapDisambiguationRuleSet,
     /// # };
-    /// let ref_bound = AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
+    /// let ref_bound = AbsoluteFiniteBound::new(
     ///     "2025-01-01 08:00:00[Europe/Oslo]"
     ///         .parse::<Zoned>()?
     ///         .timestamp(),
-    /// ));
+    /// )
+    /// .to_start_bound();
     ///
-    /// let compared_bound = AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+    /// let compared_bound = AbsoluteFiniteBound::new_with_inclusivity(
     ///     "2025-01-01 08:00:00[Europe/Oslo]"
     ///         .parse::<Zoned>()?
     ///         .timestamp(),
     ///     BoundInclusivity::Exclusive,
-    /// ));
+    /// )
+    /// .to_start_bound();
     ///
     /// assert!(compared_bound.bound_ge(&ref_bound, BoundOverlapDisambiguationRuleSet::Strict));
     /// # Ok::<(), Box<dyn Error>>(())

--- a/src/intervals/ops/bound_ord_tests.rs
+++ b/src/intervals/ops/bound_ord_tests.rs
@@ -24,12 +24,12 @@ fn abs_start_start_less_inf_past_finite() -> Result<(), Box<dyn Error>> {
 #[test]
 fn abs_start_start_less_finite_finite() -> Result<(), Box<dyn Error>> {
     assert_eq!(
-        AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-        ))
-        .bound_cmp(&AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-        ))),
+        AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+            .to_start_bound()
+            .bound_cmp(
+                &AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound()
+            ),
         BoundOrdering::Less,
     );
 
@@ -47,12 +47,12 @@ fn abs_start_start_equal_inf_past() {
 #[test]
 fn abs_start_start_equal_inclusive_inclusive() -> Result<(), Box<dyn Error>> {
     assert_eq!(
-        AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-        ))
-        .bound_cmp(&AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-        ))),
+        AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+            .to_start_bound()
+            .bound_cmp(
+                &AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound()
+            ),
         BoundOrdering::Equal(Some(BoundOverlapAmbiguity::BothStarts(
             BoundInclusivity::Inclusive,
             BoundInclusivity::Inclusive,
@@ -65,13 +65,15 @@ fn abs_start_start_equal_inclusive_inclusive() -> Result<(), Box<dyn Error>> {
 #[test]
 fn abs_start_start_equal_inclusive_exclusive() -> Result<(), Box<dyn Error>> {
     assert_eq!(
-        AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-        ))
-        .bound_cmp(&AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-            "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            BoundInclusivity::Exclusive,
-        ))),
+        AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+            .to_start_bound()
+            .bound_cmp(
+                &AbsoluteFiniteBound::new_with_inclusivity(
+                    "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                    BoundInclusivity::Exclusive,
+                )
+                .to_start_bound()
+            ),
         BoundOrdering::Equal(Some(BoundOverlapAmbiguity::BothStarts(
             BoundInclusivity::Exclusive,
             BoundInclusivity::Inclusive,
@@ -84,13 +86,15 @@ fn abs_start_start_equal_inclusive_exclusive() -> Result<(), Box<dyn Error>> {
 #[test]
 fn abs_start_start_equal_exclusive_inclusive() -> Result<(), Box<dyn Error>> {
     assert_eq!(
-        AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+        AbsoluteFiniteBound::new_with_inclusivity(
             "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             BoundInclusivity::Exclusive,
-        ))
-        .bound_cmp(&AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-        ))),
+        )
+        .to_start_bound()
+        .bound_cmp(
+            &AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                .to_start_bound()
+        ),
         BoundOrdering::Equal(Some(BoundOverlapAmbiguity::BothStarts(
             BoundInclusivity::Inclusive,
             BoundInclusivity::Exclusive,
@@ -103,14 +107,18 @@ fn abs_start_start_equal_exclusive_inclusive() -> Result<(), Box<dyn Error>> {
 #[test]
 fn abs_start_start_equal_exclusive_exclusive() -> Result<(), Box<dyn Error>> {
     assert_eq!(
-        AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+        AbsoluteFiniteBound::new_with_inclusivity(
             "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             BoundInclusivity::Exclusive,
-        ))
-        .bound_cmp(&AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-            "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            BoundInclusivity::Exclusive,
-        ))),
+        )
+        .to_start_bound()
+        .bound_cmp(
+            &AbsoluteFiniteBound::new_with_inclusivity(
+                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                BoundInclusivity::Exclusive,
+            )
+            .to_start_bound()
+        ),
         BoundOrdering::Equal(Some(BoundOverlapAmbiguity::BothStarts(
             BoundInclusivity::Exclusive,
             BoundInclusivity::Exclusive,
@@ -123,10 +131,9 @@ fn abs_start_start_equal_exclusive_exclusive() -> Result<(), Box<dyn Error>> {
 #[test]
 fn abs_start_start_greater_finite_inf_past() -> Result<(), Box<dyn Error>> {
     assert_eq!(
-        AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-        ))
-        .bound_cmp(&AbsoluteStartBound::InfinitePast),
+        AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+            .to_start_bound()
+            .bound_cmp(&AbsoluteStartBound::InfinitePast),
         BoundOrdering::Greater,
     );
 
@@ -136,12 +143,12 @@ fn abs_start_start_greater_finite_inf_past() -> Result<(), Box<dyn Error>> {
 #[test]
 fn abs_start_start_greater_finite_finite() -> Result<(), Box<dyn Error>> {
     assert_eq!(
-        AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-        ))
-        .bound_cmp(&AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-        ))),
+        AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+            .to_start_bound()
+            .bound_cmp(
+                &AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound()
+            ),
         BoundOrdering::Greater,
     );
 
@@ -171,10 +178,9 @@ fn abs_start_end_less_inf_past_finite() -> Result<(), Box<dyn Error>> {
 #[test]
 fn abs_start_end_less_finite_inf_future() -> Result<(), Box<dyn Error>> {
     assert_eq!(
-        AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-        ))
-        .bound_cmp(&AbsoluteEndBound::InfiniteFuture),
+        AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+            .to_start_bound()
+            .bound_cmp(&AbsoluteEndBound::InfiniteFuture),
         BoundOrdering::Less,
     );
 
@@ -184,12 +190,11 @@ fn abs_start_end_less_finite_inf_future() -> Result<(), Box<dyn Error>> {
 #[test]
 fn abs_start_end_less_finite_finite() -> Result<(), Box<dyn Error>> {
     assert_eq!(
-        AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-        ))
-        .bound_cmp(&AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-        ))),
+        AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+            .to_start_bound()
+            .bound_cmp(&AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
+                "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
+            ))),
         BoundOrdering::Less,
     );
 
@@ -199,12 +204,11 @@ fn abs_start_end_less_finite_finite() -> Result<(), Box<dyn Error>> {
 #[test]
 fn abs_start_end_equal_inclusive_inclusive() -> Result<(), Box<dyn Error>> {
     assert_eq!(
-        AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-        ))
-        .bound_cmp(&AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-        ))),
+        AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+            .to_start_bound()
+            .bound_cmp(&AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
+                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
+            ))),
         BoundOrdering::Equal(Some(BoundOverlapAmbiguity::EndStart(
             BoundInclusivity::Inclusive,
             BoundInclusivity::Inclusive,
@@ -217,13 +221,12 @@ fn abs_start_end_equal_inclusive_inclusive() -> Result<(), Box<dyn Error>> {
 #[test]
 fn abs_start_end_equal_inclusive_exclusive() -> Result<(), Box<dyn Error>> {
     assert_eq!(
-        AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-        ))
-        .bound_cmp(&AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-            "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            BoundInclusivity::Exclusive,
-        ))),
+        AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+            .to_start_bound()
+            .bound_cmp(&AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                BoundInclusivity::Exclusive,
+            ))),
         BoundOrdering::Equal(Some(BoundOverlapAmbiguity::EndStart(
             BoundInclusivity::Exclusive,
             BoundInclusivity::Inclusive,
@@ -236,10 +239,11 @@ fn abs_start_end_equal_inclusive_exclusive() -> Result<(), Box<dyn Error>> {
 #[test]
 fn abs_start_end_equal_exclusive_inclusive() -> Result<(), Box<dyn Error>> {
     assert_eq!(
-        AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+        AbsoluteFiniteBound::new_with_inclusivity(
             "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             BoundInclusivity::Exclusive,
-        ))
+        )
+        .to_start_bound()
         .bound_cmp(&AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
             "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
         ))),
@@ -255,10 +259,11 @@ fn abs_start_end_equal_exclusive_inclusive() -> Result<(), Box<dyn Error>> {
 #[test]
 fn abs_start_end_equal_exclusive_exclusive() -> Result<(), Box<dyn Error>> {
     assert_eq!(
-        AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+        AbsoluteFiniteBound::new_with_inclusivity(
             "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             BoundInclusivity::Exclusive,
-        ))
+        )
+        .to_start_bound()
         .bound_cmp(&AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
             "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             BoundInclusivity::Exclusive,
@@ -275,12 +280,11 @@ fn abs_start_end_equal_exclusive_exclusive() -> Result<(), Box<dyn Error>> {
 #[test]
 fn abs_start_end_greater() -> Result<(), Box<dyn Error>> {
     assert_eq!(
-        AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-        ))
-        .bound_cmp(&AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-        ))),
+        AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+            .to_start_bound()
+            .bound_cmp(&AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
+                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
+            ))),
         BoundOrdering::Greater,
     );
 
@@ -293,9 +297,10 @@ fn abs_end_start_less() -> Result<(), Box<dyn Error>> {
         AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
             "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
         ))
-        .bound_cmp(&AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-        ))),
+        .bound_cmp(
+            &AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                .to_start_bound()
+        ),
         BoundOrdering::Less,
     );
 
@@ -308,9 +313,10 @@ fn abs_end_start_equal_inclusive_inclusive() -> Result<(), Box<dyn Error>> {
         AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
             "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
         ))
-        .bound_cmp(&AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-        ))),
+        .bound_cmp(
+            &AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                .to_start_bound()
+        ),
         BoundOrdering::Equal(Some(BoundOverlapAmbiguity::StartEnd(
             BoundInclusivity::Inclusive,
             BoundInclusivity::Inclusive,
@@ -326,10 +332,13 @@ fn abs_end_start_equal_inclusive_exclusive() -> Result<(), Box<dyn Error>> {
         AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
             "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
         ))
-        .bound_cmp(&AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-            "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            BoundInclusivity::Exclusive,
-        ))),
+        .bound_cmp(
+            &AbsoluteFiniteBound::new_with_inclusivity(
+                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                BoundInclusivity::Exclusive,
+            )
+            .to_start_bound()
+        ),
         BoundOrdering::Equal(Some(BoundOverlapAmbiguity::StartEnd(
             BoundInclusivity::Exclusive,
             BoundInclusivity::Inclusive,
@@ -346,9 +355,10 @@ fn abs_end_start_equal_exclusive_inclusive() -> Result<(), Box<dyn Error>> {
             "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             BoundInclusivity::Exclusive,
         ))
-        .bound_cmp(&AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-        ))),
+        .bound_cmp(
+            &AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                .to_start_bound()
+        ),
         BoundOrdering::Equal(Some(BoundOverlapAmbiguity::StartEnd(
             BoundInclusivity::Inclusive,
             BoundInclusivity::Exclusive,
@@ -365,10 +375,13 @@ fn abs_end_start_equal_exclusive_exclusive() -> Result<(), Box<dyn Error>> {
             "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             BoundInclusivity::Exclusive,
         ))
-        .bound_cmp(&AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-            "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            BoundInclusivity::Exclusive,
-        ))),
+        .bound_cmp(
+            &AbsoluteFiniteBound::new_with_inclusivity(
+                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                BoundInclusivity::Exclusive,
+            )
+            .to_start_bound()
+        ),
         BoundOrdering::Equal(Some(BoundOverlapAmbiguity::StartEnd(
             BoundInclusivity::Exclusive,
             BoundInclusivity::Exclusive,
@@ -389,9 +402,10 @@ fn abs_end_start_greater_inf_future_inf_past() {
 #[test]
 fn abs_end_start_greater_inf_future_finite() -> Result<(), Box<dyn Error>> {
     assert_eq!(
-        AbsoluteEndBound::InfiniteFuture.bound_cmp(&AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-        ))),
+        AbsoluteEndBound::InfiniteFuture.bound_cmp(
+            &AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                .to_start_bound()
+        ),
         BoundOrdering::Greater,
     );
 
@@ -417,9 +431,10 @@ fn abs_end_start_greater_finite_finite() -> Result<(), Box<dyn Error>> {
         AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
             "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
         ))
-        .bound_cmp(&AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-        ))),
+        .bound_cmp(
+            &AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                .to_start_bound()
+        ),
         BoundOrdering::Greater,
     );
 

--- a/src/intervals/ops/bound_ord_tests.rs
+++ b/src/intervals/ops/bound_ord_tests.rs
@@ -687,9 +687,8 @@ fn rel_start_end_less_inf_past_inf_future() {
 #[test]
 fn rel_start_end_less_inf_past_finite() {
     assert_eq!(
-        RelativeStartBound::InfinitePast.bound_cmp(&RelativeEndBound::Finite(RelativeFiniteBound::new(
-            SignedDuration::from_hours(101)
-        ))),
+        RelativeStartBound::InfinitePast
+            .bound_cmp(&RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_end_bound()),
         BoundOrdering::Less,
     );
 }
@@ -709,9 +708,7 @@ fn rel_start_end_less_finite_finite() {
     assert_eq!(
         RelativeFiniteBound::new(SignedDuration::from_hours(101))
             .to_start_bound()
-            .bound_cmp(&RelativeEndBound::Finite(RelativeFiniteBound::new(
-                SignedDuration::from_hours(102)
-            ))),
+            .bound_cmp(&RelativeFiniteBound::new(SignedDuration::from_hours(102)).to_end_bound()),
         BoundOrdering::Less,
     );
 }
@@ -721,9 +718,7 @@ fn rel_start_end_equal_inclusive_inclusive() {
     assert_eq!(
         RelativeFiniteBound::new(SignedDuration::from_hours(101))
             .to_start_bound()
-            .bound_cmp(&RelativeEndBound::Finite(RelativeFiniteBound::new(
-                SignedDuration::from_hours(101)
-            ))),
+            .bound_cmp(&RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_end_bound()),
         BoundOrdering::Equal(Some(BoundOverlapAmbiguity::EndStart(
             BoundInclusivity::Inclusive,
             BoundInclusivity::Inclusive,
@@ -736,10 +731,13 @@ fn rel_start_end_equal_inclusive_exclusive() {
     assert_eq!(
         RelativeFiniteBound::new(SignedDuration::from_hours(101))
             .to_start_bound()
-            .bound_cmp(&RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                SignedDuration::from_hours(101),
-                BoundInclusivity::Exclusive,
-            ))),
+            .bound_cmp(
+                &RelativeFiniteBound::new_with_inclusivity(
+                    SignedDuration::from_hours(101),
+                    BoundInclusivity::Exclusive,
+                )
+                .to_end_bound()
+            ),
         BoundOrdering::Equal(Some(BoundOverlapAmbiguity::EndStart(
             BoundInclusivity::Exclusive,
             BoundInclusivity::Inclusive,
@@ -752,9 +750,7 @@ fn rel_start_end_equal_exclusive_inclusive() {
     assert_eq!(
         RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(101), BoundInclusivity::Exclusive,)
             .to_start_bound()
-            .bound_cmp(&RelativeEndBound::Finite(RelativeFiniteBound::new(
-                SignedDuration::from_hours(101)
-            ))),
+            .bound_cmp(&RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_end_bound()),
         BoundOrdering::Equal(Some(BoundOverlapAmbiguity::EndStart(
             BoundInclusivity::Inclusive,
             BoundInclusivity::Exclusive,
@@ -767,10 +763,13 @@ fn rel_start_end_equal_exclusive_exclusive() {
     assert_eq!(
         RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(101), BoundInclusivity::Exclusive,)
             .to_start_bound()
-            .bound_cmp(&RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                SignedDuration::from_hours(101),
-                BoundInclusivity::Exclusive,
-            ))),
+            .bound_cmp(
+                &RelativeFiniteBound::new_with_inclusivity(
+                    SignedDuration::from_hours(101),
+                    BoundInclusivity::Exclusive,
+                )
+                .to_end_bound()
+            ),
         BoundOrdering::Equal(Some(BoundOverlapAmbiguity::EndStart(
             BoundInclusivity::Exclusive,
             BoundInclusivity::Exclusive,
@@ -783,9 +782,7 @@ fn rel_start_end_greater() {
     assert_eq!(
         RelativeFiniteBound::new(SignedDuration::from_hours(102))
             .to_start_bound()
-            .bound_cmp(&RelativeEndBound::Finite(RelativeFiniteBound::new(
-                SignedDuration::from_hours(101)
-            ))),
+            .bound_cmp(&RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_end_bound()),
         BoundOrdering::Greater,
     );
 }
@@ -793,7 +790,8 @@ fn rel_start_end_greater() {
 #[test]
 fn rel_end_start_less() {
     assert_eq!(
-        RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(101)))
+        RelativeFiniteBound::new(SignedDuration::from_hours(101))
+            .to_end_bound()
             .bound_cmp(&RelativeFiniteBound::new(SignedDuration::from_hours(102)).to_start_bound()),
         BoundOrdering::Less,
     );
@@ -802,7 +800,8 @@ fn rel_end_start_less() {
 #[test]
 fn rel_end_start_equal_inclusive_inclusive() {
     assert_eq!(
-        RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(101)))
+        RelativeFiniteBound::new(SignedDuration::from_hours(101))
+            .to_end_bound()
             .bound_cmp(&RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_start_bound()),
         BoundOrdering::Equal(Some(BoundOverlapAmbiguity::StartEnd(
             BoundInclusivity::Inclusive,
@@ -814,10 +813,15 @@ fn rel_end_start_equal_inclusive_inclusive() {
 #[test]
 fn rel_end_start_equal_inclusive_exclusive() {
     assert_eq!(
-        RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(101))).bound_cmp(
-            &RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(101), BoundInclusivity::Exclusive,)
+        RelativeFiniteBound::new(SignedDuration::from_hours(101))
+            .to_end_bound()
+            .bound_cmp(
+                &RelativeFiniteBound::new_with_inclusivity(
+                    SignedDuration::from_hours(101),
+                    BoundInclusivity::Exclusive,
+                )
                 .to_start_bound()
-        ),
+            ),
         BoundOrdering::Equal(Some(BoundOverlapAmbiguity::StartEnd(
             BoundInclusivity::Exclusive,
             BoundInclusivity::Inclusive,
@@ -828,11 +832,9 @@ fn rel_end_start_equal_inclusive_exclusive() {
 #[test]
 fn rel_end_start_equal_exclusive_inclusive() {
     assert_eq!(
-        RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-            SignedDuration::from_hours(101),
-            BoundInclusivity::Exclusive,
-        ))
-        .bound_cmp(&RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_start_bound()),
+        RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(101), BoundInclusivity::Exclusive,)
+            .to_end_bound()
+            .bound_cmp(&RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_start_bound()),
         BoundOrdering::Equal(Some(BoundOverlapAmbiguity::StartEnd(
             BoundInclusivity::Inclusive,
             BoundInclusivity::Exclusive,
@@ -843,14 +845,15 @@ fn rel_end_start_equal_exclusive_inclusive() {
 #[test]
 fn rel_end_start_equal_exclusive_exclusive() {
     assert_eq!(
-        RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-            SignedDuration::from_hours(101),
-            BoundInclusivity::Exclusive,
-        ))
-        .bound_cmp(
-            &RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(101), BoundInclusivity::Exclusive,)
+        RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(101), BoundInclusivity::Exclusive,)
+            .to_end_bound()
+            .bound_cmp(
+                &RelativeFiniteBound::new_with_inclusivity(
+                    SignedDuration::from_hours(101),
+                    BoundInclusivity::Exclusive,
+                )
                 .to_start_bound()
-        ),
+            ),
         BoundOrdering::Equal(Some(BoundOverlapAmbiguity::StartEnd(
             BoundInclusivity::Exclusive,
             BoundInclusivity::Exclusive,
@@ -878,7 +881,8 @@ fn rel_end_start_greater_inf_future_finite() {
 #[test]
 fn rel_end_start_greater_finite_inf_past() {
     assert_eq!(
-        RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(101)))
+        RelativeFiniteBound::new(SignedDuration::from_hours(101))
+            .to_end_bound()
             .bound_cmp(&RelativeStartBound::InfinitePast),
         BoundOrdering::Greater,
     );
@@ -887,7 +891,8 @@ fn rel_end_start_greater_finite_inf_past() {
 #[test]
 fn rel_end_start_greater_finite_finite() {
     assert_eq!(
-        RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(102)))
+        RelativeFiniteBound::new(SignedDuration::from_hours(102))
+            .to_end_bound()
             .bound_cmp(&RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_start_bound()),
         BoundOrdering::Greater,
     );
@@ -896,7 +901,8 @@ fn rel_end_start_greater_finite_finite() {
 #[test]
 fn rel_end_end_less_finite_inf_future() {
     assert_eq!(
-        RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(101)))
+        RelativeFiniteBound::new(SignedDuration::from_hours(101))
+            .to_end_bound()
             .bound_cmp(&RelativeEndBound::InfiniteFuture),
         BoundOrdering::Less,
     );
@@ -905,9 +911,9 @@ fn rel_end_end_less_finite_inf_future() {
 #[test]
 fn rel_end_end_less_finite_finite() {
     assert_eq!(
-        RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(101))).bound_cmp(
-            &RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(102)))
-        ),
+        RelativeFiniteBound::new(SignedDuration::from_hours(101))
+            .to_end_bound()
+            .bound_cmp(&RelativeFiniteBound::new(SignedDuration::from_hours(102)).to_end_bound()),
         BoundOrdering::Less,
     );
 }
@@ -923,9 +929,9 @@ fn rel_end_end_equal_inf_future_inf_future() {
 #[test]
 fn rel_end_end_equal_inclusive_inclusive() {
     assert_eq!(
-        RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(101))).bound_cmp(
-            &RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(101)))
-        ),
+        RelativeFiniteBound::new(SignedDuration::from_hours(101))
+            .to_end_bound()
+            .bound_cmp(&RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_end_bound()),
         BoundOrdering::Equal(Some(BoundOverlapAmbiguity::BothEnds(
             BoundInclusivity::Inclusive,
             BoundInclusivity::Inclusive,
@@ -936,12 +942,15 @@ fn rel_end_end_equal_inclusive_inclusive() {
 #[test]
 fn rel_end_end_equal_inclusive_exclusive() {
     assert_eq!(
-        RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(101))).bound_cmp(
-            &RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                SignedDuration::from_hours(101),
-                BoundInclusivity::Exclusive,
-            ))
-        ),
+        RelativeFiniteBound::new(SignedDuration::from_hours(101))
+            .to_end_bound()
+            .bound_cmp(
+                &RelativeFiniteBound::new_with_inclusivity(
+                    SignedDuration::from_hours(101),
+                    BoundInclusivity::Exclusive,
+                )
+                .to_end_bound()
+            ),
         BoundOrdering::Equal(Some(BoundOverlapAmbiguity::BothEnds(
             BoundInclusivity::Exclusive,
             BoundInclusivity::Inclusive,
@@ -952,13 +961,9 @@ fn rel_end_end_equal_inclusive_exclusive() {
 #[test]
 fn rel_end_end_equal_exclusive_inclusive() {
     assert_eq!(
-        RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-            SignedDuration::from_hours(101),
-            BoundInclusivity::Exclusive,
-        ))
-        .bound_cmp(&RelativeEndBound::Finite(RelativeFiniteBound::new(
-            SignedDuration::from_hours(101)
-        ))),
+        RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(101), BoundInclusivity::Exclusive,)
+            .to_end_bound()
+            .bound_cmp(&RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_end_bound()),
         BoundOrdering::Equal(Some(BoundOverlapAmbiguity::BothEnds(
             BoundInclusivity::Inclusive,
             BoundInclusivity::Exclusive,
@@ -969,14 +974,15 @@ fn rel_end_end_equal_exclusive_inclusive() {
 #[test]
 fn rel_end_end_equal_exclusive_exclusive() {
     assert_eq!(
-        RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-            SignedDuration::from_hours(101),
-            BoundInclusivity::Exclusive,
-        ))
-        .bound_cmp(&RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-            SignedDuration::from_hours(101),
-            BoundInclusivity::Exclusive,
-        ))),
+        RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(101), BoundInclusivity::Exclusive,)
+            .to_end_bound()
+            .bound_cmp(
+                &RelativeFiniteBound::new_with_inclusivity(
+                    SignedDuration::from_hours(101),
+                    BoundInclusivity::Exclusive,
+                )
+                .to_end_bound()
+            ),
         BoundOrdering::Equal(Some(BoundOverlapAmbiguity::BothEnds(
             BoundInclusivity::Exclusive,
             BoundInclusivity::Exclusive,

--- a/src/intervals/ops/bound_ord_tests.rs
+++ b/src/intervals/ops/bound_ord_tests.rs
@@ -166,9 +166,9 @@ fn abs_start_end_less_inf_past_inf_future() {
 #[test]
 fn abs_start_end_less_inf_past_finite() -> Result<(), Box<dyn Error>> {
     assert_eq!(
-        AbsoluteStartBound::InfinitePast.bound_cmp(&AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-        ))),
+        AbsoluteStartBound::InfinitePast.bound_cmp(
+            &AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound()
+        ),
         BoundOrdering::Less,
     );
 
@@ -192,9 +192,10 @@ fn abs_start_end_less_finite_finite() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
             .to_start_bound()
-            .bound_cmp(&AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            ))),
+            .bound_cmp(
+                &AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound()
+            ),
         BoundOrdering::Less,
     );
 
@@ -206,9 +207,10 @@ fn abs_start_end_equal_inclusive_inclusive() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
             .to_start_bound()
-            .bound_cmp(&AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            ))),
+            .bound_cmp(
+                &AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound()
+            ),
         BoundOrdering::Equal(Some(BoundOverlapAmbiguity::EndStart(
             BoundInclusivity::Inclusive,
             BoundInclusivity::Inclusive,
@@ -223,10 +225,13 @@ fn abs_start_end_equal_inclusive_exclusive() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
             .to_start_bound()
-            .bound_cmp(&AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                BoundInclusivity::Exclusive,
-            ))),
+            .bound_cmp(
+                &AbsoluteFiniteBound::new_with_inclusivity(
+                    "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                    BoundInclusivity::Exclusive,
+                )
+                .to_end_bound()
+            ),
         BoundOrdering::Equal(Some(BoundOverlapAmbiguity::EndStart(
             BoundInclusivity::Exclusive,
             BoundInclusivity::Inclusive,
@@ -244,9 +249,9 @@ fn abs_start_end_equal_exclusive_inclusive() -> Result<(), Box<dyn Error>> {
             BoundInclusivity::Exclusive,
         )
         .to_start_bound()
-        .bound_cmp(&AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-        ))),
+        .bound_cmp(
+            &AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound()
+        ),
         BoundOrdering::Equal(Some(BoundOverlapAmbiguity::EndStart(
             BoundInclusivity::Inclusive,
             BoundInclusivity::Exclusive,
@@ -264,10 +269,13 @@ fn abs_start_end_equal_exclusive_exclusive() -> Result<(), Box<dyn Error>> {
             BoundInclusivity::Exclusive,
         )
         .to_start_bound()
-        .bound_cmp(&AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-            "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            BoundInclusivity::Exclusive,
-        ))),
+        .bound_cmp(
+            &AbsoluteFiniteBound::new_with_inclusivity(
+                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                BoundInclusivity::Exclusive,
+            )
+            .to_end_bound()
+        ),
         BoundOrdering::Equal(Some(BoundOverlapAmbiguity::EndStart(
             BoundInclusivity::Exclusive,
             BoundInclusivity::Exclusive,
@@ -282,9 +290,10 @@ fn abs_start_end_greater() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
             .to_start_bound()
-            .bound_cmp(&AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            ))),
+            .bound_cmp(
+                &AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound()
+            ),
         BoundOrdering::Greater,
     );
 
@@ -294,13 +303,12 @@ fn abs_start_end_greater() -> Result<(), Box<dyn Error>> {
 #[test]
 fn abs_end_start_less() -> Result<(), Box<dyn Error>> {
     assert_eq!(
-        AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-        ))
-        .bound_cmp(
-            &AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
-                .to_start_bound()
-        ),
+        AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+            .to_end_bound()
+            .bound_cmp(
+                &AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound()
+            ),
         BoundOrdering::Less,
     );
 
@@ -310,13 +318,12 @@ fn abs_end_start_less() -> Result<(), Box<dyn Error>> {
 #[test]
 fn abs_end_start_equal_inclusive_inclusive() -> Result<(), Box<dyn Error>> {
     assert_eq!(
-        AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-        ))
-        .bound_cmp(
-            &AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
-                .to_start_bound()
-        ),
+        AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+            .to_end_bound()
+            .bound_cmp(
+                &AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound()
+            ),
         BoundOrdering::Equal(Some(BoundOverlapAmbiguity::StartEnd(
             BoundInclusivity::Inclusive,
             BoundInclusivity::Inclusive,
@@ -329,16 +336,15 @@ fn abs_end_start_equal_inclusive_inclusive() -> Result<(), Box<dyn Error>> {
 #[test]
 fn abs_end_start_equal_inclusive_exclusive() -> Result<(), Box<dyn Error>> {
     assert_eq!(
-        AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-        ))
-        .bound_cmp(
-            &AbsoluteFiniteBound::new_with_inclusivity(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                BoundInclusivity::Exclusive,
-            )
-            .to_start_bound()
-        ),
+        AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+            .to_end_bound()
+            .bound_cmp(
+                &AbsoluteFiniteBound::new_with_inclusivity(
+                    "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                    BoundInclusivity::Exclusive,
+                )
+                .to_start_bound()
+            ),
         BoundOrdering::Equal(Some(BoundOverlapAmbiguity::StartEnd(
             BoundInclusivity::Exclusive,
             BoundInclusivity::Inclusive,
@@ -351,10 +357,11 @@ fn abs_end_start_equal_inclusive_exclusive() -> Result<(), Box<dyn Error>> {
 #[test]
 fn abs_end_start_equal_exclusive_inclusive() -> Result<(), Box<dyn Error>> {
     assert_eq!(
-        AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+        AbsoluteFiniteBound::new_with_inclusivity(
             "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             BoundInclusivity::Exclusive,
-        ))
+        )
+        .to_end_bound()
         .bound_cmp(
             &AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                 .to_start_bound()
@@ -371,10 +378,11 @@ fn abs_end_start_equal_exclusive_inclusive() -> Result<(), Box<dyn Error>> {
 #[test]
 fn abs_end_start_equal_exclusive_exclusive() -> Result<(), Box<dyn Error>> {
     assert_eq!(
-        AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+        AbsoluteFiniteBound::new_with_inclusivity(
             "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             BoundInclusivity::Exclusive,
-        ))
+        )
+        .to_end_bound()
         .bound_cmp(
             &AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
@@ -415,10 +423,9 @@ fn abs_end_start_greater_inf_future_finite() -> Result<(), Box<dyn Error>> {
 #[test]
 fn abs_end_start_greater_finite_inf_past() -> Result<(), Box<dyn Error>> {
     assert_eq!(
-        AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-        ))
-        .bound_cmp(&AbsoluteStartBound::InfinitePast),
+        AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+            .to_end_bound()
+            .bound_cmp(&AbsoluteStartBound::InfinitePast),
         BoundOrdering::Greater,
     );
 
@@ -428,13 +435,12 @@ fn abs_end_start_greater_finite_inf_past() -> Result<(), Box<dyn Error>> {
 #[test]
 fn abs_end_start_greater_finite_finite() -> Result<(), Box<dyn Error>> {
     assert_eq!(
-        AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-        ))
-        .bound_cmp(
-            &AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
-                .to_start_bound()
-        ),
+        AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+            .to_end_bound()
+            .bound_cmp(
+                &AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound()
+            ),
         BoundOrdering::Greater,
     );
 
@@ -444,10 +450,9 @@ fn abs_end_start_greater_finite_finite() -> Result<(), Box<dyn Error>> {
 #[test]
 fn abs_end_end_less_finite_inf_future() -> Result<(), Box<dyn Error>> {
     assert_eq!(
-        AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-        ))
-        .bound_cmp(&AbsoluteEndBound::InfiniteFuture),
+        AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+            .to_end_bound()
+            .bound_cmp(&AbsoluteEndBound::InfiniteFuture),
         BoundOrdering::Less,
     );
 
@@ -457,12 +462,12 @@ fn abs_end_end_less_finite_inf_future() -> Result<(), Box<dyn Error>> {
 #[test]
 fn abs_end_end_less_finite_finite() -> Result<(), Box<dyn Error>> {
     assert_eq!(
-        AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-        ))
-        .bound_cmp(&AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-        ))),
+        AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+            .to_end_bound()
+            .bound_cmp(
+                &AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound()
+            ),
         BoundOrdering::Less,
     );
 
@@ -480,12 +485,12 @@ fn abs_end_end_equal_inf_future_inf_future() {
 #[test]
 fn abs_end_end_equal_inclusive_inclusive() -> Result<(), Box<dyn Error>> {
     assert_eq!(
-        AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-        ))
-        .bound_cmp(&AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-        ))),
+        AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+            .to_end_bound()
+            .bound_cmp(
+                &AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound()
+            ),
         BoundOrdering::Equal(Some(BoundOverlapAmbiguity::BothEnds(
             BoundInclusivity::Inclusive,
             BoundInclusivity::Inclusive,
@@ -498,13 +503,15 @@ fn abs_end_end_equal_inclusive_inclusive() -> Result<(), Box<dyn Error>> {
 #[test]
 fn abs_end_end_equal_inclusive_exclusive() -> Result<(), Box<dyn Error>> {
     assert_eq!(
-        AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-        ))
-        .bound_cmp(&AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-            "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            BoundInclusivity::Exclusive,
-        ))),
+        AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+            .to_end_bound()
+            .bound_cmp(
+                &AbsoluteFiniteBound::new_with_inclusivity(
+                    "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                    BoundInclusivity::Exclusive,
+                )
+                .to_end_bound()
+            ),
         BoundOrdering::Equal(Some(BoundOverlapAmbiguity::BothEnds(
             BoundInclusivity::Exclusive,
             BoundInclusivity::Inclusive,
@@ -517,13 +524,14 @@ fn abs_end_end_equal_inclusive_exclusive() -> Result<(), Box<dyn Error>> {
 #[test]
 fn abs_end_end_equal_exclusive_inclusive() -> Result<(), Box<dyn Error>> {
     assert_eq!(
-        AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+        AbsoluteFiniteBound::new_with_inclusivity(
             "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             BoundInclusivity::Exclusive,
-        ))
-        .bound_cmp(&AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-        ))),
+        )
+        .to_end_bound()
+        .bound_cmp(
+            &AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound()
+        ),
         BoundOrdering::Equal(Some(BoundOverlapAmbiguity::BothEnds(
             BoundInclusivity::Inclusive,
             BoundInclusivity::Exclusive,
@@ -536,14 +544,18 @@ fn abs_end_end_equal_exclusive_inclusive() -> Result<(), Box<dyn Error>> {
 #[test]
 fn abs_end_end_equal_exclusive_exclusive() -> Result<(), Box<dyn Error>> {
     assert_eq!(
-        AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+        AbsoluteFiniteBound::new_with_inclusivity(
             "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             BoundInclusivity::Exclusive,
-        ))
-        .bound_cmp(&AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-            "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            BoundInclusivity::Exclusive,
-        ))),
+        )
+        .to_end_bound()
+        .bound_cmp(
+            &AbsoluteFiniteBound::new_with_inclusivity(
+                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                BoundInclusivity::Exclusive,
+            )
+            .to_end_bound()
+        ),
         BoundOrdering::Equal(Some(BoundOverlapAmbiguity::BothEnds(
             BoundInclusivity::Exclusive,
             BoundInclusivity::Exclusive,

--- a/src/intervals/ops/bound_ord_tests.rs
+++ b/src/intervals/ops/bound_ord_tests.rs
@@ -568,9 +568,8 @@ fn abs_end_end_equal_exclusive_exclusive() -> Result<(), Box<dyn Error>> {
 #[test]
 fn rel_start_start_less_inf_past_finite() {
     assert_eq!(
-        RelativeStartBound::InfinitePast.bound_cmp(&RelativeStartBound::Finite(RelativeFiniteBound::new(
-            SignedDuration::from_hours(101)
-        ))),
+        RelativeStartBound::InfinitePast
+            .bound_cmp(&RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_start_bound()),
         BoundOrdering::Less,
     );
 }
@@ -578,9 +577,9 @@ fn rel_start_start_less_inf_past_finite() {
 #[test]
 fn rel_start_start_less_finite_finite() {
     assert_eq!(
-        RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(101))).bound_cmp(
-            &RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(102)))
-        ),
+        RelativeFiniteBound::new(SignedDuration::from_hours(101))
+            .to_start_bound()
+            .bound_cmp(&RelativeFiniteBound::new(SignedDuration::from_hours(102)).to_start_bound()),
         BoundOrdering::Less,
     );
 }
@@ -596,9 +595,9 @@ fn rel_start_start_equal_inf_past() {
 #[test]
 fn rel_start_start_equal_inclusive_inclusive() {
     assert_eq!(
-        RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(101))).bound_cmp(
-            &RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(101)))
-        ),
+        RelativeFiniteBound::new(SignedDuration::from_hours(101))
+            .to_start_bound()
+            .bound_cmp(&RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_start_bound()),
         BoundOrdering::Equal(Some(BoundOverlapAmbiguity::BothStarts(
             BoundInclusivity::Inclusive,
             BoundInclusivity::Inclusive,
@@ -609,12 +608,15 @@ fn rel_start_start_equal_inclusive_inclusive() {
 #[test]
 fn rel_start_start_equal_inclusive_exclusive() {
     assert_eq!(
-        RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(101))).bound_cmp(
-            &RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                SignedDuration::from_hours(101),
-                BoundInclusivity::Exclusive,
-            ))
-        ),
+        RelativeFiniteBound::new(SignedDuration::from_hours(101))
+            .to_start_bound()
+            .bound_cmp(
+                &RelativeFiniteBound::new_with_inclusivity(
+                    SignedDuration::from_hours(101),
+                    BoundInclusivity::Exclusive,
+                )
+                .to_start_bound()
+            ),
         BoundOrdering::Equal(Some(BoundOverlapAmbiguity::BothStarts(
             BoundInclusivity::Exclusive,
             BoundInclusivity::Inclusive,
@@ -625,13 +627,9 @@ fn rel_start_start_equal_inclusive_exclusive() {
 #[test]
 fn rel_start_start_equal_exclusive_inclusive() {
     assert_eq!(
-        RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-            SignedDuration::from_hours(101),
-            BoundInclusivity::Exclusive,
-        ))
-        .bound_cmp(&RelativeStartBound::Finite(RelativeFiniteBound::new(
-            SignedDuration::from_hours(101)
-        ))),
+        RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(101), BoundInclusivity::Exclusive,)
+            .to_start_bound()
+            .bound_cmp(&RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_start_bound()),
         BoundOrdering::Equal(Some(BoundOverlapAmbiguity::BothStarts(
             BoundInclusivity::Inclusive,
             BoundInclusivity::Exclusive,
@@ -642,14 +640,15 @@ fn rel_start_start_equal_exclusive_inclusive() {
 #[test]
 fn rel_start_start_equal_exclusive_exclusive() {
     assert_eq!(
-        RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-            SignedDuration::from_hours(101),
-            BoundInclusivity::Exclusive,
-        ))
-        .bound_cmp(&RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-            SignedDuration::from_hours(101),
-            BoundInclusivity::Exclusive,
-        ))),
+        RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(101), BoundInclusivity::Exclusive,)
+            .to_start_bound()
+            .bound_cmp(
+                &RelativeFiniteBound::new_with_inclusivity(
+                    SignedDuration::from_hours(101),
+                    BoundInclusivity::Exclusive,
+                )
+                .to_start_bound()
+            ),
         BoundOrdering::Equal(Some(BoundOverlapAmbiguity::BothStarts(
             BoundInclusivity::Exclusive,
             BoundInclusivity::Exclusive,
@@ -660,7 +659,8 @@ fn rel_start_start_equal_exclusive_exclusive() {
 #[test]
 fn rel_start_start_greater_finite_inf_past() {
     assert_eq!(
-        RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(101)))
+        RelativeFiniteBound::new(SignedDuration::from_hours(101))
+            .to_start_bound()
             .bound_cmp(&RelativeStartBound::InfinitePast),
         BoundOrdering::Greater,
     );
@@ -669,9 +669,9 @@ fn rel_start_start_greater_finite_inf_past() {
 #[test]
 fn rel_start_start_greater_finite_finite() {
     assert_eq!(
-        RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(102))).bound_cmp(
-            &RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(101)))
-        ),
+        RelativeFiniteBound::new(SignedDuration::from_hours(102))
+            .to_start_bound()
+            .bound_cmp(&RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_start_bound()),
         BoundOrdering::Greater,
     );
 }
@@ -697,7 +697,8 @@ fn rel_start_end_less_inf_past_finite() {
 #[test]
 fn rel_start_end_less_finite_inf_future() {
     assert_eq!(
-        RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(101)))
+        RelativeFiniteBound::new(SignedDuration::from_hours(101))
+            .to_start_bound()
             .bound_cmp(&RelativeEndBound::InfiniteFuture),
         BoundOrdering::Less,
     );
@@ -706,9 +707,11 @@ fn rel_start_end_less_finite_inf_future() {
 #[test]
 fn rel_start_end_less_finite_finite() {
     assert_eq!(
-        RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(101))).bound_cmp(
-            &RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(102)))
-        ),
+        RelativeFiniteBound::new(SignedDuration::from_hours(101))
+            .to_start_bound()
+            .bound_cmp(&RelativeEndBound::Finite(RelativeFiniteBound::new(
+                SignedDuration::from_hours(102)
+            ))),
         BoundOrdering::Less,
     );
 }
@@ -716,9 +719,11 @@ fn rel_start_end_less_finite_finite() {
 #[test]
 fn rel_start_end_equal_inclusive_inclusive() {
     assert_eq!(
-        RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(101))).bound_cmp(
-            &RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(101)))
-        ),
+        RelativeFiniteBound::new(SignedDuration::from_hours(101))
+            .to_start_bound()
+            .bound_cmp(&RelativeEndBound::Finite(RelativeFiniteBound::new(
+                SignedDuration::from_hours(101)
+            ))),
         BoundOrdering::Equal(Some(BoundOverlapAmbiguity::EndStart(
             BoundInclusivity::Inclusive,
             BoundInclusivity::Inclusive,
@@ -729,12 +734,12 @@ fn rel_start_end_equal_inclusive_inclusive() {
 #[test]
 fn rel_start_end_equal_inclusive_exclusive() {
     assert_eq!(
-        RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(101))).bound_cmp(
-            &RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
+        RelativeFiniteBound::new(SignedDuration::from_hours(101))
+            .to_start_bound()
+            .bound_cmp(&RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
                 SignedDuration::from_hours(101),
                 BoundInclusivity::Exclusive,
-            ))
-        ),
+            ))),
         BoundOrdering::Equal(Some(BoundOverlapAmbiguity::EndStart(
             BoundInclusivity::Exclusive,
             BoundInclusivity::Inclusive,
@@ -745,13 +750,11 @@ fn rel_start_end_equal_inclusive_exclusive() {
 #[test]
 fn rel_start_end_equal_exclusive_inclusive() {
     assert_eq!(
-        RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-            SignedDuration::from_hours(101),
-            BoundInclusivity::Exclusive,
-        ))
-        .bound_cmp(&RelativeEndBound::Finite(RelativeFiniteBound::new(
-            SignedDuration::from_hours(101)
-        ))),
+        RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(101), BoundInclusivity::Exclusive,)
+            .to_start_bound()
+            .bound_cmp(&RelativeEndBound::Finite(RelativeFiniteBound::new(
+                SignedDuration::from_hours(101)
+            ))),
         BoundOrdering::Equal(Some(BoundOverlapAmbiguity::EndStart(
             BoundInclusivity::Inclusive,
             BoundInclusivity::Exclusive,
@@ -762,14 +765,12 @@ fn rel_start_end_equal_exclusive_inclusive() {
 #[test]
 fn rel_start_end_equal_exclusive_exclusive() {
     assert_eq!(
-        RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-            SignedDuration::from_hours(101),
-            BoundInclusivity::Exclusive,
-        ))
-        .bound_cmp(&RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-            SignedDuration::from_hours(101),
-            BoundInclusivity::Exclusive,
-        ))),
+        RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(101), BoundInclusivity::Exclusive,)
+            .to_start_bound()
+            .bound_cmp(&RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
+                SignedDuration::from_hours(101),
+                BoundInclusivity::Exclusive,
+            ))),
         BoundOrdering::Equal(Some(BoundOverlapAmbiguity::EndStart(
             BoundInclusivity::Exclusive,
             BoundInclusivity::Exclusive,
@@ -780,9 +781,11 @@ fn rel_start_end_equal_exclusive_exclusive() {
 #[test]
 fn rel_start_end_greater() {
     assert_eq!(
-        RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(102))).bound_cmp(
-            &RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(101)))
-        ),
+        RelativeFiniteBound::new(SignedDuration::from_hours(102))
+            .to_start_bound()
+            .bound_cmp(&RelativeEndBound::Finite(RelativeFiniteBound::new(
+                SignedDuration::from_hours(101)
+            ))),
         BoundOrdering::Greater,
     );
 }
@@ -790,9 +793,8 @@ fn rel_start_end_greater() {
 #[test]
 fn rel_end_start_less() {
     assert_eq!(
-        RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(101))).bound_cmp(
-            &RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(102)))
-        ),
+        RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(101)))
+            .bound_cmp(&RelativeFiniteBound::new(SignedDuration::from_hours(102)).to_start_bound()),
         BoundOrdering::Less,
     );
 }
@@ -800,9 +802,8 @@ fn rel_end_start_less() {
 #[test]
 fn rel_end_start_equal_inclusive_inclusive() {
     assert_eq!(
-        RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(101))).bound_cmp(
-            &RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(101)))
-        ),
+        RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(101)))
+            .bound_cmp(&RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_start_bound()),
         BoundOrdering::Equal(Some(BoundOverlapAmbiguity::StartEnd(
             BoundInclusivity::Inclusive,
             BoundInclusivity::Inclusive,
@@ -814,10 +815,8 @@ fn rel_end_start_equal_inclusive_inclusive() {
 fn rel_end_start_equal_inclusive_exclusive() {
     assert_eq!(
         RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(101))).bound_cmp(
-            &RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                SignedDuration::from_hours(101),
-                BoundInclusivity::Exclusive,
-            ))
+            &RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(101), BoundInclusivity::Exclusive,)
+                .to_start_bound()
         ),
         BoundOrdering::Equal(Some(BoundOverlapAmbiguity::StartEnd(
             BoundInclusivity::Exclusive,
@@ -833,9 +832,7 @@ fn rel_end_start_equal_exclusive_inclusive() {
             SignedDuration::from_hours(101),
             BoundInclusivity::Exclusive,
         ))
-        .bound_cmp(&RelativeStartBound::Finite(RelativeFiniteBound::new(
-            SignedDuration::from_hours(101)
-        ))),
+        .bound_cmp(&RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_start_bound()),
         BoundOrdering::Equal(Some(BoundOverlapAmbiguity::StartEnd(
             BoundInclusivity::Inclusive,
             BoundInclusivity::Exclusive,
@@ -850,10 +847,10 @@ fn rel_end_start_equal_exclusive_exclusive() {
             SignedDuration::from_hours(101),
             BoundInclusivity::Exclusive,
         ))
-        .bound_cmp(&RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-            SignedDuration::from_hours(101),
-            BoundInclusivity::Exclusive,
-        ))),
+        .bound_cmp(
+            &RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(101), BoundInclusivity::Exclusive,)
+                .to_start_bound()
+        ),
         BoundOrdering::Equal(Some(BoundOverlapAmbiguity::StartEnd(
             BoundInclusivity::Exclusive,
             BoundInclusivity::Exclusive,
@@ -872,9 +869,8 @@ fn rel_end_start_greater_inf_future_inf_past() {
 #[test]
 fn rel_end_start_greater_inf_future_finite() {
     assert_eq!(
-        RelativeEndBound::InfiniteFuture.bound_cmp(&RelativeStartBound::Finite(RelativeFiniteBound::new(
-            SignedDuration::from_hours(101)
-        ))),
+        RelativeEndBound::InfiniteFuture
+            .bound_cmp(&RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_start_bound()),
         BoundOrdering::Greater,
     );
 }
@@ -891,9 +887,8 @@ fn rel_end_start_greater_finite_inf_past() {
 #[test]
 fn rel_end_start_greater_finite_finite() {
     assert_eq!(
-        RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(102))).bound_cmp(
-            &RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(101)))
-        ),
+        RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(102)))
+            .bound_cmp(&RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_start_bound()),
         BoundOrdering::Greater,
     );
 }

--- a/src/intervals/ops/continuation.rs
+++ b/src/intervals/ops/continuation.rs
@@ -538,10 +538,10 @@ pub fn future_continuation_rel_bound_pair(bounds: &RelativeBoundPair) -> Emptiab
     match bounds.rel_end() {
         RelativeEndBound::InfiniteFuture => EmptiableRelativeBoundPair::Empty,
         RelativeEndBound::Finite(finite) => EmptiableRelativeBoundPair::from(RelativeBoundPair::new(
-            RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
+            RelativeFiniteBound::new_with_inclusivity(
                 finite.offset(),
                 finite.inclusivity().opposite(),
-            )),
+            ).to_start_bound(),
             RelativeEndBound::InfiniteFuture,
         )),
     }

--- a/src/intervals/ops/continuation.rs
+++ b/src/intervals/ops/continuation.rs
@@ -323,11 +323,11 @@ impl Continuable for HalfBoundedAbsoluteInterval {
     type Output = EmptiableAbsoluteInterval;
 
     fn past_continuation(&self) -> Self::Output {
-        EmptiableAbsoluteInterval::from(past_continuation_abs_bound_pair(&self.abs_bound_pair()))
+        past_continuation_abs_bound_pair(&self.abs_bound_pair()).to_emptiable_interval()
     }
 
     fn future_continuation(&self) -> Self::Output {
-        EmptiableAbsoluteInterval::from(future_continuation_abs_bound_pair(&self.abs_bound_pair()))
+        future_continuation_abs_bound_pair(&self.abs_bound_pair()).to_emptiable_interval()
     }
 }
 
@@ -399,11 +399,11 @@ impl Continuable for HalfBoundedRelativeInterval {
     type Output = EmptiableRelativeInterval;
 
     fn past_continuation(&self) -> Self::Output {
-        Self::Output::from(past_continuation_rel_bound_pair(&self.rel_bound_pair()))
+        past_continuation_rel_bound_pair(&self.rel_bound_pair()).to_emptiable_interval()
     }
 
     fn future_continuation(&self) -> Self::Output {
-        Self::Output::from(future_continuation_rel_bound_pair(&self.rel_bound_pair()))
+        future_continuation_rel_bound_pair(&self.rel_bound_pair()).to_emptiable_interval()
     }
 }
 
@@ -440,10 +440,7 @@ pub fn past_continuation_abs_bound_pair(bounds: &AbsoluteBoundPair) -> Emptiable
         AbsoluteStartBound::InfinitePast => EmptiableAbsoluteBoundPair::Empty,
         AbsoluteStartBound::Finite(finite) => EmptiableAbsoluteBoundPair::from(AbsoluteBoundPair::new(
             AbsoluteStartBound::InfinitePast,
-            AbsoluteFiniteBound::new_with_inclusivity(
-                finite.time(),
-                finite.inclusivity().opposite(),
-            ).to_end_bound(),
+            AbsoluteFiniteBound::new_with_inclusivity(finite.time(), finite.inclusivity().opposite()).to_end_bound(),
         )),
     }
 }
@@ -456,10 +453,7 @@ pub fn future_continuation_abs_bound_pair(bounds: &AbsoluteBoundPair) -> Emptiab
     match bounds.abs_end() {
         AbsoluteEndBound::InfiniteFuture => EmptiableAbsoluteBoundPair::Empty,
         AbsoluteEndBound::Finite(finite) => EmptiableAbsoluteBoundPair::from(AbsoluteBoundPair::new(
-            AbsoluteFiniteBound::new_with_inclusivity(
-                finite.time(),
-                finite.inclusivity().opposite(),
-            ).to_start_bound(),
+            AbsoluteFiniteBound::new_with_inclusivity(finite.time(), finite.inclusivity().opposite()).to_start_bound(),
             AbsoluteEndBound::InfiniteFuture,
         )),
     }
@@ -522,10 +516,7 @@ pub fn past_continuation_rel_bound_pair(bounds: &RelativeBoundPair) -> Emptiable
         RelativeStartBound::InfinitePast => EmptiableRelativeBoundPair::Empty,
         RelativeStartBound::Finite(finite) => EmptiableRelativeBoundPair::from(RelativeBoundPair::new(
             RelativeStartBound::InfinitePast,
-            RelativeFiniteBound::new_with_inclusivity(
-                finite.offset(),
-                finite.inclusivity().opposite(),
-            ).to_end_bound(),
+            RelativeFiniteBound::new_with_inclusivity(finite.offset(), finite.inclusivity().opposite()).to_end_bound(),
         )),
     }
 }
@@ -538,10 +529,8 @@ pub fn future_continuation_rel_bound_pair(bounds: &RelativeBoundPair) -> Emptiab
     match bounds.rel_end() {
         RelativeEndBound::InfiniteFuture => EmptiableRelativeBoundPair::Empty,
         RelativeEndBound::Finite(finite) => EmptiableRelativeBoundPair::from(RelativeBoundPair::new(
-            RelativeFiniteBound::new_with_inclusivity(
-                finite.offset(),
-                finite.inclusivity().opposite(),
-            ).to_start_bound(),
+            RelativeFiniteBound::new_with_inclusivity(finite.offset(), finite.inclusivity().opposite())
+                .to_start_bound(),
             RelativeEndBound::InfiniteFuture,
         )),
     }

--- a/src/intervals/ops/continuation.rs
+++ b/src/intervals/ops/continuation.rs
@@ -522,10 +522,10 @@ pub fn past_continuation_rel_bound_pair(bounds: &RelativeBoundPair) -> Emptiable
         RelativeStartBound::InfinitePast => EmptiableRelativeBoundPair::Empty,
         RelativeStartBound::Finite(finite) => EmptiableRelativeBoundPair::from(RelativeBoundPair::new(
             RelativeStartBound::InfinitePast,
-            RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
+            RelativeFiniteBound::new_with_inclusivity(
                 finite.offset(),
                 finite.inclusivity().opposite(),
-            )),
+            ).to_end_bound(),
         )),
     }
 }

--- a/src/intervals/ops/continuation.rs
+++ b/src/intervals/ops/continuation.rs
@@ -456,10 +456,10 @@ pub fn future_continuation_abs_bound_pair(bounds: &AbsoluteBoundPair) -> Emptiab
     match bounds.abs_end() {
         AbsoluteEndBound::InfiniteFuture => EmptiableAbsoluteBoundPair::Empty,
         AbsoluteEndBound::Finite(finite) => EmptiableAbsoluteBoundPair::from(AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 finite.time(),
                 finite.inclusivity().opposite(),
-            )),
+            ).to_start_bound(),
             AbsoluteEndBound::InfiniteFuture,
         )),
     }

--- a/src/intervals/ops/continuation.rs
+++ b/src/intervals/ops/continuation.rs
@@ -440,10 +440,10 @@ pub fn past_continuation_abs_bound_pair(bounds: &AbsoluteBoundPair) -> Emptiable
         AbsoluteStartBound::InfinitePast => EmptiableAbsoluteBoundPair::Empty,
         AbsoluteStartBound::Finite(finite) => EmptiableAbsoluteBoundPair::from(AbsoluteBoundPair::new(
             AbsoluteStartBound::InfinitePast,
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 finite.time(),
                 finite.inclusivity().opposite(),
-            )),
+            ).to_end_bound(),
         )),
     }
 }

--- a/src/intervals/ops/continuation_tests.rs
+++ b/src/intervals/ops/continuation_tests.rs
@@ -164,9 +164,7 @@ fn future_continuation_abs_bounds_unbounded() {
 fn past_continuation_abs_bounds_bounded() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             )),
@@ -188,19 +186,18 @@ fn past_continuation_abs_bounds_bounded() -> Result<(), Box<dyn Error>> {
 fn future_continuation_abs_bounds_bounded() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             )),
         )
         .future_continuation(),
         EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::InfiniteFuture,
         )),
     );

--- a/src/intervals/ops/continuation_tests.rs
+++ b/src/intervals/ops/continuation_tests.rs
@@ -165,17 +165,16 @@ fn past_continuation_abs_bounds_bounded() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         )
         .past_continuation(),
         EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
             AbsoluteStartBound::InfinitePast,
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         )),
     );
 
@@ -187,9 +186,7 @@ fn future_continuation_abs_bounds_bounded() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         )
         .future_continuation(),
         EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(

--- a/src/intervals/ops/cut.rs
+++ b/src/intervals/ops/cut.rs
@@ -905,10 +905,10 @@ pub fn cut_rel_bound_pair(
         at,
         cut_type.past_bound_inclusivity(),
     ));
-    let future_cut_start = RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
+    let future_cut_start = RelativeFiniteBound::new_with_inclusivity(
         at,
         cut_type.future_bound_inclusivity(),
-    ));
+    ).to_start_bound();
 
     if check_relative_bound_pair_for_interval_creation(&bounds.start(), &past_cut_end).is_err()
         || check_relative_bound_pair_for_interval_creation(&future_cut_start, &bounds.end()).is_err()
@@ -924,10 +924,10 @@ pub fn cut_rel_bound_pair(
         cut_type.past_bound_inclusivity(),
     )));
 
-    future_split.set_start(RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
+    future_split.set_start(RelativeFiniteBound::new_with_inclusivity(
         at,
         cut_type.future_bound_inclusivity(),
-    )));
+    ).to_start_bound());
 
     CutResult::Cut(past_split, future_split)
 }

--- a/src/intervals/ops/cut.rs
+++ b/src/intervals/ops/cut.rs
@@ -674,7 +674,7 @@ impl Cuttable<Timestamp> for AbsoluteInterval {
 
     fn cut_at(&self, position: Timestamp, cut_type: CutType) -> CutResult<Self::Output> {
         cut_abs_bound_pair(&self.abs_bound_pair(), position, cut_type)
-            .map_cut(|c1, c2| (AbsoluteInterval::from(c1), AbsoluteInterval::from(c2)))
+            .map_cut(|c1, c2| (c1.to_interval(), c2.to_interval()))
     }
 }
 
@@ -683,7 +683,7 @@ impl Cuttable<Timestamp> for EmptiableAbsoluteInterval {
 
     fn cut_at(&self, position: Timestamp, cut_type: CutType) -> CutResult<Self::Output> {
         cut_emptiable_abs_bound_pair(&self.emptiable_abs_bound_pair(), position, cut_type)
-            .map_cut(|c1, c2| (EmptiableAbsoluteInterval::from(c1), EmptiableAbsoluteInterval::from(c2)))
+            .map_cut(|c1, c2| (c1.to_emptiable_interval(), c2.to_emptiable_interval()))
     }
 }
 
@@ -700,7 +700,7 @@ impl Cuttable<Timestamp> for HalfBoundedAbsoluteInterval {
 
     fn cut_at(&self, position: Timestamp, cut_type: CutType) -> CutResult<Self::Output> {
         cut_abs_bound_pair(&self.abs_bound_pair(), position, cut_type)
-            .map_cut(|c1, c2| (AbsoluteInterval::from(c1), AbsoluteInterval::from(c2)))
+            .map_cut(|c1, c2| (c1.to_interval(), c2.to_interval()))
     }
 }
 
@@ -725,7 +725,7 @@ impl Cuttable<SignedDuration> for RelativeInterval {
 
     fn cut_at(&self, position: SignedDuration, cut_type: CutType) -> CutResult<Self::Output> {
         cut_rel_bound_pair(&self.rel_bound_pair(), position, cut_type)
-            .map_cut(|c1, c2| (RelativeInterval::from(c1), RelativeInterval::from(c2)))
+            .map_cut(|c1, c2| (c1.to_interval(), c2.to_interval()))
     }
 }
 
@@ -734,7 +734,7 @@ impl Cuttable<SignedDuration> for EmptiableRelativeInterval {
 
     fn cut_at(&self, position: SignedDuration, cut_type: CutType) -> CutResult<Self::Output> {
         cut_emptiable_rel_bound_pair(&self.emptiable_rel_bound_pair(), position, cut_type)
-            .map_cut(|c1, c2| (EmptiableRelativeInterval::from(c1), EmptiableRelativeInterval::from(c2)))
+            .map_cut(|c1, c2| (c1.to_emptiable_interval(), c2.to_emptiable_interval()))
     }
 }
 
@@ -751,7 +751,7 @@ impl Cuttable<SignedDuration> for HalfBoundedRelativeInterval {
 
     fn cut_at(&self, position: SignedDuration, cut_type: CutType) -> CutResult<Self::Output> {
         cut_rel_bound_pair(&self.rel_bound_pair(), position, cut_type)
-            .map_cut(|c1, c2| (RelativeInterval::from(c1), RelativeInterval::from(c2)))
+            .map_cut(|c1, c2| (c1.to_interval(), c2.to_interval()))
     }
 }
 
@@ -760,7 +760,7 @@ impl Cuttable<Timestamp> for UnboundedInterval {
 
     fn cut_at(&self, position: Timestamp, cut_type: CutType) -> CutResult<Self::Output> {
         cut_abs_bound_pair(&self.abs_bound_pair(), position, cut_type)
-            .map_cut(|c1, c2| (AbsoluteInterval::from(c1), AbsoluteInterval::from(c2)))
+            .map_cut(|c1, c2| (c1.to_interval(), c2.to_interval()))
     }
 }
 
@@ -769,7 +769,7 @@ impl Cuttable<SignedDuration> for UnboundedInterval {
 
     fn cut_at(&self, position: SignedDuration, cut_type: CutType) -> CutResult<Self::Output> {
         cut_rel_bound_pair(&self.rel_bound_pair(), position, cut_type)
-            .map_cut(|c1, c2| (RelativeInterval::from(c1), RelativeInterval::from(c2)))
+            .map_cut(|c1, c2| (c1.to_interval(), c2.to_interval()))
     }
 }
 

--- a/src/intervals/ops/cut.rs
+++ b/src/intervals/ops/cut.rs
@@ -191,7 +191,6 @@ use crate::intervals::absolute::{
     AbsoluteEndBound,
     AbsoluteFiniteBound,
     AbsoluteInterval,
-    AbsoluteStartBound,
     BoundedAbsoluteInterval,
     EmptiableAbsoluteBoundPair,
     EmptiableAbsoluteInterval,
@@ -810,10 +809,8 @@ pub fn cut_abs_bound_pair(
         at,
         cut_type.past_bound_inclusivity(),
     ));
-    let future_cut_start = AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-        at,
-        cut_type.future_bound_inclusivity(),
-    ));
+    let future_cut_start =
+        AbsoluteFiniteBound::new_with_inclusivity(at, cut_type.future_bound_inclusivity()).to_start_bound();
 
     if check_absolute_bound_pair_for_interval_creation(&bounds.start(), &past_cut_end).is_err()
         || check_absolute_bound_pair_for_interval_creation(&future_cut_start, &bounds.end()).is_err()
@@ -829,10 +826,8 @@ pub fn cut_abs_bound_pair(
         cut_type.past_bound_inclusivity(),
     )));
 
-    future_split.set_start(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-        at,
-        cut_type.future_bound_inclusivity(),
-    )));
+    future_split
+        .set_start(AbsoluteFiniteBound::new_with_inclusivity(at, cut_type.future_bound_inclusivity()).to_start_bound());
 
     CutResult::Cut(past_split, future_split)
 }

--- a/src/intervals/ops/cut.rs
+++ b/src/intervals/ops/cut.rs
@@ -188,7 +188,6 @@ use serde::{Deserialize, Serialize};
 use super::point_containment::CanPositionPointContainment;
 use crate::intervals::absolute::{
     AbsoluteBoundPair,
-    AbsoluteEndBound,
     AbsoluteFiniteBound,
     AbsoluteInterval,
     BoundedAbsoluteInterval,
@@ -805,10 +804,7 @@ pub fn cut_abs_bound_pair(
         return CutResult::Uncut;
     }
 
-    let past_cut_end = AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-        at,
-        cut_type.past_bound_inclusivity(),
-    ));
+    let past_cut_end = AbsoluteFiniteBound::new_with_inclusivity(at, cut_type.past_bound_inclusivity()).to_end_bound();
     let future_cut_start =
         AbsoluteFiniteBound::new_with_inclusivity(at, cut_type.future_bound_inclusivity()).to_start_bound();
 
@@ -821,10 +817,7 @@ pub fn cut_abs_bound_pair(
     let mut past_split = bounds.clone();
     let mut future_split = bounds.clone();
 
-    past_split.set_end(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-        at,
-        cut_type.past_bound_inclusivity(),
-    )));
+    past_split.set_end(AbsoluteFiniteBound::new_with_inclusivity(at, cut_type.past_bound_inclusivity()).to_end_bound());
 
     future_split
         .set_start(AbsoluteFiniteBound::new_with_inclusivity(at, cut_type.future_bound_inclusivity()).to_start_bound());

--- a/src/intervals/ops/cut.rs
+++ b/src/intervals/ops/cut.rs
@@ -207,10 +207,8 @@ use crate::intervals::relative::{
     HasEmptiableRelativeBoundPair,
     HasRelativeBoundPair,
     RelativeBoundPair,
-    RelativeEndBound,
     RelativeFiniteBound,
     RelativeInterval,
-    RelativeStartBound,
     check_relative_bound_pair_for_interval_creation,
 };
 use crate::intervals::special::{EmptyInterval, UnboundedInterval};
@@ -901,14 +899,9 @@ pub fn cut_rel_bound_pair(
         return CutResult::Uncut;
     }
 
-    let past_cut_end = RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-        at,
-        cut_type.past_bound_inclusivity(),
-    ));
-    let future_cut_start = RelativeFiniteBound::new_with_inclusivity(
-        at,
-        cut_type.future_bound_inclusivity(),
-    ).to_start_bound();
+    let past_cut_end = RelativeFiniteBound::new_with_inclusivity(at, cut_type.past_bound_inclusivity()).to_end_bound();
+    let future_cut_start =
+        RelativeFiniteBound::new_with_inclusivity(at, cut_type.future_bound_inclusivity()).to_start_bound();
 
     if check_relative_bound_pair_for_interval_creation(&bounds.start(), &past_cut_end).is_err()
         || check_relative_bound_pair_for_interval_creation(&future_cut_start, &bounds.end()).is_err()
@@ -919,15 +912,10 @@ pub fn cut_rel_bound_pair(
     let mut past_split = bounds.clone();
     let mut future_split = bounds.clone();
 
-    past_split.set_end(RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-        at,
-        cut_type.past_bound_inclusivity(),
-    )));
+    past_split.set_end(RelativeFiniteBound::new_with_inclusivity(at, cut_type.past_bound_inclusivity()).to_end_bound());
 
-    future_split.set_start(RelativeFiniteBound::new_with_inclusivity(
-        at,
-        cut_type.future_bound_inclusivity(),
-    ).to_start_bound());
+    future_split
+        .set_start(RelativeFiniteBound::new_with_inclusivity(at, cut_type.future_bound_inclusivity()).to_start_bound());
 
     CutResult::Cut(past_split, future_split)
 }

--- a/src/intervals/ops/extend_tests.rs
+++ b/src/intervals/ops/extend_tests.rs
@@ -44,9 +44,8 @@ fn abs_bound_pair_unbounded_bounded() -> Result<(), Box<dyn Error>> {
             &AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             )
         ),
         AbsoluteBoundPair::new(AbsoluteStartBound::InfinitePast, AbsoluteEndBound::InfiniteFuture),
@@ -97,9 +96,7 @@ fn abs_bound_pair_two_half_bounded_same_ref_time() -> Result<(), Box<dyn Error>>
     assert_eq!(
         AbsoluteBoundPair::new(
             AbsoluteStartBound::InfinitePast,
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            ))
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound()
         )
         .extend(&AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
@@ -116,9 +113,7 @@ fn abs_bound_pair_two_half_bounded_with_gap() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
             AbsoluteStartBound::InfinitePast,
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         )
         .extend(&AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
@@ -155,9 +150,7 @@ fn abs_bound_pair_bounded_half_bounded_with_gap() -> Result<(), Box<dyn Error>> 
     assert_eq!(
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         )
         .extend(&AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
@@ -177,21 +170,15 @@ fn abs_bound_pair_two_bounded_with_gap() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         )
         .extend(&AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         )),
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
     );
 
@@ -203,21 +190,15 @@ fn abs_bound_pair_two_bounded_overlapping() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         )
         .extend(&AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         )),
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
     );
 

--- a/src/intervals/ops/extend_tests.rs
+++ b/src/intervals/ops/extend_tests.rs
@@ -26,9 +26,8 @@ fn abs_bound_pair_unbounded_half_bounded() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(AbsoluteStartBound::InfinitePast, AbsoluteEndBound::InfiniteFuture).extend(
             &AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::InfiniteFuture,
             )
         ),
@@ -43,9 +42,8 @@ fn abs_bound_pair_unbounded_bounded() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(AbsoluteStartBound::InfinitePast, AbsoluteEndBound::InfiniteFuture).extend(
             &AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 )),
@@ -61,9 +59,7 @@ fn abs_bound_pair_unbounded_bounded() -> Result<(), Box<dyn Error>> {
 fn abs_bound_pair_half_bounded_unbounded() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::InfiniteFuture,
         )
         .extend(&AbsoluteBoundPair::new(
@@ -80,21 +76,15 @@ fn abs_bound_pair_half_bounded_unbounded() -> Result<(), Box<dyn Error>> {
 fn abs_bound_pair_two_equal_half_bounded() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::InfiniteFuture,
         )
         .extend(&AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::InfiniteFuture,
         )),
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::InfiniteFuture,
         ),
     );
@@ -112,9 +102,7 @@ fn abs_bound_pair_two_half_bounded_same_ref_time() -> Result<(), Box<dyn Error>>
             ))
         )
         .extend(&AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::InfiniteFuture,
         )),
         AbsoluteBoundPair::new(AbsoluteStartBound::InfinitePast, AbsoluteEndBound::InfiniteFuture),
@@ -133,9 +121,7 @@ fn abs_bound_pair_two_half_bounded_with_gap() -> Result<(), Box<dyn Error>> {
             )),
         )
         .extend(&AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::InfiniteFuture,
         )),
         AbsoluteBoundPair::new(AbsoluteStartBound::InfinitePast, AbsoluteEndBound::InfiniteFuture),
@@ -148,21 +134,15 @@ fn abs_bound_pair_two_half_bounded_with_gap() -> Result<(), Box<dyn Error>> {
 fn abs_bound_pair_two_half_bounded_same_direction_different_times() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::InfiniteFuture,
         )
         .extend(&AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::InfiniteFuture,
         )),
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::InfiniteFuture,
         ),
     );
@@ -174,23 +154,17 @@ fn abs_bound_pair_two_half_bounded_same_direction_different_times() -> Result<()
 fn abs_bound_pair_bounded_half_bounded_with_gap() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             )),
         )
         .extend(&AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::InfiniteFuture,
         )),
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::InfiniteFuture,
         ),
     );
@@ -202,25 +176,19 @@ fn abs_bound_pair_bounded_half_bounded_with_gap() -> Result<(), Box<dyn Error>> 
 fn abs_bound_pair_two_bounded_with_gap() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             )),
         )
         .extend(&AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             )),
         )),
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             )),
@@ -234,25 +202,19 @@ fn abs_bound_pair_two_bounded_with_gap() -> Result<(), Box<dyn Error>> {
 fn abs_bound_pair_two_bounded_overlapping() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             )),
         )
         .extend(&AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             )),
         )),
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             )),

--- a/src/intervals/ops/grow_tests.rs
+++ b/src/intervals/ops/grow_tests.rs
@@ -43,9 +43,7 @@ fn start_to_finite_unbounded_interval() -> Result<(), Box<dyn Error>> {
 fn end_to_finite_unbounded_interval() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(AbsoluteStartBound::InfinitePast, AbsoluteEndBound::InfiniteFuture).grow_end(
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            ))
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound()
         ),
         AbsoluteBoundPair::new(AbsoluteStartBound::InfinitePast, AbsoluteEndBound::InfiniteFuture),
     );
@@ -58,18 +56,14 @@ fn start_to_inside_abs_bound_pair_bounded() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            ))
+            AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound()
         )
         .grow_start(
             AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound()
         ),
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            ))
+            AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound()
         ),
     );
 
@@ -81,18 +75,14 @@ fn end_to_inside_abs_bound_pair_bounded() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            ))
+            AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound()
         )
-        .grow_end(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-        ))),
+        .grow_end(
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound()
+        ),
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            ))
+            AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound()
         ),
     );
 
@@ -104,18 +94,14 @@ fn start_to_outside_abs_bound_pair_bounded() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            ))
+            AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound()
         )
         .grow_start(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound()
         ),
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            ))
+            AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound()
         ),
     );
 
@@ -127,18 +113,14 @@ fn end_to_outside_abs_bound_pair_bounded() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            ))
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound()
         )
-        .grow_end(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-        ))),
+        .grow_end(
+            AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound()
+        ),
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            ))
+            AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound()
         ),
     );
 

--- a/src/intervals/ops/grow_tests.rs
+++ b/src/intervals/ops/grow_tests.rs
@@ -31,9 +31,7 @@ fn end_emptiable_abs_bound_pair_empty() {
 fn start_to_finite_unbounded_interval() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(AbsoluteStartBound::InfinitePast, AbsoluteEndBound::InfiniteFuture).grow_start(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            ))
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound()
         ),
         AbsoluteBoundPair::new(AbsoluteStartBound::InfinitePast, AbsoluteEndBound::InfiniteFuture),
     );
@@ -59,20 +57,16 @@ fn end_to_finite_unbounded_interval() -> Result<(), Box<dyn Error>> {
 fn start_to_inside_abs_bound_pair_bounded() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             ))
         )
-        .grow_start(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-        ))),
+        .grow_start(
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound()
+        ),
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             ))
@@ -86,9 +80,7 @@ fn start_to_inside_abs_bound_pair_bounded() -> Result<(), Box<dyn Error>> {
 fn end_to_inside_abs_bound_pair_bounded() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             ))
@@ -97,9 +89,7 @@ fn end_to_inside_abs_bound_pair_bounded() -> Result<(), Box<dyn Error>> {
             "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
         ))),
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             ))
@@ -113,20 +103,16 @@ fn end_to_inside_abs_bound_pair_bounded() -> Result<(), Box<dyn Error>> {
 fn start_to_outside_abs_bound_pair_bounded() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             ))
         )
-        .grow_start(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-        ))),
+        .grow_start(
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound()
+        ),
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             ))
@@ -140,9 +126,7 @@ fn start_to_outside_abs_bound_pair_bounded() -> Result<(), Box<dyn Error>> {
 fn end_to_outside_abs_bound_pair_bounded() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             ))
@@ -151,9 +135,7 @@ fn end_to_outside_abs_bound_pair_bounded() -> Result<(), Box<dyn Error>> {
             "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
         ))),
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             ))

--- a/src/intervals/ops/point_containment_tests.rs
+++ b/src/intervals/ops/point_containment_tests.rs
@@ -7,7 +7,6 @@ use crate::intervals::absolute::{
     AbsoluteBoundPair,
     AbsoluteEndBound,
     AbsoluteFiniteBound,
-    AbsoluteStartBound,
     EmptiableAbsoluteBoundPair,
 };
 use crate::intervals::meta::BoundInclusivity;
@@ -412,10 +411,11 @@ fn rule_counts_as_contained_deny_on_bounds_false_outside() {
 fn time_outside_before() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
@@ -432,10 +432,11 @@ fn time_outside_before() -> Result<(), Box<dyn Error>> {
 fn time_outside_after() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
@@ -463,10 +464,11 @@ fn time_outside() -> Result<(), Box<dyn Error>> {
 fn time_on_start_inclusive() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
@@ -483,10 +485,11 @@ fn time_on_start_inclusive() -> Result<(), Box<dyn Error>> {
 fn time_on_start_exclusive() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
@@ -503,10 +506,11 @@ fn time_on_start_exclusive() -> Result<(), Box<dyn Error>> {
 fn time_on_end_inclusive() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
@@ -523,10 +527,11 @@ fn time_on_end_inclusive() -> Result<(), Box<dyn Error>> {
 fn time_on_end_exclusive() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
@@ -543,10 +548,11 @@ fn time_on_end_exclusive() -> Result<(), Box<dyn Error>> {
 fn time_inside() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,

--- a/src/intervals/ops/point_containment_tests.rs
+++ b/src/intervals/ops/point_containment_tests.rs
@@ -3,12 +3,7 @@ use std::error::Error;
 use jiff::Zoned;
 
 use super::point_containment::*;
-use crate::intervals::absolute::{
-    AbsoluteBoundPair,
-    AbsoluteEndBound,
-    AbsoluteFiniteBound,
-    EmptiableAbsoluteBoundPair,
-};
+use crate::intervals::absolute::{AbsoluteBoundPair, AbsoluteFiniteBound, EmptiableAbsoluteBoundPair};
 use crate::intervals::meta::BoundInclusivity;
 
 #[test]
@@ -416,10 +411,11 @@ fn time_outside_before() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Inclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_end_bound(),
         )
         .point_containment_position("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()),
         Ok(PointContainmentPosition::OutsideBefore),
@@ -437,10 +433,11 @@ fn time_outside_after() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Inclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_end_bound(),
         )
         .point_containment_position("2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()),
         Ok(PointContainmentPosition::OutsideAfter),
@@ -469,10 +466,11 @@ fn time_on_start_inclusive() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Inclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_end_bound(),
         )
         .point_containment_position("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()),
         Ok(PointContainmentPosition::OnStart(BoundInclusivity::Inclusive)),
@@ -490,10 +488,11 @@ fn time_on_start_exclusive() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Exclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_end_bound(),
         )
         .point_containment_position("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()),
         Ok(PointContainmentPosition::OnStart(BoundInclusivity::Exclusive)),
@@ -511,10 +510,11 @@ fn time_on_end_inclusive() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Inclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_end_bound(),
         )
         .point_containment_position("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()),
         Ok(PointContainmentPosition::OnEnd(BoundInclusivity::Inclusive)),
@@ -532,10 +532,11 @@ fn time_on_end_exclusive() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Inclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         )
         .point_containment_position("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()),
         Ok(PointContainmentPosition::OnEnd(BoundInclusivity::Exclusive)),
@@ -553,10 +554,11 @@ fn time_inside() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Inclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_end_bound(),
         )
         .point_containment_position("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()),
         Ok(PointContainmentPosition::Inside),

--- a/src/intervals/ops/precision/absolute/bound_tests.rs
+++ b/src/intervals/ops/precision/absolute/bound_tests.rs
@@ -45,18 +45,20 @@ fn start_infinite() -> Result<(), Box<dyn Error>> {
 #[test]
 fn start_common_precision() -> Result<(), Box<dyn Error>> {
     assert_eq!(
-        AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+        AbsoluteFiniteBound::new_with_inclusivity(
             "2025-01-01 02:23:44[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             BoundInclusivity::Exclusive,
-        ))
+        )
+        .to_start_bound()
         .precise_bound(
             TimeZone::get("Europe/Oslo")?,
             Precision::new(Duration::from_mins(5), PrecisionMode::ToFuture)?,
         ),
-        Ok(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+        Ok(AbsoluteFiniteBound::new_with_inclusivity(
             "2025-01-01 02:25:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             BoundInclusivity::Exclusive,
-        ))),
+        )
+        .to_start_bound()),
     );
 
     Ok(())
@@ -65,10 +67,11 @@ fn start_common_precision() -> Result<(), Box<dyn Error>> {
 #[test]
 fn start_uncommon_precision_with_base() -> Result<(), Box<dyn Error>> {
     assert_eq!(
-        AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+        AbsoluteFiniteBound::new_with_inclusivity(
             "2025-01-01 02:23:44[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             BoundInclusivity::Exclusive,
-        ))
+        )
+        .to_start_bound()
         .precise_bound_with_base_time(
             TimeZone::get("Europe/Oslo")?,
             Precision::new(
@@ -77,10 +80,11 @@ fn start_uncommon_precision_with_base() -> Result<(), Box<dyn Error>> {
             )?,
             "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
         ),
-        Ok(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+        Ok(AbsoluteFiniteBound::new_with_inclusivity(
             "2025-01-01 02:30:20[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             BoundInclusivity::Exclusive,
-        ))),
+        )
+        .to_start_bound()),
     );
 
     Ok(())

--- a/src/intervals/ops/precision/absolute/bound_tests.rs
+++ b/src/intervals/ops/precision/absolute/bound_tests.rs
@@ -106,18 +106,20 @@ fn end_infinite() -> Result<(), Box<dyn Error>> {
 #[test]
 fn end_common_precision() -> Result<(), Box<dyn Error>> {
     assert_eq!(
-        AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+        AbsoluteFiniteBound::new_with_inclusivity(
             "2025-01-01 09:56:21[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             BoundInclusivity::Exclusive,
-        ))
+        )
+        .to_end_bound()
         .precise_bound(
             TimeZone::get("Europe/Oslo")?,
             Precision::new(Duration::from_mins(5), PrecisionMode::ToFuture)?,
         ),
-        Ok(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+        Ok(AbsoluteFiniteBound::new_with_inclusivity(
             "2025-01-01 10:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             BoundInclusivity::Exclusive,
-        ))),
+        )
+        .to_end_bound()),
     );
 
     Ok(())
@@ -126,10 +128,11 @@ fn end_common_precision() -> Result<(), Box<dyn Error>> {
 #[test]
 fn end_uncommon_precision_with_base() -> Result<(), Box<dyn Error>> {
     assert_eq!(
-        AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+        AbsoluteFiniteBound::new_with_inclusivity(
             "2025-01-01 09:56:21[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             BoundInclusivity::Exclusive,
-        ))
+        )
+        .to_end_bound()
         .precise_bound_with_base_time(
             TimeZone::get("Europe/Oslo")?,
             Precision::new(
@@ -138,10 +141,11 @@ fn end_uncommon_precision_with_base() -> Result<(), Box<dyn Error>> {
             )?,
             "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
         ),
-        Ok(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+        Ok(AbsoluteFiniteBound::new_with_inclusivity(
             "2025-01-01 10:01:20[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             BoundInclusivity::Exclusive,
-        ))),
+        )
+        .to_end_bound()),
     );
 
     Ok(())

--- a/src/intervals/ops/precision/absolute/interval.rs
+++ b/src/intervals/ops/precision/absolute/interval.rs
@@ -398,12 +398,7 @@ impl PreciseAbsoluteInterval for AbsoluteInterval {
         precision_start: Precision,
         precision_end: Precision,
     ) -> Self::PrecisedIntervalOutput {
-        Ok(AbsoluteInterval::from(precise_abs_bound_pair(
-            &self.abs_bound_pair(),
-            tz,
-            precision_start,
-            precision_end,
-        )?))
+        Ok(precise_abs_bound_pair(&self.abs_bound_pair(), tz, precision_start, precision_end)?.to_interval())
     }
 
     fn precise_interval_with_different_precisions_with_base_time(
@@ -414,14 +409,15 @@ impl PreciseAbsoluteInterval for AbsoluteInterval {
         precision_end: Precision,
         base_end: Timestamp,
     ) -> Self::PrecisedIntervalOutput {
-        Ok(AbsoluteInterval::from(precise_abs_bound_pair_with_base_time(
+        Ok(precise_abs_bound_pair_with_base_time(
             &self.abs_bound_pair(),
             tz,
             precision_start,
             base_start,
             precision_end,
             base_end,
-        )?))
+        )?
+        .to_interval())
     }
 }
 
@@ -435,12 +431,9 @@ impl PreciseAbsoluteInterval for EmptiableAbsoluteInterval {
         precision_end: Precision,
     ) -> Self::PrecisedIntervalOutput {
         if let EmptiableAbsoluteBoundPair::Bound(ref abs_bound_pair) = self.emptiable_abs_bound_pair() {
-            return Ok(EmptiableAbsoluteInterval::from(precise_abs_bound_pair(
-                abs_bound_pair,
-                tz,
-                precision_start,
-                precision_end,
-            )?));
+            return Ok(
+                precise_abs_bound_pair(abs_bound_pair, tz, precision_start, precision_end)?.to_emptiable_interval(),
+            );
         }
 
         Ok(EmptiableAbsoluteInterval::Empty(EmptyInterval))
@@ -455,14 +448,15 @@ impl PreciseAbsoluteInterval for EmptiableAbsoluteInterval {
         base_end: Timestamp,
     ) -> Self::PrecisedIntervalOutput {
         if let EmptiableAbsoluteBoundPair::Bound(ref abs_bound_pair) = self.emptiable_abs_bound_pair() {
-            return Ok(EmptiableAbsoluteInterval::from(precise_abs_bound_pair_with_base_time(
+            return Ok(precise_abs_bound_pair_with_base_time(
                 abs_bound_pair,
                 tz,
                 precision_start,
                 base_start,
                 precision_end,
                 base_end,
-            )?));
+            )?
+            .to_emptiable_interval());
         }
 
         Ok(EmptiableAbsoluteInterval::Empty(EmptyInterval))

--- a/src/intervals/ops/precision/absolute/interval_tests.rs
+++ b/src/intervals/ops/precision/absolute/interval_tests.rs
@@ -5,12 +5,7 @@ use jiff::Zoned;
 use jiff::tz::TimeZone;
 
 use super::interval::*;
-use crate::intervals::absolute::{
-    AbsoluteBoundPair,
-    AbsoluteEndBound,
-    AbsoluteFiniteBound,
-    EmptiableAbsoluteBoundPair,
-};
+use crate::intervals::absolute::{AbsoluteBoundPair, AbsoluteFiniteBound, EmptiableAbsoluteBoundPair};
 use crate::intervals::meta::BoundInclusivity;
 use crate::ops::{Precision, PrecisionMode};
 
@@ -23,10 +18,11 @@ fn abs_bound_pair_same_precision() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Exclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-01 09:56:21[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         )
         .precise_interval(
             TimeZone::get("Europe/Oslo")?,
@@ -38,10 +34,11 @@ fn abs_bound_pair_same_precision() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Exclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-01 10:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         )),
     );
 
@@ -57,10 +54,11 @@ fn abs_bound_pair_different_precisions() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Exclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-01 09:56:21[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         )
         .precise_interval_with_different_precisions(
             TimeZone::get("Europe/Oslo")?,
@@ -73,10 +71,11 @@ fn abs_bound_pair_different_precisions() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Exclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-01 09:55:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         )),
     );
 

--- a/src/intervals/ops/precision/absolute/interval_tests.rs
+++ b/src/intervals/ops/precision/absolute/interval_tests.rs
@@ -9,7 +9,6 @@ use crate::intervals::absolute::{
     AbsoluteBoundPair,
     AbsoluteEndBound,
     AbsoluteFiniteBound,
-    AbsoluteStartBound,
     EmptiableAbsoluteBoundPair,
 };
 use crate::intervals::meta::BoundInclusivity;
@@ -19,10 +18,11 @@ use crate::ops::{Precision, PrecisionMode};
 fn abs_bound_pair_same_precision() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-01 02:23:44[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-01 09:56:21[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
@@ -33,10 +33,11 @@ fn abs_bound_pair_same_precision() -> Result<(), Box<dyn Error>> {
             Precision::new(Duration::from_mins(5), PrecisionMode::ToFuture)?
         ),
         Ok(AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-01 02:25:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-01 10:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
@@ -51,10 +52,11 @@ fn abs_bound_pair_same_precision() -> Result<(), Box<dyn Error>> {
 fn abs_bound_pair_different_precisions() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-01 02:23:44[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-01 09:56:21[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
@@ -66,10 +68,11 @@ fn abs_bound_pair_different_precisions() -> Result<(), Box<dyn Error>> {
             Precision::new(Duration::from_mins(5), PrecisionMode::ToPast)?,
         ),
         Ok(AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-01 02:25:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-01 09:55:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,

--- a/src/intervals/ops/relativity_conversion.rs
+++ b/src/intervals/ops/relativity_conversion.rs
@@ -192,10 +192,10 @@ impl ToAbsolute for RelativeEndBound {
         match self {
             RelativeEndBound::InfiniteFuture => AbsoluteEndBound::InfiniteFuture,
             RelativeEndBound::Finite(relative_finite) => {
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     reference + relative_finite.offset(),
                     relative_finite.inclusivity(),
-                ))
+                ).to_end_bound()
             },
         }
     }

--- a/src/intervals/ops/relativity_conversion.rs
+++ b/src/intervals/ops/relativity_conversion.rs
@@ -176,10 +176,10 @@ impl ToAbsolute for RelativeStartBound {
         match self {
             RelativeStartBound::InfinitePast => AbsoluteStartBound::InfinitePast,
             RelativeStartBound::Finite(relative_finite) => {
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     reference + relative_finite.offset(),
                     relative_finite.inclusivity(),
-                ))
+                ).to_start_bound()
             },
         }
     }

--- a/src/intervals/ops/relativity_conversion.rs
+++ b/src/intervals/ops/relativity_conversion.rs
@@ -404,10 +404,10 @@ impl ToRelative for AbsoluteEndBound {
         match self {
             AbsoluteEndBound::InfiniteFuture => RelativeEndBound::InfiniteFuture,
             AbsoluteEndBound::Finite(absolute_finite) => {
-                RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
+                RelativeFiniteBound::new_with_inclusivity(
                     absolute_finite.time().duration_since(reference),
                     absolute_finite.inclusivity(),
-                ))
+                ).to_end_bound()
             },
         }
     }

--- a/src/intervals/ops/relativity_conversion.rs
+++ b/src/intervals/ops/relativity_conversion.rs
@@ -175,12 +175,11 @@ impl ToAbsolute for RelativeStartBound {
     fn to_absolute(&self, reference: Timestamp) -> Self::AbsoluteType {
         match self {
             RelativeStartBound::InfinitePast => AbsoluteStartBound::InfinitePast,
-            RelativeStartBound::Finite(relative_finite) => {
-                AbsoluteFiniteBound::new_with_inclusivity(
-                    reference + relative_finite.offset(),
-                    relative_finite.inclusivity(),
-                ).to_start_bound()
-            },
+            RelativeStartBound::Finite(relative_finite) => AbsoluteFiniteBound::new_with_inclusivity(
+                reference + relative_finite.offset(),
+                relative_finite.inclusivity(),
+            )
+            .to_start_bound(),
         }
     }
 }
@@ -191,12 +190,11 @@ impl ToAbsolute for RelativeEndBound {
     fn to_absolute(&self, reference: Timestamp) -> Self::AbsoluteType {
         match self {
             RelativeEndBound::InfiniteFuture => AbsoluteEndBound::InfiniteFuture,
-            RelativeEndBound::Finite(relative_finite) => {
-                AbsoluteFiniteBound::new_with_inclusivity(
-                    reference + relative_finite.offset(),
-                    relative_finite.inclusivity(),
-                ).to_end_bound()
-            },
+            RelativeEndBound::Finite(relative_finite) => AbsoluteFiniteBound::new_with_inclusivity(
+                reference + relative_finite.offset(),
+                relative_finite.inclusivity(),
+            )
+            .to_end_bound(),
         }
     }
 }
@@ -387,12 +385,11 @@ impl ToRelative for AbsoluteStartBound {
     fn to_relative(&self, reference: Timestamp) -> Self::RelativeType {
         match self {
             AbsoluteStartBound::InfinitePast => RelativeStartBound::InfinitePast,
-            AbsoluteStartBound::Finite(absolute_finite) => {
-                RelativeFiniteBound::new_with_inclusivity(
-                    absolute_finite.time().duration_since(reference),
-                    absolute_finite.inclusivity(),
-                ).to_start_bound()
-            },
+            AbsoluteStartBound::Finite(absolute_finite) => RelativeFiniteBound::new_with_inclusivity(
+                absolute_finite.time().duration_since(reference),
+                absolute_finite.inclusivity(),
+            )
+            .to_start_bound(),
         }
     }
 }
@@ -403,12 +400,11 @@ impl ToRelative for AbsoluteEndBound {
     fn to_relative(&self, reference: Timestamp) -> Self::RelativeType {
         match self {
             AbsoluteEndBound::InfiniteFuture => RelativeEndBound::InfiniteFuture,
-            AbsoluteEndBound::Finite(absolute_finite) => {
-                RelativeFiniteBound::new_with_inclusivity(
-                    absolute_finite.time().duration_since(reference),
-                    absolute_finite.inclusivity(),
-                ).to_end_bound()
-            },
+            AbsoluteEndBound::Finite(absolute_finite) => RelativeFiniteBound::new_with_inclusivity(
+                absolute_finite.time().duration_since(reference),
+                absolute_finite.inclusivity(),
+            )
+            .to_end_bound(),
         }
     }
 }

--- a/src/intervals/ops/relativity_conversion.rs
+++ b/src/intervals/ops/relativity_conversion.rs
@@ -388,10 +388,10 @@ impl ToRelative for AbsoluteStartBound {
         match self {
             AbsoluteStartBound::InfinitePast => RelativeStartBound::InfinitePast,
             AbsoluteStartBound::Finite(absolute_finite) => {
-                RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
+                RelativeFiniteBound::new_with_inclusivity(
                     absolute_finite.time().duration_since(reference),
                     absolute_finite.inclusivity(),
-                ))
+                ).to_start_bound()
             },
         }
     }

--- a/src/intervals/ops/remove_overlap_or_gap_tests.rs
+++ b/src/intervals/ops/remove_overlap_or_gap_tests.rs
@@ -105,25 +105,22 @@ mod remove_overlap_or_gap {
     fn gap_between_bounded() -> Result<(), Box<dyn Error>> {
         assert_eq!(
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 )),
             )
             .remove_overlap_or_gap(&AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 )),
             )),
             OverlapOrGapRemovalResult::Single(EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
@@ -138,25 +135,22 @@ mod remove_overlap_or_gap {
     fn overlap_between_bounded() -> Result<(), Box<dyn Error>> {
         assert_eq!(
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 )),
             )
             .remove_overlap_or_gap(&AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 )),
             )),
             OverlapOrGapRemovalResult::Single(EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
@@ -171,30 +165,33 @@ mod remove_overlap_or_gap {
     fn bounded_adjacent_inclusive_inclusive() -> Result<(), Box<dyn Error>> {
         assert_eq!(
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
-                )),
+                )
+                .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
                 )),
             )
             .remove_overlap_or_gap(&AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
-                )),
+                )
+                .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
                 )),
             )),
             OverlapOrGapRemovalResult::Single(EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
-                )),
+                )
+                .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
@@ -209,30 +206,33 @@ mod remove_overlap_or_gap {
     fn bounded_adjacent_inclusive_exclusive() -> Result<(), Box<dyn Error>> {
         assert_eq!(
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
-                )),
+                )
+                .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
                 )),
             )
             .remove_overlap_or_gap(&AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
                 )),
             )),
             OverlapOrGapRemovalResult::Single(EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
-                )),
+                )
+                .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
@@ -247,30 +247,33 @@ mod remove_overlap_or_gap {
     fn bounded_adjacent_exclusive_inclusive() -> Result<(), Box<dyn Error>> {
         assert_eq!(
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
-                )),
+                )
+                .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
                 )),
             )
             .remove_overlap_or_gap(&AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
-                )),
+                )
+                .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
                 )),
             )),
             OverlapOrGapRemovalResult::Single(EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
-                )),
+                )
+                .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
@@ -285,30 +288,33 @@ mod remove_overlap_or_gap {
     fn bounded_adjacent_exclusive_exclusive() -> Result<(), Box<dyn Error>> {
         assert_eq!(
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
-                )),
+                )
+                .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
                 )),
             )
             .remove_overlap_or_gap(&AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
                 )),
             )),
             OverlapOrGapRemovalResult::Single(EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
-                )),
+                )
+                .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
@@ -323,10 +329,11 @@ mod remove_overlap_or_gap {
     fn bounded_on_unbounded() -> Result<(), Box<dyn Error>> {
         assert_eq!(
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
@@ -343,10 +350,11 @@ mod remove_overlap_or_gap {
     fn unbounded_on_bounded() -> Result<(), Box<dyn Error>> {
         assert_eq!(
             UnboundedInterval.remove_overlap_or_gap(&AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,

--- a/src/intervals/ops/remove_overlap_or_gap_tests.rs
+++ b/src/intervals/ops/remove_overlap_or_gap_tests.rs
@@ -107,24 +107,23 @@ mod remove_overlap_or_gap {
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             )
             .remove_overlap_or_gap(&AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             )),
             OverlapOrGapRemovalResult::Single(EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_end_bound(),
             ))),
         );
 
@@ -137,24 +136,23 @@ mod remove_overlap_or_gap {
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             )
             .remove_overlap_or_gap(&AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             )),
             OverlapOrGapRemovalResult::Single(EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_end_bound(),
             ))),
         );
 
@@ -170,10 +168,11 @@ mod remove_overlap_or_gap {
                     BoundInclusivity::Inclusive,
                 )
                 .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
-                )),
+                )
+                .to_end_bound(),
             )
             .remove_overlap_or_gap(&AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new_with_inclusivity(
@@ -181,10 +180,11 @@ mod remove_overlap_or_gap {
                     BoundInclusivity::Inclusive,
                 )
                 .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
-                )),
+                )
+                .to_end_bound(),
             )),
             OverlapOrGapRemovalResult::Single(EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new_with_inclusivity(
@@ -192,10 +192,11 @@ mod remove_overlap_or_gap {
                     BoundInclusivity::Inclusive,
                 )
                 .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_end_bound(),
             ))),
         );
 
@@ -211,10 +212,11 @@ mod remove_overlap_or_gap {
                     BoundInclusivity::Inclusive,
                 )
                 .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
-                )),
+                )
+                .to_end_bound(),
             )
             .remove_overlap_or_gap(&AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new_with_inclusivity(
@@ -222,10 +224,11 @@ mod remove_overlap_or_gap {
                     BoundInclusivity::Exclusive,
                 )
                 .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
-                )),
+                )
+                .to_end_bound(),
             )),
             OverlapOrGapRemovalResult::Single(EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new_with_inclusivity(
@@ -233,10 +236,11 @@ mod remove_overlap_or_gap {
                     BoundInclusivity::Inclusive,
                 )
                 .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
-                )),
+                )
+                .to_end_bound(),
             ))),
         );
 
@@ -252,10 +256,11 @@ mod remove_overlap_or_gap {
                     BoundInclusivity::Inclusive,
                 )
                 .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_end_bound(),
             )
             .remove_overlap_or_gap(&AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new_with_inclusivity(
@@ -263,10 +268,11 @@ mod remove_overlap_or_gap {
                     BoundInclusivity::Inclusive,
                 )
                 .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
-                )),
+                )
+                .to_end_bound(),
             )),
             OverlapOrGapRemovalResult::Single(EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new_with_inclusivity(
@@ -274,10 +280,11 @@ mod remove_overlap_or_gap {
                     BoundInclusivity::Inclusive,
                 )
                 .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_end_bound(),
             ))),
         );
 
@@ -293,10 +300,11 @@ mod remove_overlap_or_gap {
                     BoundInclusivity::Inclusive,
                 )
                 .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_end_bound(),
             )
             .remove_overlap_or_gap(&AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new_with_inclusivity(
@@ -304,10 +312,11 @@ mod remove_overlap_or_gap {
                     BoundInclusivity::Exclusive,
                 )
                 .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
-                )),
+                )
+                .to_end_bound(),
             )),
             OverlapOrGapRemovalResult::Single(EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new_with_inclusivity(
@@ -315,10 +324,11 @@ mod remove_overlap_or_gap {
                     BoundInclusivity::Inclusive,
                 )
                 .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
-                )),
+                )
+                .to_end_bound(),
             ))),
         );
 
@@ -334,10 +344,11 @@ mod remove_overlap_or_gap {
                     BoundInclusivity::Exclusive,
                 )
                 .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
-                )),
+                )
+                .to_end_bound(),
             )
             .remove_overlap_or_gap(&UnboundedInterval),
             OverlapOrGapRemovalResult::Single(EmptiableAbsoluteBoundPair::Empty),
@@ -355,10 +366,11 @@ mod remove_overlap_or_gap {
                     BoundInclusivity::Exclusive,
                 )
                 .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
-                )),
+                )
+                .to_end_bound(),
             )),
             OverlapOrGapRemovalResult::Split(
                 AbsoluteInterval::HalfBounded(HalfBoundedAbsoluteInterval::new_with_inclusivity(

--- a/src/intervals/ops/remove_overlap_tests.rs
+++ b/src/intervals/ops/remove_overlap_tests.rs
@@ -99,17 +99,15 @@ mod remove_overlap {
     fn bounded_no_overlap() -> Result<(), Box<dyn Error>> {
         assert_eq!(
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 )),
             )
             .remove_overlap(&AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 )),
@@ -124,20 +122,22 @@ mod remove_overlap {
     fn bounded_adjacent_inclusive_inclusive() -> Result<(), Box<dyn Error>> {
         assert_eq!(
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
-                )),
+                )
+                .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
                 )),
             )
             .remove_overlap(&AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
-                )),
+                )
+                .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
@@ -145,10 +145,11 @@ mod remove_overlap {
             )),
             Ok(OverlapRemovalResult::Single(EmptiableAbsoluteBoundPair::Bound(
                 AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Inclusive,
-                    )),
+                    )
+                    .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
@@ -164,20 +165,22 @@ mod remove_overlap {
     fn bounded_adjacent_inclusive_exclusive() -> Result<(), Box<dyn Error>> {
         assert_eq!(
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
-                )),
+                )
+                .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
                 )),
             )
             .remove_overlap(&AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
@@ -193,20 +196,22 @@ mod remove_overlap {
     fn bounded_adjacent_exclusive_inclusive() -> Result<(), Box<dyn Error>> {
         assert_eq!(
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
-                )),
+                )
+                .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
                 )),
             )
             .remove_overlap(&AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
-                )),
+                )
+                .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
@@ -222,20 +227,22 @@ mod remove_overlap {
     fn bounded_adjacent_exclusive_exclusive() -> Result<(), Box<dyn Error>> {
         assert_eq!(
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
-                )),
+                )
+                .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
                 )),
             )
             .remove_overlap(&AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
@@ -251,20 +258,22 @@ mod remove_overlap {
     fn bounded_overlap() -> Result<(), Box<dyn Error>> {
         assert_eq!(
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
-                )),
+                )
+                .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
                 )),
             )
             .remove_overlap(&AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
-                )),
+                )
+                .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
@@ -272,10 +281,11 @@ mod remove_overlap {
             )),
             Ok(OverlapRemovalResult::Single(EmptiableAbsoluteBoundPair::Bound(
                 AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Inclusive,
-                    )),
+                    )
+                    .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
@@ -291,10 +301,11 @@ mod remove_overlap {
     fn bounded_on_unbounded() -> Result<(), Box<dyn Error>> {
         assert_eq!(
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
-                )),
+                )
+                .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
@@ -315,10 +326,11 @@ mod remove_overlap {
         assert_eq!(
             AbsoluteBoundPair::new(AbsoluteStartBound::InfinitePast, AbsoluteEndBound::InfiniteFuture,).remove_overlap(
                 &AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Inclusive,
-                    )),
+                    )
+                    .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Inclusive,
@@ -334,10 +346,11 @@ mod remove_overlap {
                     )),
                 )),
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_start_bound(),
                     AbsoluteEndBound::InfiniteFuture,
                 )),
             )),

--- a/src/intervals/ops/remove_overlap_tests.rs
+++ b/src/intervals/ops/remove_overlap_tests.rs
@@ -101,16 +101,14 @@ mod remove_overlap {
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             )
             .remove_overlap(&AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             )),
             Err(OverlapRemovalNoOverlapFoundError),
         );
@@ -127,10 +125,11 @@ mod remove_overlap {
                     BoundInclusivity::Inclusive,
                 )
                 .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
-                )),
+                )
+                .to_end_bound(),
             )
             .remove_overlap(&AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new_with_inclusivity(
@@ -138,10 +137,11 @@ mod remove_overlap {
                     BoundInclusivity::Inclusive,
                 )
                 .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
-                )),
+                )
+                .to_end_bound(),
             )),
             Ok(OverlapRemovalResult::Single(EmptiableAbsoluteBoundPair::Bound(
                 AbsoluteBoundPair::new(
@@ -150,10 +150,11 @@ mod remove_overlap {
                         BoundInclusivity::Inclusive,
                     )
                     .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_end_bound(),
                 )
             ))),
         );
@@ -170,10 +171,11 @@ mod remove_overlap {
                     BoundInclusivity::Inclusive,
                 )
                 .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
-                )),
+                )
+                .to_end_bound(),
             )
             .remove_overlap(&AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new_with_inclusivity(
@@ -181,10 +183,11 @@ mod remove_overlap {
                     BoundInclusivity::Exclusive,
                 )
                 .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
-                )),
+                )
+                .to_end_bound(),
             )),
             Err(OverlapRemovalNoOverlapFoundError),
         );
@@ -201,10 +204,11 @@ mod remove_overlap {
                     BoundInclusivity::Inclusive,
                 )
                 .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_end_bound(),
             )
             .remove_overlap(&AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new_with_inclusivity(
@@ -212,10 +216,11 @@ mod remove_overlap {
                     BoundInclusivity::Inclusive,
                 )
                 .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
-                )),
+                )
+                .to_end_bound(),
             )),
             Err(OverlapRemovalNoOverlapFoundError),
         );
@@ -232,10 +237,11 @@ mod remove_overlap {
                     BoundInclusivity::Inclusive,
                 )
                 .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_end_bound(),
             )
             .remove_overlap(&AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new_with_inclusivity(
@@ -243,10 +249,11 @@ mod remove_overlap {
                     BoundInclusivity::Exclusive,
                 )
                 .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
-                )),
+                )
+                .to_end_bound(),
             )),
             Err(OverlapRemovalNoOverlapFoundError),
         );
@@ -263,10 +270,11 @@ mod remove_overlap {
                     BoundInclusivity::Inclusive,
                 )
                 .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
-                )),
+                )
+                .to_end_bound(),
             )
             .remove_overlap(&AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new_with_inclusivity(
@@ -274,10 +282,11 @@ mod remove_overlap {
                     BoundInclusivity::Inclusive,
                 )
                 .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
-                )),
+                )
+                .to_end_bound(),
             )),
             Ok(OverlapRemovalResult::Single(EmptiableAbsoluteBoundPair::Bound(
                 AbsoluteBoundPair::new(
@@ -286,10 +295,11 @@ mod remove_overlap {
                         BoundInclusivity::Inclusive,
                     )
                     .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_end_bound(),
                 )
             ))),
         );
@@ -306,10 +316,11 @@ mod remove_overlap {
                     BoundInclusivity::Inclusive,
                 )
                 .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
-                )),
+                )
+                .to_end_bound(),
             )
             .remove_overlap(&AbsoluteBoundPair::new(
                 AbsoluteStartBound::InfinitePast,
@@ -331,19 +342,21 @@ mod remove_overlap {
                         BoundInclusivity::Inclusive,
                     )
                     .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Inclusive,
-                    )),
+                    )
+                    .to_end_bound(),
                 )
             ),
             Ok(OverlapRemovalResult::Split(
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                     AbsoluteStartBound::InfinitePast,
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_end_bound(),
                 )),
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new_with_inclusivity(

--- a/src/intervals/ops/set_ops/diff_tests.rs
+++ b/src/intervals/ops/set_ops/diff_tests.rs
@@ -55,17 +55,13 @@ fn unbounded_unbounded() {
 fn bounded_no_overlap() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             )),
         )
         .differentiate(&AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             )),
@@ -80,30 +76,33 @@ fn bounded_no_overlap() -> Result<(), Box<dyn Error>> {
 fn bounded_adjacent_inclusive_inclusive() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
             )),
         )
         .differentiate(&AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
             )),
         )),
         DifferenceResult::Single(EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
@@ -118,20 +117,22 @@ fn bounded_adjacent_inclusive_inclusive() -> Result<(), Box<dyn Error>> {
 fn bounded_adjacent_inclusive_exclusive() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
             )),
         )
         .differentiate(&AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
@@ -147,20 +148,22 @@ fn bounded_adjacent_inclusive_exclusive() -> Result<(), Box<dyn Error>> {
 fn bounded_adjacent_exclusive_inclusive() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
             )),
         )
         .differentiate(&AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
@@ -176,20 +179,22 @@ fn bounded_adjacent_exclusive_inclusive() -> Result<(), Box<dyn Error>> {
 fn bounded_adjacent_exclusive_exclusive() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
             )),
         )
         .differentiate(&AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
@@ -205,25 +210,19 @@ fn bounded_adjacent_exclusive_exclusive() -> Result<(), Box<dyn Error>> {
 fn bounded_clear_overlap() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             )),
         )
         .differentiate(&AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             )),
         )),
         DifferenceResult::Single(EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
@@ -238,9 +237,7 @@ fn bounded_clear_overlap() -> Result<(), Box<dyn Error>> {
 fn bounded_on_unbounded() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             )),
@@ -260,9 +257,8 @@ fn unbounded_on_bounded() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(AbsoluteStartBound::InfinitePast, AbsoluteEndBound::InfiniteFuture,).differentiate(
             &AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 )),
@@ -277,10 +273,11 @@ fn unbounded_on_bounded() -> Result<(), Box<dyn Error>> {
                 )),
             )),
             EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_start_bound(),
                 AbsoluteEndBound::InfiniteFuture,
             )),
         ),

--- a/src/intervals/ops/set_ops/diff_tests.rs
+++ b/src/intervals/ops/set_ops/diff_tests.rs
@@ -56,15 +56,11 @@ fn bounded_no_overlap() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         )
         .differentiate(&AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         )),
         DifferenceResult::Separate,
     );
@@ -81,10 +77,11 @@ fn bounded_adjacent_inclusive_inclusive() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Inclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_end_bound(),
         )
         .differentiate(&AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new_with_inclusivity(
@@ -92,10 +89,11 @@ fn bounded_adjacent_inclusive_inclusive() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Inclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_end_bound(),
         )),
         DifferenceResult::Single(EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new_with_inclusivity(
@@ -103,10 +101,11 @@ fn bounded_adjacent_inclusive_inclusive() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Inclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         ))),
     );
 
@@ -122,10 +121,11 @@ fn bounded_adjacent_inclusive_exclusive() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Inclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_end_bound(),
         )
         .differentiate(&AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new_with_inclusivity(
@@ -133,10 +133,11 @@ fn bounded_adjacent_inclusive_exclusive() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Exclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_end_bound(),
         )),
         DifferenceResult::Separate,
     );
@@ -153,10 +154,11 @@ fn bounded_adjacent_exclusive_inclusive() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Inclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         )
         .differentiate(&AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new_with_inclusivity(
@@ -164,10 +166,11 @@ fn bounded_adjacent_exclusive_inclusive() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Inclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_end_bound(),
         )),
         DifferenceResult::Separate,
     );
@@ -184,10 +187,11 @@ fn bounded_adjacent_exclusive_exclusive() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Inclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         )
         .differentiate(&AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new_with_inclusivity(
@@ -195,10 +199,11 @@ fn bounded_adjacent_exclusive_exclusive() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Exclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_end_bound(),
         )),
         DifferenceResult::Separate,
     );
@@ -211,22 +216,19 @@ fn bounded_clear_overlap() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         )
         .differentiate(&AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         )),
         DifferenceResult::Single(EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         ))),
     );
 
@@ -238,9 +240,7 @@ fn bounded_on_unbounded() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         )
         .differentiate(&AbsoluteBoundPair::new(
             AbsoluteStartBound::InfinitePast,
@@ -259,18 +259,18 @@ fn unbounded_on_bounded() -> Result<(), Box<dyn Error>> {
             &AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             )
         ),
         DifferenceResult::Split(
             EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                 AbsoluteStartBound::InfinitePast,
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_end_bound(),
             )),
             EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new_with_inclusivity(

--- a/src/intervals/ops/set_ops/intersect_tests.rs
+++ b/src/intervals/ops/set_ops/intersect_tests.rs
@@ -59,15 +59,11 @@ fn bounded_no_overlap() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         )
         .intersect(&AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         )),
         IntersectionResult::Separate,
     );
@@ -84,10 +80,11 @@ fn bounded_adjacent_inclusive_inclusive() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Inclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_end_bound(),
         )
         .intersect(&AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new_with_inclusivity(
@@ -95,10 +92,11 @@ fn bounded_adjacent_inclusive_inclusive() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Inclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_end_bound(),
         )),
         IntersectionResult::Intersected(AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new_with_inclusivity(
@@ -106,10 +104,11 @@ fn bounded_adjacent_inclusive_inclusive() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Inclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_end_bound(),
         )),
     );
 
@@ -125,10 +124,11 @@ fn bounded_adjacent_inclusive_exclusive() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Inclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_end_bound(),
         )
         .intersect(&AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new_with_inclusivity(
@@ -136,10 +136,11 @@ fn bounded_adjacent_inclusive_exclusive() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Exclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_end_bound(),
         )),
         IntersectionResult::Separate,
     );
@@ -156,10 +157,11 @@ fn bounded_adjacent_exclusive_inclusive() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Inclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         )
         .intersect(&AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new_with_inclusivity(
@@ -167,10 +169,11 @@ fn bounded_adjacent_exclusive_inclusive() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Inclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_end_bound(),
         )),
         IntersectionResult::Separate,
     );
@@ -187,10 +190,11 @@ fn bounded_adjacent_exclusive_exclusive() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Inclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         )
         .intersect(&AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new_with_inclusivity(
@@ -198,10 +202,11 @@ fn bounded_adjacent_exclusive_exclusive() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Exclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_end_bound(),
         )),
         IntersectionResult::Separate,
     );
@@ -214,21 +219,15 @@ fn bounded_clear_overlap() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         )
         .intersect(&AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         )),
         IntersectionResult::Intersected(AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         )),
     );
 
@@ -240,9 +239,7 @@ fn bounded_on_unbounded() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         )
         .intersect(&AbsoluteBoundPair::new(
             AbsoluteStartBound::InfinitePast,
@@ -250,9 +247,7 @@ fn bounded_on_unbounded() -> Result<(), Box<dyn Error>> {
         )),
         IntersectionResult::Intersected(AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         )),
     );
 
@@ -266,16 +261,13 @@ fn unbounded_on_bounded() -> Result<(), Box<dyn Error>> {
             &AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             )
         ),
         IntersectionResult::Intersected(AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         )),
     );
 

--- a/src/intervals/ops/set_ops/intersect_tests.rs
+++ b/src/intervals/ops/set_ops/intersect_tests.rs
@@ -58,17 +58,13 @@ fn unbounded_unbounded() {
 fn bounded_no_overlap() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             )),
         )
         .intersect(&AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             )),
@@ -83,30 +79,33 @@ fn bounded_no_overlap() -> Result<(), Box<dyn Error>> {
 fn bounded_adjacent_inclusive_inclusive() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
             )),
         )
         .intersect(&AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
             )),
         )),
         IntersectionResult::Intersected(AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
@@ -121,20 +120,22 @@ fn bounded_adjacent_inclusive_inclusive() -> Result<(), Box<dyn Error>> {
 fn bounded_adjacent_inclusive_exclusive() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
             )),
         )
         .intersect(&AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
@@ -150,20 +151,22 @@ fn bounded_adjacent_inclusive_exclusive() -> Result<(), Box<dyn Error>> {
 fn bounded_adjacent_exclusive_inclusive() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
             )),
         )
         .intersect(&AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
@@ -179,20 +182,22 @@ fn bounded_adjacent_exclusive_inclusive() -> Result<(), Box<dyn Error>> {
 fn bounded_adjacent_exclusive_exclusive() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
             )),
         )
         .intersect(&AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
@@ -208,25 +213,19 @@ fn bounded_adjacent_exclusive_exclusive() -> Result<(), Box<dyn Error>> {
 fn bounded_clear_overlap() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             )),
         )
         .intersect(&AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             )),
         )),
         IntersectionResult::Intersected(AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             )),
@@ -240,9 +239,7 @@ fn bounded_clear_overlap() -> Result<(), Box<dyn Error>> {
 fn bounded_on_unbounded() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             )),
@@ -252,9 +249,7 @@ fn bounded_on_unbounded() -> Result<(), Box<dyn Error>> {
             AbsoluteEndBound::InfiniteFuture,
         )),
         IntersectionResult::Intersected(AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             )),
@@ -269,18 +264,15 @@ fn unbounded_on_bounded() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(AbsoluteStartBound::InfinitePast, AbsoluteEndBound::InfiniteFuture,).intersect(
             &AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 )),
             )
         ),
         IntersectionResult::Intersected(AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             )),

--- a/src/intervals/ops/set_ops/sym_diff_tests.rs
+++ b/src/intervals/ops/set_ops/sym_diff_tests.rs
@@ -57,17 +57,13 @@ fn unbounded_unbounded() {
 fn bounded_no_overlap() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             )),
         )
         .symmetrically_differentiate(&AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             )),
@@ -82,20 +78,22 @@ fn bounded_no_overlap() -> Result<(), Box<dyn Error>> {
 fn bounded_adjacent_inclusive_inclusive() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
             )),
         )
         .symmetrically_differentiate(&AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
@@ -103,20 +101,22 @@ fn bounded_adjacent_inclusive_inclusive() -> Result<(), Box<dyn Error>> {
         )),
         SymmetricDifferenceResult::Split(
             EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
-                )),
+                )
+                .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
                 )),
             )),
             EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
@@ -132,20 +132,22 @@ fn bounded_adjacent_inclusive_inclusive() -> Result<(), Box<dyn Error>> {
 fn bounded_adjacent_inclusive_exclusive() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
             )),
         )
         .symmetrically_differentiate(&AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
@@ -161,20 +163,22 @@ fn bounded_adjacent_inclusive_exclusive() -> Result<(), Box<dyn Error>> {
 fn bounded_adjacent_exclusive_inclusive() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
             )),
         )
         .symmetrically_differentiate(&AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
@@ -190,20 +194,22 @@ fn bounded_adjacent_exclusive_inclusive() -> Result<(), Box<dyn Error>> {
 fn bounded_adjacent_exclusive_exclusive() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
             )),
         )
         .symmetrically_differentiate(&AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
@@ -219,37 +225,35 @@ fn bounded_adjacent_exclusive_exclusive() -> Result<(), Box<dyn Error>> {
 fn bounded_clear_overlap() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             )),
         )
         .symmetrically_differentiate(&AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             )),
         )),
         SymmetricDifferenceResult::Split(
             EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
-                )),
+                )
+                .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
                 )),
             )),
             EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
@@ -265,9 +269,7 @@ fn bounded_clear_overlap() -> Result<(), Box<dyn Error>> {
 fn bounded_on_unbounded() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             )),
@@ -285,10 +287,11 @@ fn bounded_on_unbounded() -> Result<(), Box<dyn Error>> {
                 )),
             )),
             EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_start_bound(),
                 AbsoluteEndBound::InfiniteFuture,
             )),
         ),
@@ -302,9 +305,8 @@ fn unbounded_on_bounded() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(AbsoluteStartBound::InfinitePast, AbsoluteEndBound::InfiniteFuture,)
             .symmetrically_differentiate(&AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 )),
@@ -318,10 +320,11 @@ fn unbounded_on_bounded() -> Result<(), Box<dyn Error>> {
                 )),
             )),
             EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_start_bound(),
                 AbsoluteEndBound::InfiniteFuture,
             )),
         ),

--- a/src/intervals/ops/set_ops/sym_diff_tests.rs
+++ b/src/intervals/ops/set_ops/sym_diff_tests.rs
@@ -58,15 +58,11 @@ fn bounded_no_overlap() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         )
         .symmetrically_differentiate(&AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         )),
         SymmetricDifferenceResult::Separate,
     );
@@ -83,10 +79,11 @@ fn bounded_adjacent_inclusive_inclusive() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Inclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_end_bound(),
         )
         .symmetrically_differentiate(&AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new_with_inclusivity(
@@ -94,10 +91,11 @@ fn bounded_adjacent_inclusive_inclusive() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Inclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_end_bound(),
         )),
         SymmetricDifferenceResult::Split(
             EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
@@ -106,10 +104,11 @@ fn bounded_adjacent_inclusive_inclusive() -> Result<(), Box<dyn Error>> {
                     BoundInclusivity::Inclusive,
                 )
                 .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_end_bound(),
             )),
             EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new_with_inclusivity(
@@ -117,10 +116,11 @@ fn bounded_adjacent_inclusive_inclusive() -> Result<(), Box<dyn Error>> {
                     BoundInclusivity::Exclusive,
                 )
                 .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
-                )),
+                )
+                .to_end_bound(),
             )),
         ),
     );
@@ -137,10 +137,11 @@ fn bounded_adjacent_inclusive_exclusive() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Inclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_end_bound(),
         )
         .symmetrically_differentiate(&AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new_with_inclusivity(
@@ -148,10 +149,11 @@ fn bounded_adjacent_inclusive_exclusive() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Exclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_end_bound(),
         )),
         SymmetricDifferenceResult::Separate,
     );
@@ -168,10 +170,11 @@ fn bounded_adjacent_exclusive_inclusive() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Inclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         )
         .symmetrically_differentiate(&AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new_with_inclusivity(
@@ -179,10 +182,11 @@ fn bounded_adjacent_exclusive_inclusive() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Inclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_end_bound(),
         )),
         SymmetricDifferenceResult::Separate,
     );
@@ -199,10 +203,11 @@ fn bounded_adjacent_exclusive_exclusive() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Inclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         )
         .symmetrically_differentiate(&AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new_with_inclusivity(
@@ -210,10 +215,11 @@ fn bounded_adjacent_exclusive_exclusive() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Exclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_end_bound(),
         )),
         SymmetricDifferenceResult::Separate,
     );
@@ -226,15 +232,11 @@ fn bounded_clear_overlap() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         )
         .symmetrically_differentiate(&AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         )),
         SymmetricDifferenceResult::Split(
             EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
@@ -243,10 +245,11 @@ fn bounded_clear_overlap() -> Result<(), Box<dyn Error>> {
                     BoundInclusivity::Inclusive,
                 )
                 .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_end_bound(),
             )),
             EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new_with_inclusivity(
@@ -254,10 +257,11 @@ fn bounded_clear_overlap() -> Result<(), Box<dyn Error>> {
                     BoundInclusivity::Exclusive,
                 )
                 .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Inclusive,
-                )),
+                )
+                .to_end_bound(),
             )),
         ),
     );
@@ -270,9 +274,7 @@ fn bounded_on_unbounded() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         )
         .symmetrically_differentiate(&AbsoluteBoundPair::new(
             AbsoluteStartBound::InfinitePast,
@@ -281,10 +283,11 @@ fn bounded_on_unbounded() -> Result<(), Box<dyn Error>> {
         SymmetricDifferenceResult::Split(
             EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                 AbsoluteStartBound::InfinitePast,
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_end_bound(),
             )),
             EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new_with_inclusivity(
@@ -307,17 +310,17 @@ fn unbounded_on_bounded() -> Result<(), Box<dyn Error>> {
             .symmetrically_differentiate(&AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             )),
         SymmetricDifferenceResult::Split(
             EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                 AbsoluteStartBound::InfinitePast,
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_end_bound(),
             )),
             EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new_with_inclusivity(

--- a/src/intervals/ops/set_ops/unite_tests.rs
+++ b/src/intervals/ops/set_ops/unite_tests.rs
@@ -59,15 +59,11 @@ fn bounded_no_overlap() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         )
         .unite(&AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         )),
         UnionResult::Separate,
     );
@@ -84,10 +80,11 @@ fn bounded_adjacent_inclusive_inclusive() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Inclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_end_bound(),
         )
         .unite(&AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new_with_inclusivity(
@@ -95,10 +92,11 @@ fn bounded_adjacent_inclusive_inclusive() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Inclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_end_bound(),
         )),
         UnionResult::United(AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new_with_inclusivity(
@@ -106,10 +104,11 @@ fn bounded_adjacent_inclusive_inclusive() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Inclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_end_bound(),
         )),
     );
 
@@ -125,10 +124,11 @@ fn bounded_adjacent_inclusive_exclusive() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Inclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_end_bound(),
         )
         .unite(&AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new_with_inclusivity(
@@ -136,10 +136,11 @@ fn bounded_adjacent_inclusive_exclusive() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Exclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_end_bound(),
         )),
         UnionResult::United(AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new_with_inclusivity(
@@ -147,10 +148,11 @@ fn bounded_adjacent_inclusive_exclusive() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Inclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_end_bound(),
         )),
     );
 
@@ -166,10 +168,11 @@ fn bounded_adjacent_exclusive_inclusive() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Inclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         )
         .unite(&AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new_with_inclusivity(
@@ -177,10 +180,11 @@ fn bounded_adjacent_exclusive_inclusive() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Inclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_end_bound(),
         )),
         UnionResult::United(AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new_with_inclusivity(
@@ -188,10 +192,11 @@ fn bounded_adjacent_exclusive_inclusive() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Inclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_end_bound(),
         )),
     );
 
@@ -207,10 +212,11 @@ fn bounded_adjacent_exclusive_exclusive() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Inclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         )
         .unite(&AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new_with_inclusivity(
@@ -218,10 +224,11 @@ fn bounded_adjacent_exclusive_exclusive() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Exclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_end_bound(),
         )),
         UnionResult::Separate,
     );
@@ -234,21 +241,15 @@ fn bounded_clear_overlap() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         )
         .unite(&AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         )),
         UnionResult::United(AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         )),
     );
 
@@ -260,9 +261,7 @@ fn bounded_on_unbounded() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         )
         .unite(&AbsoluteBoundPair::new(
             AbsoluteStartBound::InfinitePast,
@@ -284,9 +283,8 @@ fn unbounded_on_bounded() -> Result<(), Box<dyn Error>> {
             &AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             )
         ),
         UnionResult::United(AbsoluteBoundPair::new(

--- a/src/intervals/ops/set_ops/unite_tests.rs
+++ b/src/intervals/ops/set_ops/unite_tests.rs
@@ -58,17 +58,13 @@ fn unbounded_unbounded() {
 fn bounded_no_overlap() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             )),
         )
         .unite(&AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             )),
@@ -83,30 +79,33 @@ fn bounded_no_overlap() -> Result<(), Box<dyn Error>> {
 fn bounded_adjacent_inclusive_inclusive() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
             )),
         )
         .unite(&AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
             )),
         )),
         UnionResult::United(AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
@@ -121,30 +120,33 @@ fn bounded_adjacent_inclusive_inclusive() -> Result<(), Box<dyn Error>> {
 fn bounded_adjacent_inclusive_exclusive() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
             )),
         )
         .unite(&AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
             )),
         )),
         UnionResult::United(AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
@@ -159,30 +161,33 @@ fn bounded_adjacent_inclusive_exclusive() -> Result<(), Box<dyn Error>> {
 fn bounded_adjacent_exclusive_inclusive() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
             )),
         )
         .unite(&AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
             )),
         )),
         UnionResult::United(AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
@@ -197,20 +202,22 @@ fn bounded_adjacent_exclusive_inclusive() -> Result<(), Box<dyn Error>> {
 fn bounded_adjacent_exclusive_exclusive() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
             )),
         )
         .unite(&AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
@@ -226,25 +233,19 @@ fn bounded_adjacent_exclusive_exclusive() -> Result<(), Box<dyn Error>> {
 fn bounded_clear_overlap() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             )),
         )
         .unite(&AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             )),
         )),
         UnionResult::United(AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             )),
@@ -258,9 +259,7 @@ fn bounded_clear_overlap() -> Result<(), Box<dyn Error>> {
 fn bounded_on_unbounded() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             )),
@@ -283,9 +282,8 @@ fn unbounded_on_bounded() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(AbsoluteStartBound::InfinitePast, AbsoluteEndBound::InfiniteFuture,).unite(
             &AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 )),

--- a/src/intervals/ops/shrink_tests.rs
+++ b/src/intervals/ops/shrink_tests.rs
@@ -46,15 +46,11 @@ fn shrink_start_to_finite_unbounded_interval() -> Result<(), Box<dyn Error>> {
 fn shrink_end_to_finite_unbounded_interval() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(AbsoluteStartBound::InfinitePast, AbsoluteEndBound::InfiniteFuture).shrink_end(
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            ))
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound()
         ),
         AbsoluteBoundPair::new(
             AbsoluteStartBound::InfinitePast,
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
     );
 
@@ -66,18 +62,14 @@ fn shrink_start_to_inside_abs_bounds_bounded() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            ))
+            AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound()
         )
         .shrink_start(
             AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound()
         ),
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            ))
+            AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound()
         ),
     );
 
@@ -89,18 +81,14 @@ fn shrink_end_to_inside_abs_bounds_bounded() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            ))
+            AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound()
         )
-        .shrink_end(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-        ))),
+        .shrink_end(
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound()
+        ),
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            ))
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound()
         ),
     );
 
@@ -112,18 +100,14 @@ fn shrink_start_to_outside_abs_bounds_bounded() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            ))
+            AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound()
         )
         .shrink_start(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound()
         ),
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            ))
+            AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound()
         ),
     );
 
@@ -135,18 +119,14 @@ fn shrink_end_to_outside_abs_bounds_bounded() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            ))
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound()
         )
-        .shrink_end(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-        ))),
+        .shrink_end(
+            AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound()
+        ),
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            ))
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound()
         ),
     );
 

--- a/src/intervals/ops/shrink_tests.rs
+++ b/src/intervals/ops/shrink_tests.rs
@@ -31,14 +31,10 @@ fn shrink_end_emptiable_abs_bounds_empty() {
 fn shrink_start_to_finite_unbounded_interval() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(AbsoluteStartBound::InfinitePast, AbsoluteEndBound::InfiniteFuture).shrink_start(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            ))
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound()
         ),
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::InfiniteFuture,
         ),
     );
@@ -69,20 +65,16 @@ fn shrink_end_to_finite_unbounded_interval() -> Result<(), Box<dyn Error>> {
 fn shrink_start_to_inside_abs_bounds_bounded() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             ))
         )
-        .shrink_start(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-        ))),
+        .shrink_start(
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound()
+        ),
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             ))
@@ -96,9 +88,7 @@ fn shrink_start_to_inside_abs_bounds_bounded() -> Result<(), Box<dyn Error>> {
 fn shrink_end_to_inside_abs_bounds_bounded() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             ))
@@ -107,9 +97,7 @@ fn shrink_end_to_inside_abs_bounds_bounded() -> Result<(), Box<dyn Error>> {
             "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
         ))),
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             ))
@@ -123,20 +111,16 @@ fn shrink_end_to_inside_abs_bounds_bounded() -> Result<(), Box<dyn Error>> {
 fn shrink_start_to_outside_abs_bounds_bounded() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             ))
         )
-        .shrink_start(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-        ))),
+        .shrink_start(
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound()
+        ),
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             ))
@@ -150,9 +134,7 @@ fn shrink_start_to_outside_abs_bounds_bounded() -> Result<(), Box<dyn Error>> {
 fn shrink_end_to_outside_abs_bounds_bounded() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             ))
@@ -161,9 +143,7 @@ fn shrink_end_to_outside_abs_bounds_bounded() -> Result<(), Box<dyn Error>> {
             "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
         ))),
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
             ))

--- a/src/intervals/relative.rs
+++ b/src/intervals/relative.rs
@@ -91,7 +91,7 @@ pub fn swap_relative_bound_pair(start: &mut RelativeStartBound, end: &mut Relati
             *end = RelativeEndBound::InfiniteFuture;
         },
         (RelativeStartBound::Finite(finite_start), RelativeEndBound::InfiniteFuture) => {
-            *end = RelativeEndBound::Finite(*finite_start);
+            *end = finite_start.to_end_bound();
             *start = RelativeStartBound::InfinitePast;
         },
         (RelativeStartBound::Finite(finite_start), RelativeEndBound::Finite(finite_end)) => {

--- a/src/intervals/relative.rs
+++ b/src/intervals/relative.rs
@@ -87,7 +87,7 @@ pub fn swap_relative_bound_pair(start: &mut RelativeStartBound, end: &mut Relati
     match (&mut *start, &mut *end) {
         (RelativeStartBound::InfinitePast, RelativeEndBound::InfiniteFuture) => {},
         (RelativeStartBound::InfinitePast, RelativeEndBound::Finite(finite_end)) => {
-            *start = RelativeStartBound::Finite(*finite_end);
+            *start = finite_end.to_start_bound();
             *end = RelativeEndBound::InfiniteFuture;
         },
         (RelativeStartBound::Finite(finite_start), RelativeEndBound::InfiniteFuture) => {

--- a/src/intervals/relative/bound.rs
+++ b/src/intervals/relative/bound.rs
@@ -38,8 +38,12 @@ impl RelativeBound {
     /// let start_offset = SignedDuration::from_hours(8);
     /// let end_offset = SignedDuration::from_hours(16);
     ///
-    /// let start = RelativeBound::Start(RelativeFiniteBound::new(start_offset).to_start_bound());
-    /// let end = RelativeBound::End(RelativeFiniteBound::new(end_offset).to_end_bound());
+    /// let start = RelativeFiniteBound::new(start_offset)
+    ///     .to_start_bound()
+    ///     .to_bound();
+    /// let end = RelativeFiniteBound::new(end_offset)
+    ///     .to_end_bound()
+    ///     .to_bound();
     ///
     /// assert!(start.is_start());
     /// assert!(!end.is_start());
@@ -59,8 +63,12 @@ impl RelativeBound {
     /// let start_offset = SignedDuration::from_hours(8);
     /// let end_offset = SignedDuration::from_hours(16);
     ///
-    /// let start = RelativeBound::Start(RelativeFiniteBound::new(start_offset).to_start_bound());
-    /// let end = RelativeBound::End(RelativeFiniteBound::new(end_offset).to_end_bound());
+    /// let start = RelativeFiniteBound::new(start_offset)
+    ///     .to_start_bound()
+    ///     .to_bound();
+    /// let end = RelativeFiniteBound::new(end_offset)
+    ///     .to_end_bound()
+    ///     .to_bound();
     ///
     /// assert!(end.is_end());
     /// assert!(!start.is_end());
@@ -84,8 +92,12 @@ impl RelativeBound {
     /// let start_offset = SignedDuration::from_hours(8);
     /// let end_offset = SignedDuration::from_hours(16);
     ///
-    /// let start = RelativeBound::Start(RelativeFiniteBound::new(start_offset).to_start_bound());
-    /// let end = RelativeBound::End(RelativeFiniteBound::new(end_offset).to_end_bound());
+    /// let start = RelativeFiniteBound::new(start_offset)
+    ///     .to_start_bound()
+    ///     .to_bound();
+    /// let end = RelativeFiniteBound::new(end_offset)
+    ///     .to_end_bound()
+    ///     .to_bound();
     ///
     /// assert_eq!(
     ///     start.start(),
@@ -115,8 +127,12 @@ impl RelativeBound {
     /// let start_offset = SignedDuration::from_hours(8);
     /// let end_offset = SignedDuration::from_hours(16);
     ///
-    /// let start = RelativeBound::Start(RelativeFiniteBound::new(start_offset).to_start_bound());
-    /// let end = RelativeBound::End(RelativeFiniteBound::new(end_offset).to_end_bound());
+    /// let start = RelativeFiniteBound::new(start_offset)
+    ///     .to_start_bound()
+    ///     .to_bound();
+    /// let end = RelativeFiniteBound::new(end_offset)
+    ///     .to_end_bound()
+    ///     .to_bound();
     ///
     /// assert_eq!(
     ///     end.end(),

--- a/src/intervals/relative/bound_pair.rs
+++ b/src/intervals/relative/bound_pair.rs
@@ -170,12 +170,6 @@ impl RelativeBoundPair {
         )
     }
 
-    /// Wraps the [`RelativeBoundPair`] in an [`EmptiableRelativeBoundPair`]
-    #[must_use]
-    pub fn to_emptiable(self) -> EmptiableRelativeBoundPair {
-        EmptiableRelativeBoundPair::from(self)
-    }
-
     /// Returns the relative start bound
     ///
     /// # Examples
@@ -376,6 +370,24 @@ impl RelativeBoundPair {
             Ordering::Equal => self.end.cmp(&other.end).reverse(),
             Ordering::Greater => Ordering::Greater,
         }
+    }
+
+    /// Converts the [`RelativeBoundPair`] into [`RelativeInterval`]
+    #[must_use]
+    pub fn to_interval(self) -> RelativeInterval {
+        RelativeInterval::from(self)
+    }
+
+    /// Converts the [`RelativeBoundPair`] into [`EmptiableRelativeInterval`]
+    #[must_use]
+    pub fn to_emptiable_interval(self) -> EmptiableRelativeInterval {
+        self.to_interval().to_emptiable()
+    }
+
+    /// Wraps the [`RelativeBoundPair`] in an [`EmptiableRelativeBoundPair`]
+    #[must_use]
+    pub fn to_emptiable(self) -> EmptiableRelativeBoundPair {
+        EmptiableRelativeBoundPair::from(self)
     }
 }
 

--- a/src/intervals/relative/bounded_interval_tests.rs
+++ b/src/intervals/relative/bounded_interval_tests.rs
@@ -204,10 +204,8 @@ fn try_from_relative_bounds_correct() {
         BoundedRelativeInterval::try_from(RelativeBoundPair::new(
             RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(1), BoundInclusivity::Exclusive,)
                 .to_start_bound(),
-            RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                SignedDuration::from_hours(2),
-                BoundInclusivity::Inclusive,
-            )),
+            RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(2), BoundInclusivity::Inclusive,)
+                .to_end_bound(),
         )),
         Ok(BoundedRelativeInterval::new_with_inclusivity(
             SignedDuration::from_hours(1),
@@ -223,7 +221,7 @@ fn try_from_relative_bounds_wrong() {
     assert_eq!(
         BoundedRelativeInterval::try_from(RelativeBoundPair::new(
             RelativeStartBound::InfinitePast,
-            RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1))),
+            RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_end_bound(),
         )),
         Err(BoundedRelativeIntervalTryFromRelativeBoundPairError),
     );

--- a/src/intervals/relative/bounded_interval_tests.rs
+++ b/src/intervals/relative/bounded_interval_tests.rs
@@ -202,10 +202,8 @@ fn from_range_inclusive() {
 fn try_from_relative_bounds_correct() {
     assert_eq!(
         BoundedRelativeInterval::try_from(RelativeBoundPair::new(
-            RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                SignedDuration::from_hours(1),
-                BoundInclusivity::Exclusive,
-            )),
+            RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(1), BoundInclusivity::Exclusive,)
+                .to_start_bound(),
             RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
                 SignedDuration::from_hours(2),
                 BoundInclusivity::Inclusive,
@@ -231,7 +229,7 @@ fn try_from_relative_bounds_wrong() {
     );
     assert_eq!(
         BoundedRelativeInterval::try_from(RelativeBoundPair::new(
-            RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1))),
+            RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_start_bound(),
             RelativeEndBound::InfiniteFuture,
         )),
         Err(BoundedRelativeIntervalTryFromRelativeBoundPairError),

--- a/src/intervals/relative/emptiable_bound_pair.rs
+++ b/src/intervals/relative/emptiable_bound_pair.rs
@@ -120,6 +120,36 @@ impl EmptiableRelativeBoundPair {
         RelativeBoundPair::from_range(range).to_emptiable()
     }
 
+    /// Compares two [`EmptiableRelativeBoundPair`], but if they have the same
+    /// start, order by decreasing length
+    ///
+    /// Uses [`RelativeBoundPair::ord_by_start_and_inv_length`] under the hood
+    /// for the [`Bound`](EmptiableRelativeBoundPair::Bound) variants and
+    /// [`EmptiableRelativeBoundPair::cmp`]
+    /// for the [`Empty`](EmptiableRelativeBoundPair::Empty) variants (which
+    /// will just place all empty bounds before any bound bounds).
+    ///
+    /// Don't rely on this method for checking for equality of start, as it will
+    /// produce other [`Ordering`]s if their lengths don't match too.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use periodical::intervals::relative::EmptiableRelativeBoundPair;
+    /// # let mut bounds: [EmptiableRelativeBoundPair; 0] = [];
+    /// bounds.sort_by(EmptiableRelativeBoundPair::ord_by_start_and_inv_length);
+    /// ```
+    #[must_use]
+    pub fn ord_by_start_and_inv_length(&self, other: &Self) -> Ordering {
+        match (self, other) {
+            (
+                EmptiableRelativeBoundPair::Bound(og_rel_bound_pair),
+                EmptiableRelativeBoundPair::Bound(other_rel_bound_pair),
+            ) => og_rel_bound_pair.ord_by_start_and_inv_length(other_rel_bound_pair),
+            _ => self.cmp(other),
+        }
+    }
+
     /// Returns the content of the [`Bound`](EmptiableRelativeBoundPair::Bound)
     /// variant
     ///
@@ -153,34 +183,10 @@ impl EmptiableRelativeBoundPair {
         }
     }
 
-    /// Compares two [`EmptiableRelativeBoundPair`], but if they have the same
-    /// start, order by decreasing length
-    ///
-    /// Uses [`RelativeBoundPair::ord_by_start_and_inv_length`] under the hood
-    /// for the [`Bound`](EmptiableRelativeBoundPair::Bound) variants and
-    /// [`EmptiableRelativeBoundPair::cmp`]
-    /// for the [`Empty`](EmptiableRelativeBoundPair::Empty) variants (which
-    /// will just place all empty bounds before any bound bounds).
-    ///
-    /// Don't rely on this method for checking for equality of start, as it will
-    /// produce other [`Ordering`]s if their lengths don't match too.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use periodical::intervals::relative::EmptiableRelativeBoundPair;
-    /// # let mut bounds: [EmptiableRelativeBoundPair; 0] = [];
-    /// bounds.sort_by(EmptiableRelativeBoundPair::ord_by_start_and_inv_length);
-    /// ```
+    /// Converts the [`EmptiableRelativeBoundPair`] into [`EmptiableRelativeInterval`]
     #[must_use]
-    pub fn ord_by_start_and_inv_length(&self, other: &Self) -> Ordering {
-        match (self, other) {
-            (
-                EmptiableRelativeBoundPair::Bound(og_rel_bound_pair),
-                EmptiableRelativeBoundPair::Bound(other_rel_bound_pair),
-            ) => og_rel_bound_pair.ord_by_start_and_inv_length(other_rel_bound_pair),
-            _ => self.cmp(other),
-        }
+    pub fn to_emptiable_interval(self) -> EmptiableRelativeInterval {
+        EmptiableRelativeInterval::from(self)
     }
 }
 

--- a/src/intervals/relative/emptiable_interval_tests.rs
+++ b/src/intervals/relative/emptiable_interval_tests.rs
@@ -10,7 +10,6 @@ use crate::intervals::relative::{
     RelativeEndBound,
     RelativeFiniteBound,
     RelativeInterval,
-    RelativeStartBound,
 };
 use crate::intervals::special::{EmptyInterval, UnboundedInterval};
 
@@ -18,10 +17,8 @@ use crate::intervals::special::{EmptyInterval, UnboundedInterval};
 fn relative_interval_from_relative_bounds() {
     assert_eq!(
         EmptiableRelativeInterval::from(RelativeBoundPair::new(
-            RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                SignedDuration::from_hours(1),
-                BoundInclusivity::Exclusive,
-            )),
+            RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(1), BoundInclusivity::Exclusive,)
+                .to_start_bound(),
             RelativeEndBound::InfiniteFuture,
         )),
         EmptiableRelativeInterval::Bound(RelativeInterval::HalfBounded(
@@ -38,10 +35,8 @@ fn relative_interval_from_relative_bounds() {
 fn relative_interval_from_emptiable_relative_bounds() {
     assert_eq!(
         EmptiableRelativeInterval::from(EmptiableRelativeBoundPair::Bound(RelativeBoundPair::new(
-            RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                SignedDuration::from_hours(1),
-                BoundInclusivity::Exclusive,
-            )),
+            RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(1), BoundInclusivity::Exclusive,)
+                .to_start_bound(),
             RelativeEndBound::InfiniteFuture,
         ))),
         EmptiableRelativeInterval::Bound(RelativeInterval::HalfBounded(

--- a/src/intervals/relative/end_bound.rs
+++ b/src/intervals/relative/end_bound.rs
@@ -57,8 +57,7 @@ impl RelativeEndBound {
     /// # use jiff::SignedDuration;
     /// # use periodical::intervals::relative::{RelativeEndBound, RelativeFiniteBound};
     /// let infinite_end_bound = RelativeEndBound::InfiniteFuture;
-    /// let finite_end_bound =
-    ///     RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1)));
+    /// let finite_end_bound = RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_end_bound();
     ///
     /// assert!(finite_end_bound.is_finite());
     /// assert!(!infinite_end_bound.is_finite());
@@ -77,8 +76,7 @@ impl RelativeEndBound {
     /// # use jiff::SignedDuration;
     /// # use periodical::intervals::relative::{RelativeEndBound, RelativeFiniteBound};
     /// let infinite_end_bound = RelativeEndBound::InfiniteFuture;
-    /// let finite_end_bound =
-    ///     RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1)));
+    /// let finite_end_bound = RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_end_bound();
     ///
     /// assert!(infinite_end_bound.is_infinite_future());
     /// assert!(!finite_end_bound.is_infinite_future());
@@ -100,8 +98,7 @@ impl RelativeEndBound {
     /// # use jiff::SignedDuration;
     /// # use periodical::intervals::relative::{RelativeEndBound, RelativeFiniteBound};
     /// let infinite_end_bound = RelativeEndBound::InfiniteFuture;
-    /// let finite_end_bound =
-    ///     RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1)));
+    /// let finite_end_bound = RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_end_bound();
     ///
     /// assert_eq!(
     ///     finite_end_bound.finite(),
@@ -147,8 +144,7 @@ impl RelativeEndBound {
     /// # }
     /// #
     /// # impl Error for FiniteBoundExpectedError {}
-    /// let end_first_shift =
-    ///     RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1)));
+    /// let end_first_shift = RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_end_bound();
     /// let break_start = end_first_shift.opposite().ok_or(FiniteBoundExpectedError)?;
     ///
     /// assert_eq!(
@@ -276,14 +272,12 @@ impl From<Option<(SignedDuration, BoundInclusivity)>> for RelativeEndBound {
 impl From<Bound<SignedDuration>> for RelativeEndBound {
     fn from(bound: Bound<SignedDuration>) -> Self {
         match bound {
-            Bound::Included(offset) => RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                offset,
-                BoundInclusivity::Inclusive,
-            )),
-            Bound::Excluded(offset) => RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                offset,
-                BoundInclusivity::Exclusive,
-            )),
+            Bound::Included(offset) => {
+                RelativeFiniteBound::new_with_inclusivity(offset, BoundInclusivity::Inclusive).to_end_bound()
+            },
+            Bound::Excluded(offset) => {
+                RelativeFiniteBound::new_with_inclusivity(offset, BoundInclusivity::Exclusive).to_end_bound()
+            },
             Bound::Unbounded => RelativeEndBound::InfiniteFuture,
         }
     }

--- a/src/intervals/relative/half_bounded_interval_tests.rs
+++ b/src/intervals/relative/half_bounded_interval_tests.rs
@@ -149,10 +149,8 @@ fn interval_from_range_to_inclusive() {
 fn interval_try_from_relative_bounds_correct() {
     assert_eq!(
         HalfBoundedRelativeInterval::try_from(RelativeBoundPair::new(
-            RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                SignedDuration::from_hours(1),
-                BoundInclusivity::Exclusive,
-            )),
+            RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(1), BoundInclusivity::Exclusive,)
+                .to_start_bound(),
             RelativeEndBound::InfiniteFuture,
         )),
         Ok(HalfBoundedRelativeInterval::new_with_inclusivity(
@@ -188,7 +186,7 @@ fn interval_try_from_relative_bounds_wrong() {
     );
     assert_eq!(
         HalfBoundedRelativeInterval::try_from(RelativeBoundPair::new(
-            RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1))),
+            RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_start_bound(),
             RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(2))),
         )),
         Err(HalfBoundedRelativeIntervalTryFromRelativeBoundPairError),

--- a/src/intervals/relative/half_bounded_interval_tests.rs
+++ b/src/intervals/relative/half_bounded_interval_tests.rs
@@ -162,10 +162,8 @@ fn interval_try_from_relative_bounds_correct() {
     assert_eq!(
         HalfBoundedRelativeInterval::try_from(RelativeBoundPair::new(
             RelativeStartBound::InfinitePast,
-            RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                SignedDuration::from_hours(1),
-                BoundInclusivity::Exclusive,
-            )),
+            RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(1), BoundInclusivity::Exclusive,)
+                .to_end_bound(),
         )),
         Ok(HalfBoundedRelativeInterval::new_with_inclusivity(
             SignedDuration::from_hours(1),
@@ -187,7 +185,7 @@ fn interval_try_from_relative_bounds_wrong() {
     assert_eq!(
         HalfBoundedRelativeInterval::try_from(RelativeBoundPair::new(
             RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_start_bound(),
-            RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(2))),
+            RelativeFiniteBound::new(SignedDuration::from_hours(2)).to_end_bound(),
         )),
         Err(HalfBoundedRelativeIntervalTryFromRelativeBoundPairError),
     );

--- a/src/intervals/relative/interval_tests.rs
+++ b/src/intervals/relative/interval_tests.rs
@@ -8,7 +8,6 @@ use crate::intervals::relative::{
     RelativeBoundPair,
     RelativeEndBound,
     RelativeFiniteBound,
-    RelativeStartBound,
 };
 use crate::intervals::special::UnboundedInterval;
 
@@ -16,10 +15,8 @@ use crate::intervals::special::UnboundedInterval;
 fn relative_interval_from_relative_bounds() {
     assert_eq!(
         RelativeInterval::from(RelativeBoundPair::new(
-            RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                SignedDuration::from_hours(1),
-                BoundInclusivity::Exclusive,
-            )),
+            RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(1), BoundInclusivity::Exclusive,)
+                .to_start_bound(),
             RelativeEndBound::InfiniteFuture,
         )),
         RelativeInterval::HalfBounded(HalfBoundedRelativeInterval::new_with_inclusivity(

--- a/src/intervals/relative/start_bound.rs
+++ b/src/intervals/relative/start_bound.rs
@@ -58,7 +58,7 @@ impl RelativeStartBound {
     /// # use periodical::intervals::relative::{RelativeFiniteBound, RelativeStartBound};
     /// let infinite_start_bound = RelativeStartBound::InfinitePast;
     /// let finite_start_bound =
-    ///     RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1)));
+    ///     RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_start_bound();
     ///
     /// assert!(finite_start_bound.is_finite());
     /// assert!(!infinite_start_bound.is_finite());
@@ -78,7 +78,7 @@ impl RelativeStartBound {
     /// # use periodical::intervals::relative::{RelativeFiniteBound, RelativeStartBound};
     /// let infinite_start_bound = RelativeStartBound::InfinitePast;
     /// let finite_start_bound =
-    ///     RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1)));
+    ///     RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_start_bound();
     ///
     /// assert!(infinite_start_bound.is_infinite_past());
     /// assert!(!finite_start_bound.is_infinite_past());
@@ -102,7 +102,7 @@ impl RelativeStartBound {
     /// # use periodical::intervals::relative::{RelativeFiniteBound, RelativeStartBound};
     /// let infinite_start_bound = RelativeStartBound::InfinitePast;
     /// let finite_start_bound =
-    ///     RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1)));
+    ///     RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_start_bound();
     ///
     /// assert_eq!(
     ///     finite_start_bound.finite(),
@@ -148,7 +148,7 @@ impl RelativeStartBound {
     /// #
     /// # impl Error for FiniteBoundExpectedError {}
     /// let start_second_part_my_shift =
-    ///     RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(3)));
+    ///     RelativeFiniteBound::new(SignedDuration::from_hours(3)).to_start_bound();
     /// let break_end_before_shift = start_second_part_my_shift
     ///     .opposite()
     ///     .ok_or(FiniteBoundExpectedError)?;
@@ -294,14 +294,12 @@ impl From<Option<(SignedDuration, BoundInclusivity)>> for RelativeStartBound {
 impl From<Bound<SignedDuration>> for RelativeStartBound {
     fn from(bound: Bound<SignedDuration>) -> Self {
         match bound {
-            Bound::Included(offset) => RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                offset,
-                BoundInclusivity::Inclusive,
-            )),
-            Bound::Excluded(offset) => RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                offset,
-                BoundInclusivity::Exclusive,
-            )),
+            Bound::Included(offset) => {
+                RelativeFiniteBound::new_with_inclusivity(offset, BoundInclusivity::Inclusive).to_start_bound()
+            },
+            Bound::Excluded(offset) => {
+                RelativeFiniteBound::new_with_inclusivity(offset, BoundInclusivity::Exclusive).to_start_bound()
+            },
             Bound::Unbounded => RelativeStartBound::InfinitePast,
         }
     }

--- a/src/intervals/relative/start_bound_tests.rs
+++ b/src/intervals/relative/start_bound_tests.rs
@@ -336,10 +336,8 @@ fn from_relative_finite_bound() {
             SignedDuration::from_hours(1),
             BoundInclusivity::Exclusive,
         )),
-        RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-            SignedDuration::from_hours(1),
-            BoundInclusivity::Exclusive,
-        )),
+        RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(1), BoundInclusivity::Exclusive,)
+            .to_start_bound(),
     );
 }
 

--- a/src/intervals/relative/start_bound_tests.rs
+++ b/src/intervals/relative/start_bound_tests.rs
@@ -336,8 +336,10 @@ fn from_relative_finite_bound() {
             SignedDuration::from_hours(1),
             BoundInclusivity::Exclusive,
         )),
-        RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(1), BoundInclusivity::Exclusive,)
-            .to_start_bound(),
+        RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
+            SignedDuration::from_hours(1),
+            BoundInclusivity::Exclusive,
+        )),
     );
 }
 

--- a/src/intervals/relative_tests.rs
+++ b/src/intervals/relative_tests.rs
@@ -17,10 +17,8 @@ fn relative_start_bound_inf_relative_end_bound_inf_swap() {
 #[test]
 fn relative_start_bound_inf_relative_end_bound_finite_swap() {
     let mut start = RelativeStartBound::InfinitePast;
-    let mut end = RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-        SignedDuration::from_hours(1),
-        BoundInclusivity::Exclusive,
-    ));
+    let mut end = RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(1), BoundInclusivity::Exclusive)
+        .to_end_bound();
 
     swap_relative_bound_pair(&mut start, &mut end);
 
@@ -44,10 +42,8 @@ fn relative_start_bound_finite_relative_end_bound_inf_swap() {
     assert_eq!(start, RelativeStartBound::InfinitePast);
     assert_eq!(
         end,
-        RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-            SignedDuration::from_hours(1),
-            BoundInclusivity::Exclusive,
-        ))
+        RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(1), BoundInclusivity::Exclusive,)
+            .to_end_bound()
     );
 }
 
@@ -56,10 +52,8 @@ fn relative_start_bound_finite_relative_end_bound_finite_swap() {
     let mut start =
         RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(1), BoundInclusivity::Exclusive)
             .to_start_bound();
-    let mut end = RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-        SignedDuration::from_hours(2),
-        BoundInclusivity::Inclusive,
-    ));
+    let mut end = RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(2), BoundInclusivity::Inclusive)
+        .to_end_bound();
 
     swap_relative_bound_pair(&mut start, &mut end);
 
@@ -70,10 +64,8 @@ fn relative_start_bound_finite_relative_end_bound_finite_swap() {
     );
     assert_eq!(
         end,
-        RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-            SignedDuration::from_hours(1),
-            BoundInclusivity::Exclusive,
-        ))
+        RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(1), BoundInclusivity::Exclusive,)
+            .to_end_bound()
     );
 }
 
@@ -93,7 +85,7 @@ fn check_relative_bound_pair_for_interval_creation_inf_past_finite() {
     assert_eq!(
         check_relative_bound_pair_for_interval_creation(
             &RelativeStartBound::InfinitePast,
-            &RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1))),
+            &RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_end_bound(),
         ),
         Ok(()),
     );
@@ -115,7 +107,7 @@ fn check_relative_bound_pair_for_interval_creation_finite_finite_different_offse
     assert_eq!(
         check_relative_bound_pair_for_interval_creation(
             &RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_start_bound(),
-            &RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(2))),
+            &RelativeFiniteBound::new(SignedDuration::from_hours(2)).to_end_bound(),
         ),
         Ok(()),
     );
@@ -126,7 +118,7 @@ fn check_relative_bound_pair_for_interval_creation_finite_finite_different_offse
     assert_eq!(
         check_relative_bound_pair_for_interval_creation(
             &RelativeFiniteBound::new(SignedDuration::from_hours(2)).to_start_bound(),
-            &RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1))),
+            &RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_end_bound(),
         ),
         Err(RelativeBoundPairCheckForIntervalCreationError::StartPastEnd),
     );
@@ -137,7 +129,7 @@ fn check_relative_bound_pair_for_interval_creation_finite_finite_same_offset_inc
     assert_eq!(
         check_relative_bound_pair_for_interval_creation(
             &RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_start_bound(),
-            &RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1))),
+            &RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_end_bound(),
         ),
         Ok(()),
     );
@@ -148,10 +140,8 @@ fn check_relative_bound_pair_for_interval_creation_finite_finite_same_offset_inc
     assert_eq!(
         check_relative_bound_pair_for_interval_creation(
             &RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_start_bound(),
-            &RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                SignedDuration::from_hours(1),
-                BoundInclusivity::Exclusive,
-            )),
+            &RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(1), BoundInclusivity::Exclusive,)
+                .to_end_bound(),
         ),
         Err(RelativeBoundPairCheckForIntervalCreationError::SameOffsetButNotDoublyInclusive),
     );
@@ -172,7 +162,7 @@ fn prepare_relative_bound_pair_for_interval_creation_inf_past_inf_future() {
 #[test]
 fn prepare_relative_bound_pair_for_interval_creation_inf_past_finite() {
     let mut start = RelativeStartBound::InfinitePast;
-    let mut end = RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1)));
+    let mut end = RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_end_bound();
 
     let was_changed = prepare_relative_bound_pair_for_interval_creation(&mut start, &mut end);
 
@@ -180,7 +170,7 @@ fn prepare_relative_bound_pair_for_interval_creation_inf_past_finite() {
     assert_eq!(start, RelativeStartBound::InfinitePast);
     assert_eq!(
         end,
-        RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1)))
+        RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_end_bound()
     );
 }
 
@@ -202,7 +192,7 @@ fn prepare_relative_bound_pair_for_interval_creation_finite_inf_future() {
 #[test]
 fn prepare_relative_bound_pair_for_interval_creation_finite_finite_different_offsets_correct_order() {
     let mut start = RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_start_bound();
-    let mut end = RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(2)));
+    let mut end = RelativeFiniteBound::new(SignedDuration::from_hours(2)).to_end_bound();
 
     let was_changed = prepare_relative_bound_pair_for_interval_creation(&mut start, &mut end);
 
@@ -213,21 +203,21 @@ fn prepare_relative_bound_pair_for_interval_creation_finite_finite_different_off
     );
     assert_eq!(
         end,
-        RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(2)))
+        RelativeFiniteBound::new(SignedDuration::from_hours(2)).to_end_bound()
     );
 }
 
 #[test]
 fn prepare_relative_bound_pair_for_interval_creation_finite_finite_different_offsets_wrong_order() {
     let mut start = RelativeFiniteBound::new(SignedDuration::from_hours(2)).to_start_bound();
-    let mut end = RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1)));
+    let mut end = RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_end_bound();
 
     let was_changed = prepare_relative_bound_pair_for_interval_creation(&mut start, &mut end);
 
     assert!(was_changed);
     assert_eq!(
         start,
-        RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1)))
+        RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_end_bound()
     );
     assert_eq!(
         end,
@@ -238,7 +228,7 @@ fn prepare_relative_bound_pair_for_interval_creation_finite_finite_different_off
 #[test]
 fn prepare_relative_bound_pair_for_interval_creation_finite_finite_same_offset_inclusive_inclusive() {
     let mut start = RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_start_bound();
-    let mut end = RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1)));
+    let mut end = RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_end_bound();
 
     let was_changed = prepare_relative_bound_pair_for_interval_creation(&mut start, &mut end);
 
@@ -249,17 +239,15 @@ fn prepare_relative_bound_pair_for_interval_creation_finite_finite_same_offset_i
     );
     assert_eq!(
         end,
-        RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1)))
+        RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_end_bound()
     );
 }
 
 #[test]
 fn prepare_relative_bound_pair_for_interval_creation_finite_finite_same_offset_inclusive_exclusive() {
     let mut start = RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_start_bound();
-    let mut end = RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-        SignedDuration::from_hours(1),
-        BoundInclusivity::Exclusive,
-    ));
+    let mut end = RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(1), BoundInclusivity::Exclusive)
+        .to_end_bound();
 
     let was_changed = prepare_relative_bound_pair_for_interval_creation(&mut start, &mut end);
 

--- a/src/intervals/relative_tests.rs
+++ b/src/intervals/relative_tests.rs
@@ -26,20 +26,17 @@ fn relative_start_bound_inf_relative_end_bound_finite_swap() {
 
     assert_eq!(
         start,
-        RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-            SignedDuration::from_hours(1),
-            BoundInclusivity::Exclusive,
-        ))
+        RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(1), BoundInclusivity::Exclusive,)
+            .to_start_bound()
     );
     assert_eq!(end, RelativeEndBound::InfiniteFuture);
 }
 
 #[test]
 fn relative_start_bound_finite_relative_end_bound_inf_swap() {
-    let mut start = RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-        SignedDuration::from_hours(1),
-        BoundInclusivity::Exclusive,
-    ));
+    let mut start =
+        RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(1), BoundInclusivity::Exclusive)
+            .to_start_bound();
     let mut end = RelativeEndBound::InfiniteFuture;
 
     swap_relative_bound_pair(&mut start, &mut end);
@@ -56,10 +53,9 @@ fn relative_start_bound_finite_relative_end_bound_inf_swap() {
 
 #[test]
 fn relative_start_bound_finite_relative_end_bound_finite_swap() {
-    let mut start = RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-        SignedDuration::from_hours(1),
-        BoundInclusivity::Exclusive,
-    ));
+    let mut start =
+        RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(1), BoundInclusivity::Exclusive)
+            .to_start_bound();
     let mut end = RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
         SignedDuration::from_hours(2),
         BoundInclusivity::Inclusive,
@@ -69,10 +65,8 @@ fn relative_start_bound_finite_relative_end_bound_finite_swap() {
 
     assert_eq!(
         start,
-        RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-            SignedDuration::from_hours(2),
-            BoundInclusivity::Inclusive,
-        ))
+        RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(2), BoundInclusivity::Inclusive,)
+            .to_start_bound()
     );
     assert_eq!(
         end,
@@ -109,7 +103,7 @@ fn check_relative_bound_pair_for_interval_creation_inf_past_finite() {
 fn check_relative_bound_pair_for_interval_creation_finite_inf_future() {
     assert_eq!(
         check_relative_bound_pair_for_interval_creation(
-            &RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1))),
+            &RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_start_bound(),
             &RelativeEndBound::InfiniteFuture,
         ),
         Ok(()),
@@ -120,7 +114,7 @@ fn check_relative_bound_pair_for_interval_creation_finite_inf_future() {
 fn check_relative_bound_pair_for_interval_creation_finite_finite_different_offsets_correct_order() {
     assert_eq!(
         check_relative_bound_pair_for_interval_creation(
-            &RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1))),
+            &RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_start_bound(),
             &RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(2))),
         ),
         Ok(()),
@@ -131,7 +125,7 @@ fn check_relative_bound_pair_for_interval_creation_finite_finite_different_offse
 fn check_relative_bound_pair_for_interval_creation_finite_finite_different_offsets_wrong_order() {
     assert_eq!(
         check_relative_bound_pair_for_interval_creation(
-            &RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(2))),
+            &RelativeFiniteBound::new(SignedDuration::from_hours(2)).to_start_bound(),
             &RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1))),
         ),
         Err(RelativeBoundPairCheckForIntervalCreationError::StartPastEnd),
@@ -142,7 +136,7 @@ fn check_relative_bound_pair_for_interval_creation_finite_finite_different_offse
 fn check_relative_bound_pair_for_interval_creation_finite_finite_same_offset_inclusive_inclusive() {
     assert_eq!(
         check_relative_bound_pair_for_interval_creation(
-            &RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1))),
+            &RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_start_bound(),
             &RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1))),
         ),
         Ok(()),
@@ -153,7 +147,7 @@ fn check_relative_bound_pair_for_interval_creation_finite_finite_same_offset_inc
 fn check_relative_bound_pair_for_interval_creation_finite_finite_same_offset_inclusive_exclusive() {
     assert_eq!(
         check_relative_bound_pair_for_interval_creation(
-            &RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1))),
+            &RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_start_bound(),
             &RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
                 SignedDuration::from_hours(1),
                 BoundInclusivity::Exclusive,
@@ -192,7 +186,7 @@ fn prepare_relative_bound_pair_for_interval_creation_inf_past_finite() {
 
 #[test]
 fn prepare_relative_bound_pair_for_interval_creation_finite_inf_future() {
-    let mut start = RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1)));
+    let mut start = RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_start_bound();
     let mut end = RelativeEndBound::InfiniteFuture;
 
     let was_changed = prepare_relative_bound_pair_for_interval_creation(&mut start, &mut end);
@@ -200,14 +194,14 @@ fn prepare_relative_bound_pair_for_interval_creation_finite_inf_future() {
     assert!(!was_changed);
     assert_eq!(
         start,
-        RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1)))
+        RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_start_bound()
     );
     assert_eq!(end, RelativeEndBound::InfiniteFuture);
 }
 
 #[test]
 fn prepare_relative_bound_pair_for_interval_creation_finite_finite_different_offsets_correct_order() {
-    let mut start = RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1)));
+    let mut start = RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_start_bound();
     let mut end = RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(2)));
 
     let was_changed = prepare_relative_bound_pair_for_interval_creation(&mut start, &mut end);
@@ -215,7 +209,7 @@ fn prepare_relative_bound_pair_for_interval_creation_finite_finite_different_off
     assert!(!was_changed);
     assert_eq!(
         start,
-        RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1)))
+        RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_start_bound()
     );
     assert_eq!(
         end,
@@ -225,7 +219,7 @@ fn prepare_relative_bound_pair_for_interval_creation_finite_finite_different_off
 
 #[test]
 fn prepare_relative_bound_pair_for_interval_creation_finite_finite_different_offsets_wrong_order() {
-    let mut start = RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(2)));
+    let mut start = RelativeFiniteBound::new(SignedDuration::from_hours(2)).to_start_bound();
     let mut end = RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1)));
 
     let was_changed = prepare_relative_bound_pair_for_interval_creation(&mut start, &mut end);
@@ -237,13 +231,13 @@ fn prepare_relative_bound_pair_for_interval_creation_finite_finite_different_off
     );
     assert_eq!(
         end,
-        RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(2)))
+        RelativeFiniteBound::new(SignedDuration::from_hours(2)).to_start_bound()
     );
 }
 
 #[test]
 fn prepare_relative_bound_pair_for_interval_creation_finite_finite_same_offset_inclusive_inclusive() {
-    let mut start = RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1)));
+    let mut start = RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_start_bound();
     let mut end = RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1)));
 
     let was_changed = prepare_relative_bound_pair_for_interval_creation(&mut start, &mut end);
@@ -251,7 +245,7 @@ fn prepare_relative_bound_pair_for_interval_creation_finite_finite_same_offset_i
     assert!(!was_changed);
     assert_eq!(
         start,
-        RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1)))
+        RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_start_bound()
     );
     assert_eq!(
         end,
@@ -261,7 +255,7 @@ fn prepare_relative_bound_pair_for_interval_creation_finite_finite_same_offset_i
 
 #[test]
 fn prepare_relative_bound_pair_for_interval_creation_finite_finite_same_offset_inclusive_exclusive() {
-    let mut start = RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1)));
+    let mut start = RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_start_bound();
     let mut end = RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
         SignedDuration::from_hours(1),
         BoundInclusivity::Exclusive,
@@ -272,10 +266,10 @@ fn prepare_relative_bound_pair_for_interval_creation_finite_finite_same_offset_i
     assert!(was_changed);
     assert_eq!(
         start,
-        RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1)))
+        RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_start_bound()
     );
     assert_eq!(
         end,
-        RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1)))
+        RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_start_bound()
     );
 }

--- a/src/iter/intervals/bounds_tests.rs
+++ b/src/iter/intervals/bounds_tests.rs
@@ -122,11 +122,11 @@ mod abs_bounds {
 fn create_rel_bounds_iter() {
     let data = [
         RelativeBoundPair::new(
-            RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1))),
+            RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_start_bound(),
             RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1))),
         ),
         RelativeBoundPair::new(
-            RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(3))),
+            RelativeFiniteBound::new(SignedDuration::from_hours(3)).to_start_bound(),
             RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(5))),
         ),
     ];
@@ -142,23 +142,23 @@ fn rel_bounds_iter_run() {
             RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1))),
         ),
         RelativeBoundPair::new(
-            RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(10))),
+            RelativeFiniteBound::new(SignedDuration::from_hours(10)).to_start_bound(),
             RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(15))),
         ),
         RelativeBoundPair::new(
-            RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(13))),
+            RelativeFiniteBound::new(SignedDuration::from_hours(13)).to_start_bound(),
             RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(19))),
         ),
         RelativeBoundPair::new(
-            RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(20))),
+            RelativeFiniteBound::new(SignedDuration::from_hours(20)).to_start_bound(),
             RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(24))),
         ),
         RelativeBoundPair::new(
-            RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(25))),
+            RelativeFiniteBound::new(SignedDuration::from_hours(25)).to_start_bound(),
             RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(29))),
         ),
         RelativeBoundPair::new(
-            RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(27))),
+            RelativeFiniteBound::new(SignedDuration::from_hours(27)).to_start_bound(),
             RelativeEndBound::InfiniteFuture,
         ),
     ];
@@ -170,33 +170,23 @@ fn rel_bounds_iter_run() {
             RelativeBound::End(RelativeEndBound::Finite(RelativeFiniteBound::new(
                 SignedDuration::from_hours(1)
             ))),
-            RelativeBound::Start(RelativeStartBound::Finite(RelativeFiniteBound::new(
-                SignedDuration::from_hours(10)
-            ))),
+            RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(10)).to_start_bound()),
             RelativeBound::End(RelativeEndBound::Finite(RelativeFiniteBound::new(
                 SignedDuration::from_hours(15)
             ))),
-            RelativeBound::Start(RelativeStartBound::Finite(RelativeFiniteBound::new(
-                SignedDuration::from_hours(13)
-            ))),
+            RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(13)).to_start_bound()),
             RelativeBound::End(RelativeEndBound::Finite(RelativeFiniteBound::new(
                 SignedDuration::from_hours(19)
             ))),
-            RelativeBound::Start(RelativeStartBound::Finite(RelativeFiniteBound::new(
-                SignedDuration::from_hours(20)
-            ))),
+            RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(20)).to_start_bound()),
             RelativeBound::End(RelativeEndBound::Finite(RelativeFiniteBound::new(
                 SignedDuration::from_hours(24)
             ))),
-            RelativeBound::Start(RelativeStartBound::Finite(RelativeFiniteBound::new(
-                SignedDuration::from_hours(25)
-            ))),
+            RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(25)).to_start_bound()),
             RelativeBound::End(RelativeEndBound::Finite(RelativeFiniteBound::new(
                 SignedDuration::from_hours(29)
             ))),
-            RelativeBound::Start(RelativeStartBound::Finite(RelativeFiniteBound::new(
-                SignedDuration::from_hours(27)
-            ))),
+            RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(27)).to_start_bound()),
             RelativeBound::End(RelativeEndBound::InfiniteFuture),
         ],
     );

--- a/src/iter/intervals/bounds_tests.rs
+++ b/src/iter/intervals/bounds_tests.rs
@@ -3,13 +3,7 @@ use std::error::Error;
 use jiff::{SignedDuration, Zoned};
 
 use super::bounds::*;
-use crate::intervals::absolute::{
-    AbsoluteBound,
-    AbsoluteBoundPair,
-    AbsoluteEndBound,
-    AbsoluteFiniteBound,
-    AbsoluteStartBound,
-};
+use crate::intervals::absolute::{AbsoluteBoundPair, AbsoluteEndBound, AbsoluteFiniteBound, AbsoluteStartBound};
 use crate::intervals::relative::{
     RelativeBound,
     RelativeBoundPair,
@@ -85,48 +79,38 @@ mod abs_bounds {
         assert_eq!(
             AbsoluteBoundsIter::new(data.into_iter()).collect::<Vec<_>>(),
             vec![
-                AbsoluteBound::Start(AbsoluteStartBound::InfinitePast),
-                AbsoluteBound::End(
-                    AbsoluteFiniteBound::new("2024-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
-                        .to_end_bound()
-                ),
-                AbsoluteBound::Start(
-                    AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
-                        .to_start_bound()
-                ),
-                AbsoluteBound::End(
-                    AbsoluteFiniteBound::new("2025-01-06 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
-                        .to_end_bound()
-                ),
-                AbsoluteBound::Start(
-                    AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
-                        .to_start_bound()
-                ),
-                AbsoluteBound::End(
-                    AbsoluteFiniteBound::new("2025-01-09 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
-                        .to_end_bound()
-                ),
-                AbsoluteBound::Start(
-                    AbsoluteFiniteBound::new("2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
-                        .to_start_bound()
-                ),
-                AbsoluteBound::End(
-                    AbsoluteFiniteBound::new("2025-02-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
-                        .to_end_bound()
-                ),
-                AbsoluteBound::Start(
-                    AbsoluteFiniteBound::new("2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
-                        .to_start_bound()
-                ),
-                AbsoluteBound::End(
-                    AbsoluteFiniteBound::new("2025-02-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
-                        .to_end_bound()
-                ),
-                AbsoluteBound::Start(
-                    AbsoluteFiniteBound::new("2025-02-06 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
-                        .to_start_bound()
-                ),
-                AbsoluteBound::End(AbsoluteEndBound::InfiniteFuture),
+                AbsoluteStartBound::InfinitePast.to_bound(),
+                AbsoluteFiniteBound::new("2024-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound()
+                    .to_bound(),
+                AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound()
+                    .to_bound(),
+                AbsoluteFiniteBound::new("2025-01-06 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound()
+                    .to_bound(),
+                AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound()
+                    .to_bound(),
+                AbsoluteFiniteBound::new("2025-01-09 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound()
+                    .to_bound(),
+                AbsoluteFiniteBound::new("2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound()
+                    .to_bound(),
+                AbsoluteFiniteBound::new("2025-02-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound()
+                    .to_bound(),
+                AbsoluteFiniteBound::new("2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound()
+                    .to_bound(),
+                AbsoluteFiniteBound::new("2025-02-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound()
+                    .to_bound(),
+                AbsoluteFiniteBound::new("2025-02-06 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound()
+                    .to_bound(),
+                AbsoluteEndBound::InfiniteFuture.to_bound(),
             ],
         );
 

--- a/src/iter/intervals/bounds_tests.rs
+++ b/src/iter/intervals/bounds_tests.rs
@@ -4,13 +4,7 @@ use jiff::{SignedDuration, Zoned};
 
 use super::bounds::*;
 use crate::intervals::absolute::{AbsoluteBoundPair, AbsoluteEndBound, AbsoluteFiniteBound, AbsoluteStartBound};
-use crate::intervals::relative::{
-    RelativeBound,
-    RelativeBoundPair,
-    RelativeEndBound,
-    RelativeFiniteBound,
-    RelativeStartBound,
-};
+use crate::intervals::relative::{RelativeBoundPair, RelativeEndBound, RelativeFiniteBound, RelativeStartBound};
 
 mod abs_bounds {
     use super::*;
@@ -166,18 +160,38 @@ fn rel_bounds_iter_run() {
     assert_eq!(
         RelativeBoundsIter::new(data.into_iter()).collect::<Vec<_>>(),
         vec![
-            RelativeBound::Start(RelativeStartBound::InfinitePast),
-            RelativeBound::End(RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_end_bound()),
-            RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(10)).to_start_bound()),
-            RelativeBound::End(RelativeFiniteBound::new(SignedDuration::from_hours(15)).to_end_bound()),
-            RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(13)).to_start_bound()),
-            RelativeBound::End(RelativeFiniteBound::new(SignedDuration::from_hours(19)).to_end_bound()),
-            RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(20)).to_start_bound()),
-            RelativeBound::End(RelativeFiniteBound::new(SignedDuration::from_hours(24)).to_end_bound()),
-            RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(25)).to_start_bound()),
-            RelativeBound::End(RelativeFiniteBound::new(SignedDuration::from_hours(29)).to_end_bound()),
-            RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(27)).to_start_bound()),
-            RelativeBound::End(RelativeEndBound::InfiniteFuture),
+            RelativeStartBound::InfinitePast.to_bound(),
+            RelativeFiniteBound::new(SignedDuration::from_hours(1))
+                .to_end_bound()
+                .to_bound(),
+            RelativeFiniteBound::new(SignedDuration::from_hours(10))
+                .to_start_bound()
+                .to_bound(),
+            RelativeFiniteBound::new(SignedDuration::from_hours(15))
+                .to_end_bound()
+                .to_bound(),
+            RelativeFiniteBound::new(SignedDuration::from_hours(13))
+                .to_start_bound()
+                .to_bound(),
+            RelativeFiniteBound::new(SignedDuration::from_hours(19))
+                .to_end_bound()
+                .to_bound(),
+            RelativeFiniteBound::new(SignedDuration::from_hours(20))
+                .to_start_bound()
+                .to_bound(),
+            RelativeFiniteBound::new(SignedDuration::from_hours(24))
+                .to_end_bound()
+                .to_bound(),
+            RelativeFiniteBound::new(SignedDuration::from_hours(25))
+                .to_start_bound()
+                .to_bound(),
+            RelativeFiniteBound::new(SignedDuration::from_hours(29))
+                .to_end_bound()
+                .to_bound(),
+            RelativeFiniteBound::new(SignedDuration::from_hours(27))
+                .to_start_bound()
+                .to_bound(),
+            RelativeEndBound::InfiniteFuture.to_bound(),
         ],
     );
 }

--- a/src/iter/intervals/bounds_tests.rs
+++ b/src/iter/intervals/bounds_tests.rs
@@ -27,16 +27,14 @@ mod abs_bounds {
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
         ];
 
@@ -50,37 +48,32 @@ mod abs_bounds {
         let data = [
             AbsoluteBoundPair::new(
                 AbsoluteStartBound::InfinitePast,
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2024-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2024-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-06 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-06 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-09 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-09 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-02-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-02-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-02-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-02-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-02-06 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
@@ -93,37 +86,42 @@ mod abs_bounds {
             AbsoluteBoundsIter::new(data.into_iter()).collect::<Vec<_>>(),
             vec![
                 AbsoluteBound::Start(AbsoluteStartBound::InfinitePast),
-                AbsoluteBound::End(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2024-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                ))),
+                AbsoluteBound::End(
+                    AbsoluteFiniteBound::new("2024-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound()
+                ),
                 AbsoluteBound::Start(
                     AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound()
                 ),
-                AbsoluteBound::End(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-06 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                ))),
+                AbsoluteBound::End(
+                    AbsoluteFiniteBound::new("2025-01-06 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound()
+                ),
                 AbsoluteBound::Start(
                     AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound()
                 ),
-                AbsoluteBound::End(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-09 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                ))),
+                AbsoluteBound::End(
+                    AbsoluteFiniteBound::new("2025-01-09 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound()
+                ),
                 AbsoluteBound::Start(
                     AbsoluteFiniteBound::new("2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound()
                 ),
-                AbsoluteBound::End(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-02-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                ))),
+                AbsoluteBound::End(
+                    AbsoluteFiniteBound::new("2025-02-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound()
+                ),
                 AbsoluteBound::Start(
                     AbsoluteFiniteBound::new("2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound()
                 ),
-                AbsoluteBound::End(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-02-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                ))),
+                AbsoluteBound::End(
+                    AbsoluteFiniteBound::new("2025-02-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound()
+                ),
                 AbsoluteBound::Start(
                     AbsoluteFiniteBound::new("2025-02-06 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound()

--- a/src/iter/intervals/bounds_tests.rs
+++ b/src/iter/intervals/bounds_tests.rs
@@ -123,11 +123,11 @@ fn create_rel_bounds_iter() {
     let data = [
         RelativeBoundPair::new(
             RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_start_bound(),
-            RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1))),
+            RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_end_bound(),
         ),
         RelativeBoundPair::new(
             RelativeFiniteBound::new(SignedDuration::from_hours(3)).to_start_bound(),
-            RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(5))),
+            RelativeFiniteBound::new(SignedDuration::from_hours(5)).to_end_bound(),
         ),
     ];
 
@@ -139,23 +139,23 @@ fn rel_bounds_iter_run() {
     let data = [
         RelativeBoundPair::new(
             RelativeStartBound::InfinitePast,
-            RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1))),
+            RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_end_bound(),
         ),
         RelativeBoundPair::new(
             RelativeFiniteBound::new(SignedDuration::from_hours(10)).to_start_bound(),
-            RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(15))),
+            RelativeFiniteBound::new(SignedDuration::from_hours(15)).to_end_bound(),
         ),
         RelativeBoundPair::new(
             RelativeFiniteBound::new(SignedDuration::from_hours(13)).to_start_bound(),
-            RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(19))),
+            RelativeFiniteBound::new(SignedDuration::from_hours(19)).to_end_bound(),
         ),
         RelativeBoundPair::new(
             RelativeFiniteBound::new(SignedDuration::from_hours(20)).to_start_bound(),
-            RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(24))),
+            RelativeFiniteBound::new(SignedDuration::from_hours(24)).to_end_bound(),
         ),
         RelativeBoundPair::new(
             RelativeFiniteBound::new(SignedDuration::from_hours(25)).to_start_bound(),
-            RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(29))),
+            RelativeFiniteBound::new(SignedDuration::from_hours(29)).to_end_bound(),
         ),
         RelativeBoundPair::new(
             RelativeFiniteBound::new(SignedDuration::from_hours(27)).to_start_bound(),
@@ -167,25 +167,15 @@ fn rel_bounds_iter_run() {
         RelativeBoundsIter::new(data.into_iter()).collect::<Vec<_>>(),
         vec![
             RelativeBound::Start(RelativeStartBound::InfinitePast),
-            RelativeBound::End(RelativeEndBound::Finite(RelativeFiniteBound::new(
-                SignedDuration::from_hours(1)
-            ))),
+            RelativeBound::End(RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_end_bound()),
             RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(10)).to_start_bound()),
-            RelativeBound::End(RelativeEndBound::Finite(RelativeFiniteBound::new(
-                SignedDuration::from_hours(15)
-            ))),
+            RelativeBound::End(RelativeFiniteBound::new(SignedDuration::from_hours(15)).to_end_bound()),
             RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(13)).to_start_bound()),
-            RelativeBound::End(RelativeEndBound::Finite(RelativeFiniteBound::new(
-                SignedDuration::from_hours(19)
-            ))),
+            RelativeBound::End(RelativeFiniteBound::new(SignedDuration::from_hours(19)).to_end_bound()),
             RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(20)).to_start_bound()),
-            RelativeBound::End(RelativeEndBound::Finite(RelativeFiniteBound::new(
-                SignedDuration::from_hours(24)
-            ))),
+            RelativeBound::End(RelativeFiniteBound::new(SignedDuration::from_hours(24)).to_end_bound()),
             RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(25)).to_start_bound()),
-            RelativeBound::End(RelativeEndBound::Finite(RelativeFiniteBound::new(
-                SignedDuration::from_hours(29)
-            ))),
+            RelativeBound::End(RelativeFiniteBound::new(SignedDuration::from_hours(29)).to_end_bound()),
             RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(27)).to_start_bound()),
             RelativeBound::End(RelativeEndBound::InfiniteFuture),
         ],

--- a/src/iter/intervals/bounds_tests.rs
+++ b/src/iter/intervals/bounds_tests.rs
@@ -25,17 +25,15 @@ mod abs_bounds {
     fn create_abs_bounds_iter() -> Result<(), Box<dyn Error>> {
         let data = [
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 )),
             ),
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 )),
@@ -57,41 +55,36 @@ mod abs_bounds {
                 )),
             ),
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-06 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 )),
             ),
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-09 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 )),
             ),
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-02-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 )),
             ),
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-02-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 )),
             ),
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-02-06 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-02-06 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::InfiniteFuture,
             ),
         ];
@@ -103,33 +96,38 @@ mod abs_bounds {
                 AbsoluteBound::End(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2024-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 ))),
-                AbsoluteBound::Start(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                ))),
+                AbsoluteBound::Start(
+                    AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound()
+                ),
                 AbsoluteBound::End(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-06 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 ))),
-                AbsoluteBound::Start(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                ))),
+                AbsoluteBound::Start(
+                    AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound()
+                ),
                 AbsoluteBound::End(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-09 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 ))),
-                AbsoluteBound::Start(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                ))),
+                AbsoluteBound::Start(
+                    AbsoluteFiniteBound::new("2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound()
+                ),
                 AbsoluteBound::End(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-02-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 ))),
-                AbsoluteBound::Start(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                ))),
+                AbsoluteBound::Start(
+                    AbsoluteFiniteBound::new("2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound()
+                ),
                 AbsoluteBound::End(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-02-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 ))),
-                AbsoluteBound::Start(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-02-06 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                ))),
+                AbsoluteBound::Start(
+                    AbsoluteFiniteBound::new("2025-02-06 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound()
+                ),
                 AbsoluteBound::End(AbsoluteEndBound::InfiniteFuture),
             ],
         );

--- a/src/iter/intervals/layered_bounds/abs_state_change_tests.rs
+++ b/src/iter/intervals/layered_bounds/abs_state_change_tests.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 use jiff::Zoned;
 
 use super::abs_state_change::*;
-use crate::intervals::absolute::{AbsoluteEndBound, AbsoluteFiniteBound};
+use crate::intervals::absolute::AbsoluteFiniteBound;
 use crate::intervals::meta::BoundInclusivity;
 use crate::iter::intervals::layered_bounds::state::LayeredBoundsState;
 
@@ -41,10 +41,13 @@ fn at_abs_bound_old_state_end() -> Result<(), Box<dyn Error>> {
         LayeredBoundsStateChangeAtAbsoluteBound::new(
             LayeredBoundsState::FirstLayer,
             LayeredBoundsState::SecondLayer,
-            Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                BoundInclusivity::Inclusive,
-            ))),
+            Some(
+                AbsoluteFiniteBound::new_with_inclusivity(
+                    "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                    BoundInclusivity::Inclusive,
+                )
+                .to_end_bound()
+            ),
             Some(
                 AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
@@ -54,10 +57,13 @@ fn at_abs_bound_old_state_end() -> Result<(), Box<dyn Error>> {
             ),
         )
         .old_state_end(),
-        Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-            "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            BoundInclusivity::Inclusive,
-        ))),
+        Some(
+            AbsoluteFiniteBound::new_with_inclusivity(
+                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                BoundInclusivity::Inclusive,
+            )
+            .to_end_bound()
+        ),
     );
 
     Ok(())
@@ -69,10 +75,13 @@ fn at_abs_bound_new_state_start() -> Result<(), Box<dyn Error>> {
         LayeredBoundsStateChangeAtAbsoluteBound::new(
             LayeredBoundsState::FirstLayer,
             LayeredBoundsState::SecondLayer,
-            Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                BoundInclusivity::Inclusive,
-            ))),
+            Some(
+                AbsoluteFiniteBound::new_with_inclusivity(
+                    "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                    BoundInclusivity::Inclusive,
+                )
+                .to_end_bound()
+            ),
             Some(
                 AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),

--- a/src/iter/intervals/layered_bounds/abs_state_change_tests.rs
+++ b/src/iter/intervals/layered_bounds/abs_state_change_tests.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 use jiff::Zoned;
 
 use super::abs_state_change::*;
-use crate::intervals::absolute::{AbsoluteEndBound, AbsoluteFiniteBound, AbsoluteStartBound};
+use crate::intervals::absolute::{AbsoluteEndBound, AbsoluteFiniteBound};
 use crate::intervals::meta::BoundInclusivity;
 use crate::iter::intervals::layered_bounds::state::LayeredBoundsState;
 
@@ -45,10 +45,13 @@ fn at_abs_bound_old_state_end() -> Result<(), Box<dyn Error>> {
                 "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
             ))),
-            Some(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                BoundInclusivity::Exclusive,
-            ))),
+            Some(
+                AbsoluteFiniteBound::new_with_inclusivity(
+                    "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                    BoundInclusivity::Exclusive,
+                )
+                .to_start_bound()
+            ),
         )
         .old_state_end(),
         Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
@@ -70,16 +73,22 @@ fn at_abs_bound_new_state_start() -> Result<(), Box<dyn Error>> {
                 "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Inclusive,
             ))),
-            Some(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                BoundInclusivity::Exclusive,
-            ))),
+            Some(
+                AbsoluteFiniteBound::new_with_inclusivity(
+                    "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                    BoundInclusivity::Exclusive,
+                )
+                .to_start_bound()
+            ),
         )
         .new_state_start(),
-        Some(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-            "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            BoundInclusivity::Exclusive,
-        ))),
+        Some(
+            AbsoluteFiniteBound::new_with_inclusivity(
+                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                BoundInclusivity::Exclusive,
+            )
+            .to_start_bound()
+        ),
     );
 
     Ok(())

--- a/src/iter/intervals/layered_bounds/absolute.rs
+++ b/src/iter/intervals/layered_bounds/absolute.rs
@@ -751,7 +751,7 @@ pub fn layered_abs_bounds_change_start_start(
 /// 1. The peeked value of a layer wasn't equal to the value returned by calling `next()` on that layer
 /// 2. The value returned by `next()` on the layer wasn't of the expected variant
 /// 3. The comparison between [`AbsoluteStartBound`](crate::intervals::absolute::AbsoluteStartBound) and
-///    [`AbsoluteEndBound`] returned [`None`]
+///    [`AbsoluteEndBound`](crate::intervals::absolute::AbsoluteEndBound) returned [`None`]
 #[must_use]
 pub fn layered_abs_bounds_change_start_end(
     old_state: LayeredBoundsState,
@@ -870,7 +870,7 @@ pub fn layered_abs_bounds_change_start_end(
 ///
 /// 1. The peeked value of a layer wasn't equal to the value returned by calling `next()` on that layer
 /// 2. The value returned by `next()` on the layer wasn't of the expected variant
-/// 3. The comparison between [`AbsoluteEndBound`] and
+/// 3. The comparison between [`AbsoluteEndBound`](crate::intervals::absolute::AbsoluteEndBound) and
 ///    [`AbsoluteStartBound`](crate::intervals::absolute::AbsoluteStartBound) returned [`None`]
 #[must_use]
 pub fn layered_abs_bounds_change_end_start(

--- a/src/iter/intervals/layered_bounds/absolute.rs
+++ b/src/iter/intervals/layered_bounds/absolute.rs
@@ -4,7 +4,7 @@ use std::cmp::Ordering;
 use std::iter::{FusedIterator, Peekable};
 use std::ops::{Add, Sub};
 
-use crate::intervals::absolute::{AbsoluteBound, AbsoluteEndBound};
+use crate::intervals::absolute::AbsoluteBound;
 use crate::intervals::meta::BoundInclusivity;
 use crate::intervals::ops::{BoundOrdering, BoundOverlapDisambiguationRuleSet, PartialBoundOrd};
 use crate::iter::intervals::layered_bounds::abs_state_change::LayeredBoundsStateChangeAtAbsoluteBound;
@@ -804,7 +804,7 @@ pub fn layered_abs_bounds_change_start_end(
                 let change_to_return = Change::new(
                     old_state,
                     LayeredBoundsState::BothLayers,
-                    Some(AbsoluteEndBound::Finite(end_of_second_layer)),
+                    Some(end_of_second_layer.to_end_bound()),
                     // We use `finite_first_layer_start` here because it overlaps with the second layer's end
                     // for a single instant
                     Some(finite_first_layer_start.to_start_bound()),
@@ -820,7 +820,7 @@ pub fn layered_abs_bounds_change_start_end(
                 *queued_result_mut = Some(Change::new(
                     LayeredBoundsState::BothLayers,
                     *state_mut,
-                    Some(AbsoluteEndBound::Finite(finite_first_layer_start)),
+                    Some(finite_first_layer_start.to_end_bound()),
                     Some(start_of_first_layer.to_start_bound()),
                 ));
 
@@ -833,7 +833,7 @@ pub fn layered_abs_bounds_change_start_end(
                 Change::new(
                     old_state,
                     *state_mut,
-                    Some(AbsoluteEndBound::Finite(finite_second_layer_end)),
+                    Some(finite_second_layer_end.to_end_bound()),
                     Some(finite_first_layer_start.to_start_bound()),
                 )
             }
@@ -919,7 +919,7 @@ pub fn layered_abs_bounds_change_end_start(
                 let change_to_return = Change::new(
                     old_state,
                     LayeredBoundsState::BothLayers,
-                    Some(AbsoluteEndBound::Finite(end_of_first_layer)),
+                    Some(end_of_first_layer.to_end_bound()),
                     // We use `finite_second_layer_start` here because it overlaps with the first layer's end
                     // for a single instant
                     Some(finite_second_layer_start.to_start_bound()),
@@ -935,7 +935,7 @@ pub fn layered_abs_bounds_change_end_start(
                 *queued_result_mut = Some(Change::new(
                     LayeredBoundsState::BothLayers,
                     *state_mut,
-                    Some(AbsoluteEndBound::Finite(finite_second_layer_start)),
+                    Some(finite_second_layer_start.to_end_bound()),
                     Some(start_of_second_layer.to_start_bound()),
                 ));
 
@@ -948,7 +948,7 @@ pub fn layered_abs_bounds_change_end_start(
                 Change::new(
                     old_state,
                     *state_mut,
-                    Some(AbsoluteEndBound::Finite(finite_first_layer_end)),
+                    Some(finite_first_layer_end.to_end_bound()),
                     Some(finite_second_layer_start.to_start_bound()),
                 )
             }

--- a/src/iter/intervals/layered_bounds/absolute.rs
+++ b/src/iter/intervals/layered_bounds/absolute.rs
@@ -4,7 +4,7 @@ use std::cmp::Ordering;
 use std::iter::{FusedIterator, Peekable};
 use std::ops::{Add, Sub};
 
-use crate::intervals::absolute::{AbsoluteBound, AbsoluteEndBound, AbsoluteStartBound};
+use crate::intervals::absolute::{AbsoluteBound, AbsoluteEndBound};
 use crate::intervals::meta::BoundInclusivity;
 use crate::intervals::ops::{BoundOrdering, BoundOverlapDisambiguationRuleSet, PartialBoundOrd};
 use crate::iter::intervals::layered_bounds::abs_state_change::LayeredBoundsStateChangeAtAbsoluteBound;
@@ -750,7 +750,8 @@ pub fn layered_abs_bounds_change_start_start(
 ///
 /// 1. The peeked value of a layer wasn't equal to the value returned by calling `next()` on that layer
 /// 2. The value returned by `next()` on the layer wasn't of the expected variant
-/// 3. The comparison between [`AbsoluteStartBound`] and [`AbsoluteEndBound`] returned [`None`]
+/// 3. The comparison between [`AbsoluteStartBound`](crate::intervals::absolute::AbsoluteStartBound) and
+///    [`AbsoluteEndBound`] returned [`None`]
 #[must_use]
 pub fn layered_abs_bounds_change_start_end(
     old_state: LayeredBoundsState,
@@ -806,7 +807,7 @@ pub fn layered_abs_bounds_change_start_end(
                     Some(AbsoluteEndBound::Finite(end_of_second_layer)),
                     // We use `finite_first_layer_start` here because it overlaps with the second layer's end
                     // for a single instant
-                    Some(AbsoluteStartBound::Finite(finite_first_layer_start)),
+                    Some(finite_first_layer_start.to_start_bound()),
                 );
 
                 let mut start_of_first_layer = finite_first_layer_start; // Copy
@@ -820,7 +821,7 @@ pub fn layered_abs_bounds_change_start_end(
                     LayeredBoundsState::BothLayers,
                     *state_mut,
                     Some(AbsoluteEndBound::Finite(finite_first_layer_start)),
-                    Some(AbsoluteStartBound::Finite(start_of_first_layer)),
+                    Some(start_of_first_layer.to_start_bound()),
                 ));
 
                 change_to_return
@@ -833,7 +834,7 @@ pub fn layered_abs_bounds_change_start_end(
                     old_state,
                     *state_mut,
                     Some(AbsoluteEndBound::Finite(finite_second_layer_end)),
-                    Some(AbsoluteStartBound::Finite(finite_first_layer_start)),
+                    Some(finite_first_layer_start.to_start_bound()),
                 )
             }
         },
@@ -869,7 +870,8 @@ pub fn layered_abs_bounds_change_start_end(
 ///
 /// 1. The peeked value of a layer wasn't equal to the value returned by calling `next()` on that layer
 /// 2. The value returned by `next()` on the layer wasn't of the expected variant
-/// 3. The comparison between [`AbsoluteEndBound`] and [`AbsoluteStartBound`] returned [`None`]
+/// 3. The comparison between [`AbsoluteEndBound`] and
+///    [`AbsoluteStartBound`](crate::intervals::absolute::AbsoluteStartBound) returned [`None`]
 #[must_use]
 pub fn layered_abs_bounds_change_end_start(
     old_state: LayeredBoundsState,
@@ -920,7 +922,7 @@ pub fn layered_abs_bounds_change_end_start(
                     Some(AbsoluteEndBound::Finite(end_of_first_layer)),
                     // We use `finite_second_layer_start` here because it overlaps with the first layer's end
                     // for a single instant
-                    Some(AbsoluteStartBound::Finite(finite_second_layer_start)),
+                    Some(finite_second_layer_start.to_start_bound()),
                 );
 
                 let mut start_of_second_layer = finite_second_layer_start; // Copy
@@ -934,7 +936,7 @@ pub fn layered_abs_bounds_change_end_start(
                     LayeredBoundsState::BothLayers,
                     *state_mut,
                     Some(AbsoluteEndBound::Finite(finite_second_layer_start)),
-                    Some(AbsoluteStartBound::Finite(start_of_second_layer)),
+                    Some(start_of_second_layer.to_start_bound()),
                 ));
 
                 change_to_return
@@ -947,7 +949,7 @@ pub fn layered_abs_bounds_change_end_start(
                     old_state,
                     *state_mut,
                     Some(AbsoluteEndBound::Finite(finite_first_layer_end)),
-                    Some(AbsoluteStartBound::Finite(finite_second_layer_start)),
+                    Some(finite_second_layer_start.to_start_bound()),
                 )
             }
         },

--- a/src/iter/intervals/layered_bounds/absolute_tests.rs
+++ b/src/iter/intervals/layered_bounds/absolute_tests.rs
@@ -19,29 +19,29 @@ use crate::iter::intervals::layered_bounds::state::LayeredBoundsState;
 fn create() -> Result<(), Box<dyn Error>> {
     let first_layer_data = [
         AbsoluteBound::Start(AbsoluteStartBound::InfinitePast),
-        AbsoluteBound::Start(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-        ))),
+        AbsoluteBound::Start(
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
+        ),
         AbsoluteBound::End(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
             "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
         ))),
-        AbsoluteBound::Start(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-        ))),
+        AbsoluteBound::Start(
+            AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
+        ),
         AbsoluteBound::End(AbsoluteEndBound::InfiniteFuture),
     ];
 
     let second_layer_data = [
         AbsoluteBound::Start(AbsoluteStartBound::InfinitePast),
-        AbsoluteBound::Start(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-        ))),
+        AbsoluteBound::Start(
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
+        ),
         AbsoluteBound::End(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
             "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
         ))),
-        AbsoluteBound::Start(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-        ))),
+        AbsoluteBound::Start(
+            AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
+        ),
         AbsoluteBound::End(AbsoluteEndBound::InfiniteFuture),
     ];
 
@@ -58,46 +58,39 @@ fn run() -> Result<(), Box<dyn Error>> {
     let first_layer_data = [
         // 1
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
         ),
         // 3
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-17 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-17 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
         ),
         // 6
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-02-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
         ),
         // 7
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-02-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-02-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-02-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
         ),
         // 9
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-02-26 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-02-26 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-03-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
@@ -105,19 +98,18 @@ fn run() -> Result<(), Box<dyn Error>> {
         ),
         // 11
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-03-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-03-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
         ),
         // 13
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-03-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-03-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-03-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
@@ -127,46 +119,39 @@ fn run() -> Result<(), Box<dyn Error>> {
     let second_layer_data = [
         // 2
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
         ),
         // 4
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
         ),
         // 5
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
         ),
         // 8
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-02-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-02-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-03-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
         ),
         // 10
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-03-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-03-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-03-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
@@ -174,10 +159,11 @@ fn run() -> Result<(), Box<dyn Error>> {
         ),
         // 12
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-03-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-03-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
@@ -205,9 +191,10 @@ fn run() -> Result<(), Box<dyn Error>> {
                     "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
                 ))),
-                Some(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound()
+                ),
             ),
             // B
             LayeredBoundsStateChangeAtAbsoluteBound::new(
@@ -216,10 +203,13 @@ fn run() -> Result<(), Box<dyn Error>> {
                 Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 ))),
-                Some(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-                    "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new_with_inclusivity(
+                        "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_start_bound()
+                ),
             ),
             // C
             LayeredBoundsStateChangeAtAbsoluteBound::new(
@@ -229,9 +219,10 @@ fn run() -> Result<(), Box<dyn Error>> {
                     "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
                 ))),
-                Some(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new("2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound()
+                ),
             ),
             // D
             LayeredBoundsStateChangeAtAbsoluteBound::new(
@@ -240,10 +231,13 @@ fn run() -> Result<(), Box<dyn Error>> {
                 Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 ))),
-                Some(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-                    "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new_with_inclusivity(
+                        "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_start_bound()
+                ),
             ),
             // E
             LayeredBoundsStateChangeAtAbsoluteBound::new(
@@ -253,9 +247,10 @@ fn run() -> Result<(), Box<dyn Error>> {
                     "2025-01-17 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
                 ))),
-                Some(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-17 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new("2025-01-17 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound()
+                ),
             ),
             // F
             LayeredBoundsStateChangeAtAbsoluteBound::new(
@@ -264,10 +259,13 @@ fn run() -> Result<(), Box<dyn Error>> {
                 Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 ))),
-                Some(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-                    "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new_with_inclusivity(
+                        "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_start_bound()
+                ),
             ),
             // G
             LayeredBoundsStateChangeAtAbsoluteBound::new(
@@ -276,10 +274,13 @@ fn run() -> Result<(), Box<dyn Error>> {
                 Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 ))),
-                Some(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-                    "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new_with_inclusivity(
+                        "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_start_bound()
+                ),
             ),
             // H
             LayeredBoundsStateChangeAtAbsoluteBound::new(
@@ -289,9 +290,10 @@ fn run() -> Result<(), Box<dyn Error>> {
                     "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
                 ))),
-                Some(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new("2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound()
+                ),
             ),
             // I
             LayeredBoundsStateChangeAtAbsoluteBound::new(
@@ -300,10 +302,13 @@ fn run() -> Result<(), Box<dyn Error>> {
                 Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 ))),
-                Some(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-                    "2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new_with_inclusivity(
+                        "2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_start_bound()
+                ),
             ),
             // J
             LayeredBoundsStateChangeAtAbsoluteBound::new(
@@ -312,10 +317,13 @@ fn run() -> Result<(), Box<dyn Error>> {
                 Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-02-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 ))),
-                Some(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-                    "2025-02-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new_with_inclusivity(
+                        "2025-02-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_start_bound()
+                ),
             ),
             // K
             LayeredBoundsStateChangeAtAbsoluteBound::new(
@@ -325,9 +333,10 @@ fn run() -> Result<(), Box<dyn Error>> {
                     "2025-02-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
                 ))),
-                Some(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-02-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new("2025-02-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound()
+                ),
             ),
             // L
             LayeredBoundsStateChangeAtAbsoluteBound::new(
@@ -337,9 +346,10 @@ fn run() -> Result<(), Box<dyn Error>> {
                     "2025-02-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
                 ))),
-                Some(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-02-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new("2025-02-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound()
+                ),
             ),
             // M
             LayeredBoundsStateChangeAtAbsoluteBound::new(
@@ -348,10 +358,13 @@ fn run() -> Result<(), Box<dyn Error>> {
                 Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-02-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 ))),
-                Some(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-                    "2025-02-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new_with_inclusivity(
+                        "2025-02-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_start_bound()
+                ),
             ),
             // N
             LayeredBoundsStateChangeAtAbsoluteBound::new(
@@ -361,9 +374,10 @@ fn run() -> Result<(), Box<dyn Error>> {
                     "2025-02-26 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
                 ))),
-                Some(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-02-26 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new("2025-02-26 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound()
+                ),
             ),
             // O
             LayeredBoundsStateChangeAtAbsoluteBound::new(
@@ -372,10 +386,13 @@ fn run() -> Result<(), Box<dyn Error>> {
                 Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-03-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 ))),
-                Some(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-                    "2025-03-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new_with_inclusivity(
+                        "2025-03-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_start_bound()
+                ),
             ),
             // P
             LayeredBoundsStateChangeAtAbsoluteBound::new(
@@ -385,9 +402,10 @@ fn run() -> Result<(), Box<dyn Error>> {
                     "2025-03-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
                 ))),
-                Some(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-03-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new("2025-03-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound()
+                ),
             ),
             // Q
             LayeredBoundsStateChangeAtAbsoluteBound::new(
@@ -397,9 +415,10 @@ fn run() -> Result<(), Box<dyn Error>> {
                     "2025-03-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
                 ))),
-                Some(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-03-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new("2025-03-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound()
+                ),
             ),
             // R
             LayeredBoundsStateChangeAtAbsoluteBound::new(
@@ -408,10 +427,13 @@ fn run() -> Result<(), Box<dyn Error>> {
                 Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-03-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 ))),
-                Some(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-                    "2025-03-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new_with_inclusivity(
+                        "2025-03-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_start_bound()
+                ),
             ),
             // S
             LayeredBoundsStateChangeAtAbsoluteBound::new(
@@ -420,10 +442,13 @@ fn run() -> Result<(), Box<dyn Error>> {
                 Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-03-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 ))),
-                Some(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-                    "2025-03-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new_with_inclusivity(
+                        "2025-03-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_start_bound()
+                ),
             ),
             // T1
             LayeredBoundsStateChangeAtAbsoluteBound::new(
@@ -433,9 +458,10 @@ fn run() -> Result<(), Box<dyn Error>> {
                     "2025-03-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
                 ))),
-                Some(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-03-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new("2025-03-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound()
+                ),
             ),
             // T2
             LayeredBoundsStateChangeAtAbsoluteBound::new(
@@ -444,10 +470,13 @@ fn run() -> Result<(), Box<dyn Error>> {
                 Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-03-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 ))),
-                Some(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-                    "2025-03-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new_with_inclusivity(
+                        "2025-03-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_start_bound()
+                ),
             ),
             // U
             LayeredBoundsStateChangeAtAbsoluteBound::new(
@@ -456,10 +485,13 @@ fn run() -> Result<(), Box<dyn Error>> {
                 Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-03-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 ))),
-                Some(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-                    "2025-03-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new_with_inclusivity(
+                        "2025-03-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_start_bound()
+                ),
             ),
         ],
     );

--- a/src/iter/intervals/layered_bounds/absolute_tests.rs
+++ b/src/iter/intervals/layered_bounds/absolute_tests.rs
@@ -22,9 +22,9 @@ fn create() -> Result<(), Box<dyn Error>> {
         AbsoluteBound::Start(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
         ),
-        AbsoluteBound::End(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-        ))),
+        AbsoluteBound::End(
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
+        ),
         AbsoluteBound::Start(
             AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
         ),
@@ -36,9 +36,9 @@ fn create() -> Result<(), Box<dyn Error>> {
         AbsoluteBound::Start(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
         ),
-        AbsoluteBound::End(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-            "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-        ))),
+        AbsoluteBound::End(
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
+        ),
         AbsoluteBound::Start(
             AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
         ),
@@ -59,16 +59,12 @@ fn run() -> Result<(), Box<dyn Error>> {
         // 1
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
         // 3
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-17 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
         // 6
         AbsoluteBoundPair::new(
@@ -77,24 +73,21 @@ fn run() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Exclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-02-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-02-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
         // 7
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-02-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-02-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-02-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
         // 9
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-02-26 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-03-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         ),
         // 11
         AbsoluteBoundPair::new(
@@ -103,16 +96,12 @@ fn run() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Exclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-03-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-03-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
         // 13
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-03-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-03-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-03-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
     ];
 
@@ -120,9 +109,7 @@ fn run() -> Result<(), Box<dyn Error>> {
         // 2
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
         // 4
         AbsoluteBoundPair::new(
@@ -131,31 +118,26 @@ fn run() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Exclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
         // 5
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
         // 8
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-02-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-03-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-03-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
         // 10
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-03-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-03-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         ),
         // 12
         AbsoluteBoundPair::new(
@@ -164,9 +146,7 @@ fn run() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Exclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-03-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-03-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
     ];
 
@@ -187,10 +167,13 @@ fn run() -> Result<(), Box<dyn Error>> {
             LayeredBoundsStateChangeAtAbsoluteBound::new(
                 LayeredBoundsState::NoLayers,
                 LayeredBoundsState::FirstLayer,
-                Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-                    "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new_with_inclusivity(
+                        "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_end_bound()
+                ),
                 Some(
                     AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound()
@@ -200,9 +183,10 @@ fn run() -> Result<(), Box<dyn Error>> {
             LayeredBoundsStateChangeAtAbsoluteBound::new(
                 LayeredBoundsState::FirstLayer,
                 LayeredBoundsState::NoLayers,
-                Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound()
+                ),
                 Some(
                     AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
@@ -215,10 +199,13 @@ fn run() -> Result<(), Box<dyn Error>> {
             LayeredBoundsStateChangeAtAbsoluteBound::new(
                 LayeredBoundsState::NoLayers,
                 LayeredBoundsState::SecondLayer,
-                Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-                    "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new_with_inclusivity(
+                        "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_end_bound()
+                ),
                 Some(
                     AbsoluteFiniteBound::new("2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound()
@@ -228,9 +215,10 @@ fn run() -> Result<(), Box<dyn Error>> {
             LayeredBoundsStateChangeAtAbsoluteBound::new(
                 LayeredBoundsState::SecondLayer,
                 LayeredBoundsState::NoLayers,
-                Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound()
+                ),
                 Some(
                     AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
@@ -243,10 +231,13 @@ fn run() -> Result<(), Box<dyn Error>> {
             LayeredBoundsStateChangeAtAbsoluteBound::new(
                 LayeredBoundsState::NoLayers,
                 LayeredBoundsState::FirstLayer,
-                Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-                    "2025-01-17 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new_with_inclusivity(
+                        "2025-01-17 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_end_bound()
+                ),
                 Some(
                     AbsoluteFiniteBound::new("2025-01-17 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound()
@@ -256,9 +247,10 @@ fn run() -> Result<(), Box<dyn Error>> {
             LayeredBoundsStateChangeAtAbsoluteBound::new(
                 LayeredBoundsState::FirstLayer,
                 LayeredBoundsState::SecondLayer,
-                Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound()
+                ),
                 Some(
                     AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
@@ -271,9 +263,10 @@ fn run() -> Result<(), Box<dyn Error>> {
             LayeredBoundsStateChangeAtAbsoluteBound::new(
                 LayeredBoundsState::SecondLayer,
                 LayeredBoundsState::NoLayers,
-                Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new("2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound()
+                ),
                 Some(
                     AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
@@ -286,10 +279,13 @@ fn run() -> Result<(), Box<dyn Error>> {
             LayeredBoundsStateChangeAtAbsoluteBound::new(
                 LayeredBoundsState::NoLayers,
                 LayeredBoundsState::SecondLayer,
-                Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-                    "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new_with_inclusivity(
+                        "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_end_bound()
+                ),
                 Some(
                     AbsoluteFiniteBound::new("2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound()
@@ -299,9 +295,10 @@ fn run() -> Result<(), Box<dyn Error>> {
             LayeredBoundsStateChangeAtAbsoluteBound::new(
                 LayeredBoundsState::SecondLayer,
                 LayeredBoundsState::FirstLayer,
-                Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new("2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound()
+                ),
                 Some(
                     AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
@@ -314,9 +311,10 @@ fn run() -> Result<(), Box<dyn Error>> {
             LayeredBoundsStateChangeAtAbsoluteBound::new(
                 LayeredBoundsState::FirstLayer,
                 LayeredBoundsState::NoLayers,
-                Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-02-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new("2025-02-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound()
+                ),
                 Some(
                     AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-02-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
@@ -329,10 +327,13 @@ fn run() -> Result<(), Box<dyn Error>> {
             LayeredBoundsStateChangeAtAbsoluteBound::new(
                 LayeredBoundsState::NoLayers,
                 LayeredBoundsState::FirstLayer,
-                Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-                    "2025-02-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new_with_inclusivity(
+                        "2025-02-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_end_bound()
+                ),
                 Some(
                     AbsoluteFiniteBound::new("2025-02-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound()
@@ -342,10 +343,13 @@ fn run() -> Result<(), Box<dyn Error>> {
             LayeredBoundsStateChangeAtAbsoluteBound::new(
                 LayeredBoundsState::FirstLayer,
                 LayeredBoundsState::BothLayers,
-                Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-                    "2025-02-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new_with_inclusivity(
+                        "2025-02-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_end_bound()
+                ),
                 Some(
                     AbsoluteFiniteBound::new("2025-02-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound()
@@ -355,9 +359,10 @@ fn run() -> Result<(), Box<dyn Error>> {
             LayeredBoundsStateChangeAtAbsoluteBound::new(
                 LayeredBoundsState::BothLayers,
                 LayeredBoundsState::SecondLayer,
-                Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-02-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new("2025-02-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound()
+                ),
                 Some(
                     AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-02-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
@@ -370,10 +375,13 @@ fn run() -> Result<(), Box<dyn Error>> {
             LayeredBoundsStateChangeAtAbsoluteBound::new(
                 LayeredBoundsState::SecondLayer,
                 LayeredBoundsState::BothLayers,
-                Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-                    "2025-02-26 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new_with_inclusivity(
+                        "2025-02-26 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_end_bound()
+                ),
                 Some(
                     AbsoluteFiniteBound::new("2025-02-26 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound()
@@ -383,9 +391,10 @@ fn run() -> Result<(), Box<dyn Error>> {
             LayeredBoundsStateChangeAtAbsoluteBound::new(
                 LayeredBoundsState::BothLayers,
                 LayeredBoundsState::FirstLayer,
-                Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-03-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new("2025-03-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound()
+                ),
                 Some(
                     AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-03-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
@@ -398,10 +407,13 @@ fn run() -> Result<(), Box<dyn Error>> {
             LayeredBoundsStateChangeAtAbsoluteBound::new(
                 LayeredBoundsState::FirstLayer,
                 LayeredBoundsState::BothLayers,
-                Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-                    "2025-03-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new_with_inclusivity(
+                        "2025-03-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_end_bound()
+                ),
                 Some(
                     AbsoluteFiniteBound::new("2025-03-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound()
@@ -411,10 +423,13 @@ fn run() -> Result<(), Box<dyn Error>> {
             LayeredBoundsStateChangeAtAbsoluteBound::new(
                 LayeredBoundsState::BothLayers,
                 LayeredBoundsState::NoLayers,
-                Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-                    "2025-03-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new_with_inclusivity(
+                        "2025-03-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_end_bound()
+                ),
                 Some(
                     AbsoluteFiniteBound::new("2025-03-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound()
@@ -424,9 +439,10 @@ fn run() -> Result<(), Box<dyn Error>> {
             LayeredBoundsStateChangeAtAbsoluteBound::new(
                 LayeredBoundsState::NoLayers,
                 LayeredBoundsState::BothLayers,
-                Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-03-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new("2025-03-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound()
+                ),
                 Some(
                     AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-03-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
@@ -439,9 +455,10 @@ fn run() -> Result<(), Box<dyn Error>> {
             LayeredBoundsStateChangeAtAbsoluteBound::new(
                 LayeredBoundsState::BothLayers,
                 LayeredBoundsState::SecondLayer,
-                Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-03-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new("2025-03-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound()
+                ),
                 Some(
                     AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-03-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
@@ -454,10 +471,13 @@ fn run() -> Result<(), Box<dyn Error>> {
             LayeredBoundsStateChangeAtAbsoluteBound::new(
                 LayeredBoundsState::SecondLayer,
                 LayeredBoundsState::BothLayers,
-                Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-                    "2025-03-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new_with_inclusivity(
+                        "2025-03-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_end_bound()
+                ),
                 Some(
                     AbsoluteFiniteBound::new("2025-03-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound()
@@ -467,9 +487,10 @@ fn run() -> Result<(), Box<dyn Error>> {
             LayeredBoundsStateChangeAtAbsoluteBound::new(
                 LayeredBoundsState::BothLayers,
                 LayeredBoundsState::FirstLayer,
-                Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-03-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new("2025-03-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound()
+                ),
                 Some(
                     AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-03-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
@@ -482,9 +503,10 @@ fn run() -> Result<(), Box<dyn Error>> {
             LayeredBoundsStateChangeAtAbsoluteBound::new(
                 LayeredBoundsState::FirstLayer,
                 LayeredBoundsState::NoLayers,
-                Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-03-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new("2025-03-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound()
+                ),
                 Some(
                     AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-03-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),

--- a/src/iter/intervals/layered_bounds/absolute_tests.rs
+++ b/src/iter/intervals/layered_bounds/absolute_tests.rs
@@ -3,13 +3,7 @@ use std::error::Error;
 use jiff::Zoned;
 
 use super::absolute::*;
-use crate::intervals::absolute::{
-    AbsoluteBound,
-    AbsoluteBoundPair,
-    AbsoluteEndBound,
-    AbsoluteFiniteBound,
-    AbsoluteStartBound,
-};
+use crate::intervals::absolute::{AbsoluteBoundPair, AbsoluteEndBound, AbsoluteFiniteBound, AbsoluteStartBound};
 use crate::intervals::meta::BoundInclusivity;
 use crate::iter::intervals::bounds::AbsoluteBoundsIteratorDispatcher;
 use crate::iter::intervals::layered_bounds::abs_state_change::LayeredBoundsStateChangeAtAbsoluteBound;
@@ -18,31 +12,31 @@ use crate::iter::intervals::layered_bounds::state::LayeredBoundsState;
 #[test]
 fn create() -> Result<(), Box<dyn Error>> {
     let first_layer_data = [
-        AbsoluteBound::Start(AbsoluteStartBound::InfinitePast),
-        AbsoluteBound::Start(
-            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-        ),
-        AbsoluteBound::End(
-            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
-        ),
-        AbsoluteBound::Start(
-            AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-        ),
-        AbsoluteBound::End(AbsoluteEndBound::InfiniteFuture),
+        AbsoluteStartBound::InfinitePast.to_bound(),
+        AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+            .to_start_bound()
+            .to_bound(),
+        AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+            .to_end_bound()
+            .to_bound(),
+        AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+            .to_start_bound()
+            .to_bound(),
+        AbsoluteEndBound::InfiniteFuture.to_bound(),
     ];
 
     let second_layer_data = [
-        AbsoluteBound::Start(AbsoluteStartBound::InfinitePast),
-        AbsoluteBound::Start(
-            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-        ),
-        AbsoluteBound::End(
-            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
-        ),
-        AbsoluteBound::Start(
-            AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-        ),
-        AbsoluteBound::End(AbsoluteEndBound::InfiniteFuture),
+        AbsoluteStartBound::InfinitePast.to_bound(),
+        AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+            .to_start_bound()
+            .to_bound(),
+        AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+            .to_end_bound()
+            .to_bound(),
+        AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+            .to_start_bound()
+            .to_bound(),
+        AbsoluteEndBound::InfiniteFuture.to_bound(),
     ];
 
     let _ = LayeredAbsoluteBounds::new(first_layer_data.into_iter(), second_layer_data.into_iter());

--- a/src/iter/intervals/layered_bounds/rel_state_change_tests.rs
+++ b/src/iter/intervals/layered_bounds/rel_state_change_tests.rs
@@ -2,7 +2,7 @@ use jiff::SignedDuration;
 
 use super::rel_state_change::*;
 use crate::intervals::meta::BoundInclusivity;
-use crate::intervals::relative::{RelativeEndBound, RelativeFiniteBound};
+use crate::intervals::relative::RelativeFiniteBound;
 use crate::iter::intervals::layered_bounds::state::LayeredBoundsState;
 
 #[test]
@@ -39,20 +39,20 @@ fn at_rel_bound_old_state_end() {
         LayeredBoundsStateChangeAtRelativeBound::new(
             LayeredBoundsState::FirstLayer,
             LayeredBoundsState::SecondLayer,
-            Some(RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                SignedDuration::from_hours(1),
-                BoundInclusivity::Inclusive,
-            ))),
+            Some(
+                RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(1), BoundInclusivity::Inclusive,)
+                    .to_end_bound()
+            ),
             Some(
                 RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(1), BoundInclusivity::Exclusive,)
                     .to_start_bound()
             ),
         )
         .old_state_end(),
-        Some(RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-            SignedDuration::from_hours(1),
-            BoundInclusivity::Inclusive,
-        ))),
+        Some(
+            RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(1), BoundInclusivity::Inclusive,)
+                .to_end_bound()
+        ),
     );
 }
 
@@ -62,10 +62,10 @@ fn at_rel_bound_new_state_start() {
         LayeredBoundsStateChangeAtRelativeBound::new(
             LayeredBoundsState::FirstLayer,
             LayeredBoundsState::SecondLayer,
-            Some(RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                SignedDuration::from_hours(1),
-                BoundInclusivity::Inclusive,
-            ))),
+            Some(
+                RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(1), BoundInclusivity::Inclusive,)
+                    .to_end_bound()
+            ),
             Some(
                 RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(1), BoundInclusivity::Exclusive,)
                     .to_start_bound()

--- a/src/iter/intervals/layered_bounds/rel_state_change_tests.rs
+++ b/src/iter/intervals/layered_bounds/rel_state_change_tests.rs
@@ -2,7 +2,7 @@ use jiff::SignedDuration;
 
 use super::rel_state_change::*;
 use crate::intervals::meta::BoundInclusivity;
-use crate::intervals::relative::{RelativeEndBound, RelativeFiniteBound, RelativeStartBound};
+use crate::intervals::relative::{RelativeEndBound, RelativeFiniteBound};
 use crate::iter::intervals::layered_bounds::state::LayeredBoundsState;
 
 #[test]
@@ -43,10 +43,10 @@ fn at_rel_bound_old_state_end() {
                 SignedDuration::from_hours(1),
                 BoundInclusivity::Inclusive,
             ))),
-            Some(RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                SignedDuration::from_hours(1),
-                BoundInclusivity::Exclusive,
-            ))),
+            Some(
+                RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(1), BoundInclusivity::Exclusive,)
+                    .to_start_bound()
+            ),
         )
         .old_state_end(),
         Some(RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
@@ -66,15 +66,15 @@ fn at_rel_bound_new_state_start() {
                 SignedDuration::from_hours(1),
                 BoundInclusivity::Inclusive,
             ))),
-            Some(RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                SignedDuration::from_hours(1),
-                BoundInclusivity::Exclusive,
-            ))),
+            Some(
+                RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(1), BoundInclusivity::Exclusive,)
+                    .to_start_bound()
+            ),
         )
         .new_state_start(),
-        Some(RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-            SignedDuration::from_hours(1),
-            BoundInclusivity::Exclusive,
-        ))),
+        Some(
+            RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(1), BoundInclusivity::Exclusive,)
+                .to_start_bound()
+        ),
     );
 }

--- a/src/iter/intervals/layered_bounds/relative.rs
+++ b/src/iter/intervals/layered_bounds/relative.rs
@@ -6,7 +6,7 @@ use std::ops::{Add, Sub};
 
 use crate::intervals::meta::BoundInclusivity;
 use crate::intervals::ops::{BoundOrdering, BoundOverlapDisambiguationRuleSet, PartialBoundOrd};
-use crate::intervals::relative::{RelativeBound, RelativeEndBound, RelativeStartBound};
+use crate::intervals::relative::{RelativeBound, RelativeEndBound};
 use crate::iter::intervals::layered_bounds::rel_state_change::LayeredBoundsStateChangeAtRelativeBound;
 use crate::iter::intervals::layered_bounds::state::LayeredBoundsState;
 
@@ -650,7 +650,7 @@ pub fn layered_rel_bounds_change_start_end(
                     Some(RelativeEndBound::Finite(end_of_second_layer)),
                     // We use `finite_first_layer_start` here because it overlaps with the second layer's end
                     // for a single instant
-                    Some(RelativeStartBound::Finite(finite_first_layer_start)),
+                    Some(finite_first_layer_start.to_start_bound()),
                 );
 
                 let mut start_of_first_layer = finite_first_layer_start; // Copy
@@ -664,7 +664,7 @@ pub fn layered_rel_bounds_change_start_end(
                     LayeredBoundsState::BothLayers,
                     *state_mut,
                     Some(RelativeEndBound::Finite(finite_first_layer_start)),
-                    Some(RelativeStartBound::Finite(start_of_first_layer)),
+                    Some(start_of_first_layer.to_start_bound()),
                 ));
 
                 change_to_return
@@ -677,7 +677,7 @@ pub fn layered_rel_bounds_change_start_end(
                     old_state,
                     *state_mut,
                     Some(RelativeEndBound::Finite(finite_second_layer_end)),
-                    Some(RelativeStartBound::Finite(finite_first_layer_start)),
+                    Some(finite_first_layer_start.to_start_bound()),
                 )
             }
         },
@@ -764,7 +764,7 @@ pub fn layered_rel_bounds_change_end_start(
                     Some(RelativeEndBound::Finite(end_of_first_layer)),
                     // We use `finite_second_layer_start` here because it overlaps with the first layer's end
                     // for a single instant
-                    Some(RelativeStartBound::Finite(finite_second_layer_start)),
+                    Some(finite_second_layer_start.to_start_bound()),
                 );
 
                 let mut start_of_second_layer = finite_second_layer_start; // Copy
@@ -778,7 +778,7 @@ pub fn layered_rel_bounds_change_end_start(
                     LayeredBoundsState::BothLayers,
                     *state_mut,
                     Some(RelativeEndBound::Finite(finite_second_layer_start)),
-                    Some(RelativeStartBound::Finite(start_of_second_layer)),
+                    Some(start_of_second_layer.to_start_bound()),
                 ));
 
                 change_to_return
@@ -791,7 +791,7 @@ pub fn layered_rel_bounds_change_end_start(
                     old_state,
                     *state_mut,
                     Some(RelativeEndBound::Finite(finite_first_layer_end)),
-                    Some(RelativeStartBound::Finite(finite_second_layer_start)),
+                    Some(finite_second_layer_start.to_start_bound()),
                 )
             }
         },

--- a/src/iter/intervals/layered_bounds/relative.rs
+++ b/src/iter/intervals/layered_bounds/relative.rs
@@ -6,7 +6,7 @@ use std::ops::{Add, Sub};
 
 use crate::intervals::meta::BoundInclusivity;
 use crate::intervals::ops::{BoundOrdering, BoundOverlapDisambiguationRuleSet, PartialBoundOrd};
-use crate::intervals::relative::{RelativeBound, RelativeEndBound};
+use crate::intervals::relative::RelativeBound;
 use crate::iter::intervals::layered_bounds::rel_state_change::LayeredBoundsStateChangeAtRelativeBound;
 use crate::iter::intervals::layered_bounds::state::LayeredBoundsState;
 
@@ -594,7 +594,8 @@ pub fn layered_rel_bounds_change_start_start(
 ///
 /// 1. The peeked value of a layer wasn't equal to the value returned by calling `next()` on that layer
 /// 2. The value returned by `next()` on the layer wasn't of the expected variant
-/// 3. The comparison between [`RelativeStartBound`] and [`RelativeEndBound`] returned [`None`]
+/// 3. The comparison between [`RelativeStartBound`](crate::intervals::relative::RelativeStartBound) and
+///    [`RelativeEndBound`](crate::intervals::relative::RelativeEndBound) returned [`None`]
 #[must_use]
 pub fn layered_rel_bounds_change_start_end(
     old_state: LayeredBoundsState,
@@ -647,7 +648,7 @@ pub fn layered_rel_bounds_change_start_end(
                 let change_to_return = Change::new(
                     old_state,
                     LayeredBoundsState::BothLayers,
-                    Some(RelativeEndBound::Finite(end_of_second_layer)),
+                    Some(end_of_second_layer.to_end_bound()),
                     // We use `finite_first_layer_start` here because it overlaps with the second layer's end
                     // for a single instant
                     Some(finite_first_layer_start.to_start_bound()),
@@ -663,7 +664,7 @@ pub fn layered_rel_bounds_change_start_end(
                 *queued_result_mut = Some(Change::new(
                     LayeredBoundsState::BothLayers,
                     *state_mut,
-                    Some(RelativeEndBound::Finite(finite_first_layer_start)),
+                    Some(finite_first_layer_start.to_end_bound()),
                     Some(start_of_first_layer.to_start_bound()),
                 ));
 
@@ -676,7 +677,7 @@ pub fn layered_rel_bounds_change_start_end(
                 Change::new(
                     old_state,
                     *state_mut,
-                    Some(RelativeEndBound::Finite(finite_second_layer_end)),
+                    Some(finite_second_layer_end.to_end_bound()),
                     Some(finite_first_layer_start.to_start_bound()),
                 )
             }
@@ -713,7 +714,8 @@ pub fn layered_rel_bounds_change_start_end(
 ///
 /// 1. The peeked value of a layer wasn't equal to the value returned by calling `next()` on that layer
 /// 2. The value returned by `next()` on the layer wasn't of the expected variant
-/// 3. The comparison between [`RelativeEndBound`] and [`RelativeStartBound`] returned [`None`]
+/// 3. The comparison between [`RelativeEndBound`](crate::intervals::relative::RelativeEndBound) and
+///    [`RelativeStartBound`](crate::intervals::relative::RelativeStartBound) returned [`None`]
 #[must_use]
 pub fn layered_rel_bounds_change_end_start(
     old_state: LayeredBoundsState,
@@ -761,7 +763,7 @@ pub fn layered_rel_bounds_change_end_start(
                 let change_to_return = Change::new(
                     old_state,
                     LayeredBoundsState::BothLayers,
-                    Some(RelativeEndBound::Finite(end_of_first_layer)),
+                    Some(end_of_first_layer.to_end_bound()),
                     // We use `finite_second_layer_start` here because it overlaps with the first layer's end
                     // for a single instant
                     Some(finite_second_layer_start.to_start_bound()),
@@ -777,7 +779,7 @@ pub fn layered_rel_bounds_change_end_start(
                 *queued_result_mut = Some(Change::new(
                     LayeredBoundsState::BothLayers,
                     *state_mut,
-                    Some(RelativeEndBound::Finite(finite_second_layer_start)),
+                    Some(finite_second_layer_start.to_end_bound()),
                     Some(start_of_second_layer.to_start_bound()),
                 ));
 
@@ -790,7 +792,7 @@ pub fn layered_rel_bounds_change_end_start(
                 Change::new(
                     old_state,
                     *state_mut,
-                    Some(RelativeEndBound::Finite(finite_first_layer_end)),
+                    Some(finite_first_layer_end.to_end_bound()),
                     Some(finite_second_layer_start.to_start_bound()),
                 )
             }

--- a/src/iter/intervals/layered_bounds/relative_tests.rs
+++ b/src/iter/intervals/layered_bounds/relative_tests.rs
@@ -18,9 +18,7 @@ fn create() {
     let first_layer_data = [
         RelativeBound::Start(RelativeStartBound::InfinitePast),
         RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_start_bound()),
-        RelativeBound::End(RelativeEndBound::Finite(RelativeFiniteBound::new(
-            SignedDuration::from_hours(102),
-        ))),
+        RelativeBound::End(RelativeFiniteBound::new(SignedDuration::from_hours(102)).to_end_bound()),
         RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(105)).to_start_bound()),
         RelativeBound::End(RelativeEndBound::InfiniteFuture),
     ];
@@ -28,9 +26,7 @@ fn create() {
     let second_layer_data = [
         RelativeBound::Start(RelativeStartBound::InfinitePast),
         RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_start_bound()),
-        RelativeBound::End(RelativeEndBound::Finite(RelativeFiniteBound::new(
-            SignedDuration::from_hours(102),
-        ))),
+        RelativeBound::End(RelativeFiniteBound::new(SignedDuration::from_hours(102)).to_end_bound()),
         RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(105)).to_start_bound()),
         RelativeBound::End(RelativeEndBound::InfiniteFuture),
     ];
@@ -47,42 +43,40 @@ fn run() {
         // 1
         RelativeBoundPair::new(
             RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_start_bound(),
-            RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(105))),
+            RelativeFiniteBound::new(SignedDuration::from_hours(105)).to_end_bound(),
         ),
         // 3
         RelativeBoundPair::new(
             RelativeFiniteBound::new(SignedDuration::from_hours(117)).to_start_bound(),
-            RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(120))),
+            RelativeFiniteBound::new(SignedDuration::from_hours(120)).to_end_bound(),
         ),
         // 6
         RelativeBoundPair::new(
             RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(205), BoundInclusivity::Exclusive)
                 .to_start_bound(),
-            RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(210))),
+            RelativeFiniteBound::new(SignedDuration::from_hours(210)).to_end_bound(),
         ),
         // 7
         RelativeBoundPair::new(
             RelativeFiniteBound::new(SignedDuration::from_hours(215)).to_start_bound(),
-            RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(225))),
+            RelativeFiniteBound::new(SignedDuration::from_hours(225)).to_end_bound(),
         ),
         // 9
         RelativeBoundPair::new(
             RelativeFiniteBound::new(SignedDuration::from_hours(226)).to_start_bound(),
-            RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                SignedDuration::from_hours(310),
-                BoundInclusivity::Exclusive,
-            )),
+            RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(310), BoundInclusivity::Exclusive)
+                .to_end_bound(),
         ),
         // 11
         RelativeBoundPair::new(
             RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(310), BoundInclusivity::Exclusive)
                 .to_start_bound(),
-            RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(315))),
+            RelativeFiniteBound::new(SignedDuration::from_hours(315)).to_end_bound(),
         ),
         // 13
         RelativeBoundPair::new(
             RelativeFiniteBound::new(SignedDuration::from_hours(320)).to_start_bound(),
-            RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(325))),
+            RelativeFiniteBound::new(SignedDuration::from_hours(325)).to_end_bound(),
         ),
     ];
 
@@ -90,37 +84,35 @@ fn run() {
         // 2
         RelativeBoundPair::new(
             RelativeFiniteBound::new(SignedDuration::from_hours(110)).to_start_bound(),
-            RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(115))),
+            RelativeFiniteBound::new(SignedDuration::from_hours(115)).to_end_bound(),
         ),
         // 4
         RelativeBoundPair::new(
             RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(120), BoundInclusivity::Exclusive)
                 .to_start_bound(),
-            RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(125))),
+            RelativeFiniteBound::new(SignedDuration::from_hours(125)).to_end_bound(),
         ),
         // 5
         RelativeBoundPair::new(
             RelativeFiniteBound::new(SignedDuration::from_hours(130)).to_start_bound(),
-            RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(205))),
+            RelativeFiniteBound::new(SignedDuration::from_hours(205)).to_end_bound(),
         ),
         // 8
         RelativeBoundPair::new(
             RelativeFiniteBound::new(SignedDuration::from_hours(220)).to_start_bound(),
-            RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(301))),
+            RelativeFiniteBound::new(SignedDuration::from_hours(301)).to_end_bound(),
         ),
         // 10
         RelativeBoundPair::new(
             RelativeFiniteBound::new(SignedDuration::from_hours(304)).to_start_bound(),
-            RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                SignedDuration::from_hours(310),
-                BoundInclusivity::Exclusive,
-            )),
+            RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(310), BoundInclusivity::Exclusive)
+                .to_end_bound(),
         ),
         // 12
         RelativeBoundPair::new(
             RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(310), BoundInclusivity::Exclusive)
                 .to_start_bound(),
-            RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(320))),
+            RelativeFiniteBound::new(SignedDuration::from_hours(320)).to_end_bound(),
         ),
     ];
 
@@ -141,19 +133,20 @@ fn run() {
             LayeredBoundsStateChangeAtRelativeBound::new(
                 LayeredBoundsState::NoLayers,
                 LayeredBoundsState::FirstLayer,
-                Some(RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                    SignedDuration::from_hours(101),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    RelativeFiniteBound::new_with_inclusivity(
+                        SignedDuration::from_hours(101),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_end_bound()
+                ),
                 Some(RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_start_bound()),
             ),
             // B
             LayeredBoundsStateChangeAtRelativeBound::new(
                 LayeredBoundsState::FirstLayer,
                 LayeredBoundsState::NoLayers,
-                Some(RelativeEndBound::Finite(RelativeFiniteBound::new(
-                    SignedDuration::from_hours(105)
-                ))),
+                Some(RelativeFiniteBound::new(SignedDuration::from_hours(105)).to_end_bound()),
                 Some(
                     RelativeFiniteBound::new_with_inclusivity(
                         SignedDuration::from_hours(105),
@@ -166,19 +159,20 @@ fn run() {
             LayeredBoundsStateChangeAtRelativeBound::new(
                 LayeredBoundsState::NoLayers,
                 LayeredBoundsState::SecondLayer,
-                Some(RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                    SignedDuration::from_hours(110),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    RelativeFiniteBound::new_with_inclusivity(
+                        SignedDuration::from_hours(110),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_end_bound()
+                ),
                 Some(RelativeFiniteBound::new(SignedDuration::from_hours(110)).to_start_bound()),
             ),
             // D
             LayeredBoundsStateChangeAtRelativeBound::new(
                 LayeredBoundsState::SecondLayer,
                 LayeredBoundsState::NoLayers,
-                Some(RelativeEndBound::Finite(RelativeFiniteBound::new(
-                    SignedDuration::from_hours(115)
-                ))),
+                Some(RelativeFiniteBound::new(SignedDuration::from_hours(115)).to_end_bound()),
                 Some(
                     RelativeFiniteBound::new_with_inclusivity(
                         SignedDuration::from_hours(115),
@@ -191,19 +185,20 @@ fn run() {
             LayeredBoundsStateChangeAtRelativeBound::new(
                 LayeredBoundsState::NoLayers,
                 LayeredBoundsState::FirstLayer,
-                Some(RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                    SignedDuration::from_hours(117),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    RelativeFiniteBound::new_with_inclusivity(
+                        SignedDuration::from_hours(117),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_end_bound()
+                ),
                 Some(RelativeFiniteBound::new(SignedDuration::from_hours(117)).to_start_bound()),
             ),
             // F
             LayeredBoundsStateChangeAtRelativeBound::new(
                 LayeredBoundsState::FirstLayer,
                 LayeredBoundsState::SecondLayer,
-                Some(RelativeEndBound::Finite(RelativeFiniteBound::new(
-                    SignedDuration::from_hours(120)
-                ))),
+                Some(RelativeFiniteBound::new(SignedDuration::from_hours(120)).to_end_bound()),
                 Some(
                     RelativeFiniteBound::new_with_inclusivity(
                         SignedDuration::from_hours(120),
@@ -216,9 +211,7 @@ fn run() {
             LayeredBoundsStateChangeAtRelativeBound::new(
                 LayeredBoundsState::SecondLayer,
                 LayeredBoundsState::NoLayers,
-                Some(RelativeEndBound::Finite(RelativeFiniteBound::new(
-                    SignedDuration::from_hours(125)
-                ))),
+                Some(RelativeFiniteBound::new(SignedDuration::from_hours(125)).to_end_bound()),
                 Some(
                     RelativeFiniteBound::new_with_inclusivity(
                         SignedDuration::from_hours(125),
@@ -231,19 +224,20 @@ fn run() {
             LayeredBoundsStateChangeAtRelativeBound::new(
                 LayeredBoundsState::NoLayers,
                 LayeredBoundsState::SecondLayer,
-                Some(RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                    SignedDuration::from_hours(130),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    RelativeFiniteBound::new_with_inclusivity(
+                        SignedDuration::from_hours(130),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_end_bound()
+                ),
                 Some(RelativeFiniteBound::new(SignedDuration::from_hours(130)).to_start_bound()),
             ),
             // I
             LayeredBoundsStateChangeAtRelativeBound::new(
                 LayeredBoundsState::SecondLayer,
                 LayeredBoundsState::FirstLayer,
-                Some(RelativeEndBound::Finite(RelativeFiniteBound::new(
-                    SignedDuration::from_hours(205)
-                ))),
+                Some(RelativeFiniteBound::new(SignedDuration::from_hours(205)).to_end_bound()),
                 Some(
                     RelativeFiniteBound::new_with_inclusivity(
                         SignedDuration::from_hours(205),
@@ -256,9 +250,7 @@ fn run() {
             LayeredBoundsStateChangeAtRelativeBound::new(
                 LayeredBoundsState::FirstLayer,
                 LayeredBoundsState::NoLayers,
-                Some(RelativeEndBound::Finite(RelativeFiniteBound::new(
-                    SignedDuration::from_hours(210)
-                ))),
+                Some(RelativeFiniteBound::new(SignedDuration::from_hours(210)).to_end_bound()),
                 Some(
                     RelativeFiniteBound::new_with_inclusivity(
                         SignedDuration::from_hours(210),
@@ -271,29 +263,33 @@ fn run() {
             LayeredBoundsStateChangeAtRelativeBound::new(
                 LayeredBoundsState::NoLayers,
                 LayeredBoundsState::FirstLayer,
-                Some(RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                    SignedDuration::from_hours(215),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    RelativeFiniteBound::new_with_inclusivity(
+                        SignedDuration::from_hours(215),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_end_bound()
+                ),
                 Some(RelativeFiniteBound::new(SignedDuration::from_hours(215)).to_start_bound()),
             ),
             // L
             LayeredBoundsStateChangeAtRelativeBound::new(
                 LayeredBoundsState::FirstLayer,
                 LayeredBoundsState::BothLayers,
-                Some(RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                    SignedDuration::from_hours(220),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    RelativeFiniteBound::new_with_inclusivity(
+                        SignedDuration::from_hours(220),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_end_bound()
+                ),
                 Some(RelativeFiniteBound::new(SignedDuration::from_hours(220)).to_start_bound()),
             ),
             // M
             LayeredBoundsStateChangeAtRelativeBound::new(
                 LayeredBoundsState::BothLayers,
                 LayeredBoundsState::SecondLayer,
-                Some(RelativeEndBound::Finite(RelativeFiniteBound::new(
-                    SignedDuration::from_hours(225)
-                ))),
+                Some(RelativeFiniteBound::new(SignedDuration::from_hours(225)).to_end_bound()),
                 Some(
                     RelativeFiniteBound::new_with_inclusivity(
                         SignedDuration::from_hours(225),
@@ -306,19 +302,20 @@ fn run() {
             LayeredBoundsStateChangeAtRelativeBound::new(
                 LayeredBoundsState::SecondLayer,
                 LayeredBoundsState::BothLayers,
-                Some(RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                    SignedDuration::from_hours(226),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    RelativeFiniteBound::new_with_inclusivity(
+                        SignedDuration::from_hours(226),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_end_bound()
+                ),
                 Some(RelativeFiniteBound::new(SignedDuration::from_hours(226)).to_start_bound()),
             ),
             // O
             LayeredBoundsStateChangeAtRelativeBound::new(
                 LayeredBoundsState::BothLayers,
                 LayeredBoundsState::FirstLayer,
-                Some(RelativeEndBound::Finite(RelativeFiniteBound::new(
-                    SignedDuration::from_hours(301)
-                ))),
+                Some(RelativeFiniteBound::new(SignedDuration::from_hours(301)).to_end_bound()),
                 Some(
                     RelativeFiniteBound::new_with_inclusivity(
                         SignedDuration::from_hours(301),
@@ -331,29 +328,33 @@ fn run() {
             LayeredBoundsStateChangeAtRelativeBound::new(
                 LayeredBoundsState::FirstLayer,
                 LayeredBoundsState::BothLayers,
-                Some(RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                    SignedDuration::from_hours(304),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    RelativeFiniteBound::new_with_inclusivity(
+                        SignedDuration::from_hours(304),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_end_bound()
+                ),
                 Some(RelativeFiniteBound::new(SignedDuration::from_hours(304)).to_start_bound()),
             ),
             // Q
             LayeredBoundsStateChangeAtRelativeBound::new(
                 LayeredBoundsState::BothLayers,
                 LayeredBoundsState::NoLayers,
-                Some(RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                    SignedDuration::from_hours(310),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    RelativeFiniteBound::new_with_inclusivity(
+                        SignedDuration::from_hours(310),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_end_bound()
+                ),
                 Some(RelativeFiniteBound::new(SignedDuration::from_hours(310)).to_start_bound()),
             ),
             // R
             LayeredBoundsStateChangeAtRelativeBound::new(
                 LayeredBoundsState::NoLayers,
                 LayeredBoundsState::BothLayers,
-                Some(RelativeEndBound::Finite(RelativeFiniteBound::new(
-                    SignedDuration::from_hours(310)
-                ))),
+                Some(RelativeFiniteBound::new(SignedDuration::from_hours(310)).to_end_bound()),
                 Some(
                     RelativeFiniteBound::new_with_inclusivity(
                         SignedDuration::from_hours(310),
@@ -366,9 +367,7 @@ fn run() {
             LayeredBoundsStateChangeAtRelativeBound::new(
                 LayeredBoundsState::BothLayers,
                 LayeredBoundsState::SecondLayer,
-                Some(RelativeEndBound::Finite(RelativeFiniteBound::new(
-                    SignedDuration::from_hours(315)
-                ))),
+                Some(RelativeFiniteBound::new(SignedDuration::from_hours(315)).to_end_bound()),
                 Some(
                     RelativeFiniteBound::new_with_inclusivity(
                         SignedDuration::from_hours(315),
@@ -381,19 +380,20 @@ fn run() {
             LayeredBoundsStateChangeAtRelativeBound::new(
                 LayeredBoundsState::SecondLayer,
                 LayeredBoundsState::BothLayers,
-                Some(RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                    SignedDuration::from_hours(320),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    RelativeFiniteBound::new_with_inclusivity(
+                        SignedDuration::from_hours(320),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_end_bound()
+                ),
                 Some(RelativeFiniteBound::new(SignedDuration::from_hours(320)).to_start_bound()),
             ),
             // T2
             LayeredBoundsStateChangeAtRelativeBound::new(
                 LayeredBoundsState::BothLayers,
                 LayeredBoundsState::FirstLayer,
-                Some(RelativeEndBound::Finite(RelativeFiniteBound::new(
-                    SignedDuration::from_hours(320)
-                ))),
+                Some(RelativeFiniteBound::new(SignedDuration::from_hours(320)).to_end_bound()),
                 Some(
                     RelativeFiniteBound::new_with_inclusivity(
                         SignedDuration::from_hours(320),
@@ -406,9 +406,7 @@ fn run() {
             LayeredBoundsStateChangeAtRelativeBound::new(
                 LayeredBoundsState::FirstLayer,
                 LayeredBoundsState::NoLayers,
-                Some(RelativeEndBound::Finite(RelativeFiniteBound::new(
-                    SignedDuration::from_hours(325)
-                ))),
+                Some(RelativeFiniteBound::new(SignedDuration::from_hours(325)).to_end_bound()),
                 Some(
                     RelativeFiniteBound::new_with_inclusivity(
                         SignedDuration::from_hours(325),

--- a/src/iter/intervals/layered_bounds/relative_tests.rs
+++ b/src/iter/intervals/layered_bounds/relative_tests.rs
@@ -17,29 +17,21 @@ use crate::iter::intervals::layered_bounds::state::LayeredBoundsState;
 fn create() {
     let first_layer_data = [
         RelativeBound::Start(RelativeStartBound::InfinitePast),
-        RelativeBound::Start(RelativeStartBound::Finite(RelativeFiniteBound::new(
-            SignedDuration::from_hours(101),
-        ))),
+        RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_start_bound()),
         RelativeBound::End(RelativeEndBound::Finite(RelativeFiniteBound::new(
             SignedDuration::from_hours(102),
         ))),
-        RelativeBound::Start(RelativeStartBound::Finite(RelativeFiniteBound::new(
-            SignedDuration::from_hours(105),
-        ))),
+        RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(105)).to_start_bound()),
         RelativeBound::End(RelativeEndBound::InfiniteFuture),
     ];
 
     let second_layer_data = [
         RelativeBound::Start(RelativeStartBound::InfinitePast),
-        RelativeBound::Start(RelativeStartBound::Finite(RelativeFiniteBound::new(
-            SignedDuration::from_hours(101),
-        ))),
+        RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_start_bound()),
         RelativeBound::End(RelativeEndBound::Finite(RelativeFiniteBound::new(
             SignedDuration::from_hours(102),
         ))),
-        RelativeBound::Start(RelativeStartBound::Finite(RelativeFiniteBound::new(
-            SignedDuration::from_hours(105),
-        ))),
+        RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(105)).to_start_bound()),
         RelativeBound::End(RelativeEndBound::InfiniteFuture),
     ];
 
@@ -54,30 +46,28 @@ fn run() {
     let first_layer_data = [
         // 1
         RelativeBoundPair::new(
-            RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(101))),
+            RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_start_bound(),
             RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(105))),
         ),
         // 3
         RelativeBoundPair::new(
-            RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(117))),
+            RelativeFiniteBound::new(SignedDuration::from_hours(117)).to_start_bound(),
             RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(120))),
         ),
         // 6
         RelativeBoundPair::new(
-            RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                SignedDuration::from_hours(205),
-                BoundInclusivity::Exclusive,
-            )),
+            RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(205), BoundInclusivity::Exclusive)
+                .to_start_bound(),
             RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(210))),
         ),
         // 7
         RelativeBoundPair::new(
-            RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(215))),
+            RelativeFiniteBound::new(SignedDuration::from_hours(215)).to_start_bound(),
             RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(225))),
         ),
         // 9
         RelativeBoundPair::new(
-            RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(226))),
+            RelativeFiniteBound::new(SignedDuration::from_hours(226)).to_start_bound(),
             RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
                 SignedDuration::from_hours(310),
                 BoundInclusivity::Exclusive,
@@ -85,15 +75,13 @@ fn run() {
         ),
         // 11
         RelativeBoundPair::new(
-            RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                SignedDuration::from_hours(310),
-                BoundInclusivity::Exclusive,
-            )),
+            RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(310), BoundInclusivity::Exclusive)
+                .to_start_bound(),
             RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(315))),
         ),
         // 13
         RelativeBoundPair::new(
-            RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(320))),
+            RelativeFiniteBound::new(SignedDuration::from_hours(320)).to_start_bound(),
             RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(325))),
         ),
     ];
@@ -101,30 +89,28 @@ fn run() {
     let second_layer_data = [
         // 2
         RelativeBoundPair::new(
-            RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(110))),
+            RelativeFiniteBound::new(SignedDuration::from_hours(110)).to_start_bound(),
             RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(115))),
         ),
         // 4
         RelativeBoundPair::new(
-            RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                SignedDuration::from_hours(120),
-                BoundInclusivity::Exclusive,
-            )),
+            RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(120), BoundInclusivity::Exclusive)
+                .to_start_bound(),
             RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(125))),
         ),
         // 5
         RelativeBoundPair::new(
-            RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(130))),
+            RelativeFiniteBound::new(SignedDuration::from_hours(130)).to_start_bound(),
             RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(205))),
         ),
         // 8
         RelativeBoundPair::new(
-            RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(220))),
+            RelativeFiniteBound::new(SignedDuration::from_hours(220)).to_start_bound(),
             RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(301))),
         ),
         // 10
         RelativeBoundPair::new(
-            RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(304))),
+            RelativeFiniteBound::new(SignedDuration::from_hours(304)).to_start_bound(),
             RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
                 SignedDuration::from_hours(310),
                 BoundInclusivity::Exclusive,
@@ -132,10 +118,8 @@ fn run() {
         ),
         // 12
         RelativeBoundPair::new(
-            RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                SignedDuration::from_hours(310),
-                BoundInclusivity::Exclusive,
-            )),
+            RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(310), BoundInclusivity::Exclusive)
+                .to_start_bound(),
             RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(320))),
         ),
     ];
@@ -161,9 +145,7 @@ fn run() {
                     SignedDuration::from_hours(101),
                     BoundInclusivity::Exclusive,
                 ))),
-                Some(RelativeStartBound::Finite(RelativeFiniteBound::new(
-                    SignedDuration::from_hours(101)
-                ))),
+                Some(RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_start_bound()),
             ),
             // B
             LayeredBoundsStateChangeAtRelativeBound::new(
@@ -172,10 +154,13 @@ fn run() {
                 Some(RelativeEndBound::Finite(RelativeFiniteBound::new(
                     SignedDuration::from_hours(105)
                 ))),
-                Some(RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                    SignedDuration::from_hours(105),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    RelativeFiniteBound::new_with_inclusivity(
+                        SignedDuration::from_hours(105),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_start_bound()
+                ),
             ),
             // C
             LayeredBoundsStateChangeAtRelativeBound::new(
@@ -185,9 +170,7 @@ fn run() {
                     SignedDuration::from_hours(110),
                     BoundInclusivity::Exclusive,
                 ))),
-                Some(RelativeStartBound::Finite(RelativeFiniteBound::new(
-                    SignedDuration::from_hours(110)
-                ))),
+                Some(RelativeFiniteBound::new(SignedDuration::from_hours(110)).to_start_bound()),
             ),
             // D
             LayeredBoundsStateChangeAtRelativeBound::new(
@@ -196,10 +179,13 @@ fn run() {
                 Some(RelativeEndBound::Finite(RelativeFiniteBound::new(
                     SignedDuration::from_hours(115)
                 ))),
-                Some(RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                    SignedDuration::from_hours(115),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    RelativeFiniteBound::new_with_inclusivity(
+                        SignedDuration::from_hours(115),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_start_bound()
+                ),
             ),
             // E
             LayeredBoundsStateChangeAtRelativeBound::new(
@@ -209,9 +195,7 @@ fn run() {
                     SignedDuration::from_hours(117),
                     BoundInclusivity::Exclusive,
                 ))),
-                Some(RelativeStartBound::Finite(RelativeFiniteBound::new(
-                    SignedDuration::from_hours(117)
-                ))),
+                Some(RelativeFiniteBound::new(SignedDuration::from_hours(117)).to_start_bound()),
             ),
             // F
             LayeredBoundsStateChangeAtRelativeBound::new(
@@ -220,10 +204,13 @@ fn run() {
                 Some(RelativeEndBound::Finite(RelativeFiniteBound::new(
                     SignedDuration::from_hours(120)
                 ))),
-                Some(RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                    SignedDuration::from_hours(120),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    RelativeFiniteBound::new_with_inclusivity(
+                        SignedDuration::from_hours(120),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_start_bound()
+                ),
             ),
             // G
             LayeredBoundsStateChangeAtRelativeBound::new(
@@ -232,10 +219,13 @@ fn run() {
                 Some(RelativeEndBound::Finite(RelativeFiniteBound::new(
                     SignedDuration::from_hours(125)
                 ))),
-                Some(RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                    SignedDuration::from_hours(125),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    RelativeFiniteBound::new_with_inclusivity(
+                        SignedDuration::from_hours(125),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_start_bound()
+                ),
             ),
             // H
             LayeredBoundsStateChangeAtRelativeBound::new(
@@ -245,9 +235,7 @@ fn run() {
                     SignedDuration::from_hours(130),
                     BoundInclusivity::Exclusive,
                 ))),
-                Some(RelativeStartBound::Finite(RelativeFiniteBound::new(
-                    SignedDuration::from_hours(130)
-                ))),
+                Some(RelativeFiniteBound::new(SignedDuration::from_hours(130)).to_start_bound()),
             ),
             // I
             LayeredBoundsStateChangeAtRelativeBound::new(
@@ -256,10 +244,13 @@ fn run() {
                 Some(RelativeEndBound::Finite(RelativeFiniteBound::new(
                     SignedDuration::from_hours(205)
                 ))),
-                Some(RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                    SignedDuration::from_hours(205),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    RelativeFiniteBound::new_with_inclusivity(
+                        SignedDuration::from_hours(205),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_start_bound()
+                ),
             ),
             // J
             LayeredBoundsStateChangeAtRelativeBound::new(
@@ -268,10 +259,13 @@ fn run() {
                 Some(RelativeEndBound::Finite(RelativeFiniteBound::new(
                     SignedDuration::from_hours(210)
                 ))),
-                Some(RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                    SignedDuration::from_hours(210),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    RelativeFiniteBound::new_with_inclusivity(
+                        SignedDuration::from_hours(210),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_start_bound()
+                ),
             ),
             // K
             LayeredBoundsStateChangeAtRelativeBound::new(
@@ -281,9 +275,7 @@ fn run() {
                     SignedDuration::from_hours(215),
                     BoundInclusivity::Exclusive,
                 ))),
-                Some(RelativeStartBound::Finite(RelativeFiniteBound::new(
-                    SignedDuration::from_hours(215)
-                ))),
+                Some(RelativeFiniteBound::new(SignedDuration::from_hours(215)).to_start_bound()),
             ),
             // L
             LayeredBoundsStateChangeAtRelativeBound::new(
@@ -293,9 +285,7 @@ fn run() {
                     SignedDuration::from_hours(220),
                     BoundInclusivity::Exclusive,
                 ))),
-                Some(RelativeStartBound::Finite(RelativeFiniteBound::new(
-                    SignedDuration::from_hours(220)
-                ))),
+                Some(RelativeFiniteBound::new(SignedDuration::from_hours(220)).to_start_bound()),
             ),
             // M
             LayeredBoundsStateChangeAtRelativeBound::new(
@@ -304,10 +294,13 @@ fn run() {
                 Some(RelativeEndBound::Finite(RelativeFiniteBound::new(
                     SignedDuration::from_hours(225)
                 ))),
-                Some(RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                    SignedDuration::from_hours(225),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    RelativeFiniteBound::new_with_inclusivity(
+                        SignedDuration::from_hours(225),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_start_bound()
+                ),
             ),
             // N
             LayeredBoundsStateChangeAtRelativeBound::new(
@@ -317,9 +310,7 @@ fn run() {
                     SignedDuration::from_hours(226),
                     BoundInclusivity::Exclusive,
                 ))),
-                Some(RelativeStartBound::Finite(RelativeFiniteBound::new(
-                    SignedDuration::from_hours(226)
-                ))),
+                Some(RelativeFiniteBound::new(SignedDuration::from_hours(226)).to_start_bound()),
             ),
             // O
             LayeredBoundsStateChangeAtRelativeBound::new(
@@ -328,10 +319,13 @@ fn run() {
                 Some(RelativeEndBound::Finite(RelativeFiniteBound::new(
                     SignedDuration::from_hours(301)
                 ))),
-                Some(RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                    SignedDuration::from_hours(301),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    RelativeFiniteBound::new_with_inclusivity(
+                        SignedDuration::from_hours(301),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_start_bound()
+                ),
             ),
             // P
             LayeredBoundsStateChangeAtRelativeBound::new(
@@ -341,9 +335,7 @@ fn run() {
                     SignedDuration::from_hours(304),
                     BoundInclusivity::Exclusive,
                 ))),
-                Some(RelativeStartBound::Finite(RelativeFiniteBound::new(
-                    SignedDuration::from_hours(304)
-                ))),
+                Some(RelativeFiniteBound::new(SignedDuration::from_hours(304)).to_start_bound()),
             ),
             // Q
             LayeredBoundsStateChangeAtRelativeBound::new(
@@ -353,9 +345,7 @@ fn run() {
                     SignedDuration::from_hours(310),
                     BoundInclusivity::Exclusive,
                 ))),
-                Some(RelativeStartBound::Finite(RelativeFiniteBound::new(
-                    SignedDuration::from_hours(310)
-                ))),
+                Some(RelativeFiniteBound::new(SignedDuration::from_hours(310)).to_start_bound()),
             ),
             // R
             LayeredBoundsStateChangeAtRelativeBound::new(
@@ -364,10 +354,13 @@ fn run() {
                 Some(RelativeEndBound::Finite(RelativeFiniteBound::new(
                     SignedDuration::from_hours(310)
                 ))),
-                Some(RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                    SignedDuration::from_hours(310),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    RelativeFiniteBound::new_with_inclusivity(
+                        SignedDuration::from_hours(310),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_start_bound()
+                ),
             ),
             // S
             LayeredBoundsStateChangeAtRelativeBound::new(
@@ -376,10 +369,13 @@ fn run() {
                 Some(RelativeEndBound::Finite(RelativeFiniteBound::new(
                     SignedDuration::from_hours(315)
                 ))),
-                Some(RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                    SignedDuration::from_hours(315),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    RelativeFiniteBound::new_with_inclusivity(
+                        SignedDuration::from_hours(315),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_start_bound()
+                ),
             ),
             // T1
             LayeredBoundsStateChangeAtRelativeBound::new(
@@ -389,9 +385,7 @@ fn run() {
                     SignedDuration::from_hours(320),
                     BoundInclusivity::Exclusive,
                 ))),
-                Some(RelativeStartBound::Finite(RelativeFiniteBound::new(
-                    SignedDuration::from_hours(320)
-                ))),
+                Some(RelativeFiniteBound::new(SignedDuration::from_hours(320)).to_start_bound()),
             ),
             // T2
             LayeredBoundsStateChangeAtRelativeBound::new(
@@ -400,10 +394,13 @@ fn run() {
                 Some(RelativeEndBound::Finite(RelativeFiniteBound::new(
                     SignedDuration::from_hours(320)
                 ))),
-                Some(RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                    SignedDuration::from_hours(320),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    RelativeFiniteBound::new_with_inclusivity(
+                        SignedDuration::from_hours(320),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_start_bound()
+                ),
             ),
             // U
             LayeredBoundsStateChangeAtRelativeBound::new(
@@ -412,10 +409,13 @@ fn run() {
                 Some(RelativeEndBound::Finite(RelativeFiniteBound::new(
                     SignedDuration::from_hours(325)
                 ))),
-                Some(RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                    SignedDuration::from_hours(325),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    RelativeFiniteBound::new_with_inclusivity(
+                        SignedDuration::from_hours(325),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_start_bound()
+                ),
             ),
         ],
     );

--- a/src/iter/intervals/layered_bounds/relative_tests.rs
+++ b/src/iter/intervals/layered_bounds/relative_tests.rs
@@ -2,13 +2,7 @@ use jiff::SignedDuration;
 
 use super::relative::*;
 use crate::intervals::meta::BoundInclusivity;
-use crate::intervals::relative::{
-    RelativeBound,
-    RelativeBoundPair,
-    RelativeEndBound,
-    RelativeFiniteBound,
-    RelativeStartBound,
-};
+use crate::intervals::relative::{RelativeBoundPair, RelativeEndBound, RelativeFiniteBound, RelativeStartBound};
 use crate::iter::intervals::bounds::RelativeBoundsIteratorDispatcher;
 use crate::iter::intervals::layered_bounds::rel_state_change::LayeredBoundsStateChangeAtRelativeBound;
 use crate::iter::intervals::layered_bounds::state::LayeredBoundsState;
@@ -16,19 +10,31 @@ use crate::iter::intervals::layered_bounds::state::LayeredBoundsState;
 #[test]
 fn create() {
     let first_layer_data = [
-        RelativeBound::Start(RelativeStartBound::InfinitePast),
-        RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_start_bound()),
-        RelativeBound::End(RelativeFiniteBound::new(SignedDuration::from_hours(102)).to_end_bound()),
-        RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(105)).to_start_bound()),
-        RelativeBound::End(RelativeEndBound::InfiniteFuture),
+        RelativeStartBound::InfinitePast.to_bound(),
+        RelativeFiniteBound::new(SignedDuration::from_hours(101))
+            .to_start_bound()
+            .to_bound(),
+        RelativeFiniteBound::new(SignedDuration::from_hours(102))
+            .to_end_bound()
+            .to_bound(),
+        RelativeFiniteBound::new(SignedDuration::from_hours(105))
+            .to_start_bound()
+            .to_bound(),
+        RelativeEndBound::InfiniteFuture.to_bound(),
     ];
 
     let second_layer_data = [
-        RelativeBound::Start(RelativeStartBound::InfinitePast),
-        RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_start_bound()),
-        RelativeBound::End(RelativeFiniteBound::new(SignedDuration::from_hours(102)).to_end_bound()),
-        RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(105)).to_start_bound()),
-        RelativeBound::End(RelativeEndBound::InfiniteFuture),
+        RelativeStartBound::InfinitePast.to_bound(),
+        RelativeFiniteBound::new(SignedDuration::from_hours(101))
+            .to_start_bound()
+            .to_bound(),
+        RelativeFiniteBound::new(SignedDuration::from_hours(102))
+            .to_end_bound()
+            .to_bound(),
+        RelativeFiniteBound::new(SignedDuration::from_hours(105))
+            .to_start_bound()
+            .to_bound(),
+        RelativeEndBound::InfiniteFuture.to_bound(),
     ];
 
     let _ = LayeredRelativeBounds::new(first_layer_data.into_iter(), second_layer_data.into_iter());

--- a/src/iter/intervals/layered_bounds_set_ops/diff_tests.rs
+++ b/src/iter/intervals/layered_bounds_set_ops/diff_tests.rs
@@ -31,10 +31,13 @@ mod abs {
                 Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 ))),
-                Some(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-                    "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new_with_inclusivity(
+                        "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_start_bound(),
+                ),
             ),
             LayeredBoundsStateChangeAtAbsoluteBound::new(
                 LayeredBoundsState::SecondLayer,
@@ -43,9 +46,10 @@ mod abs {
                     "2025-05-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
                 ))),
-                Some(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-05-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new("2025-05-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
+                ),
             ),
         ];
 
@@ -62,27 +66,24 @@ mod abs {
         let first_layer_data = [
             // 2
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 )),
             ),
             // 6
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-02-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 )),
             ),
             // 8
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-02-17 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-02-17 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-02-23 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 )),
@@ -92,19 +93,19 @@ mod abs {
         let second_layer_data = [
             // 1
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-07 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 )),
             ),
             // 3
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
@@ -112,9 +113,8 @@ mod abs {
             ),
             // 4
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
@@ -122,18 +122,16 @@ mod abs {
             ),
             // 5
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 )),
             ),
             // 7
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-02-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-02-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-02-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 )),
@@ -149,36 +147,36 @@ mod abs {
                 .collect::<Vec<_>>(),
             vec![
                 AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-07 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                         "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                     )),
                 ),
                 AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
                     )),
                 ),
                 AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                         "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                     )),
                 ),
                 AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-02-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,

--- a/src/iter/intervals/layered_bounds_set_ops/diff_tests.rs
+++ b/src/iter/intervals/layered_bounds_set_ops/diff_tests.rs
@@ -207,10 +207,13 @@ mod rel {
                 Some(RelativeEndBound::Finite(RelativeFiniteBound::new(
                     SignedDuration::from_hours(101),
                 ))),
-                Some(RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                    SignedDuration::from_hours(101),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    RelativeFiniteBound::new_with_inclusivity(
+                        SignedDuration::from_hours(101),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_start_bound(),
+                ),
             ),
             LayeredBoundsStateChangeAtRelativeBound::new(
                 LayeredBoundsState::SecondLayer,
@@ -219,9 +222,7 @@ mod rel {
                     SignedDuration::from_hours(501),
                     BoundInclusivity::Exclusive,
                 ))),
-                Some(RelativeStartBound::Finite(RelativeFiniteBound::new(
-                    SignedDuration::from_hours(501),
-                ))),
+                Some(RelativeFiniteBound::new(SignedDuration::from_hours(501)).to_start_bound()),
             ),
         ];
 
@@ -235,17 +236,17 @@ mod rel {
         let first_layer_data = [
             // 2
             RelativeBoundPair::new(
-                RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(105))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(105)).to_start_bound(),
                 RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(125))),
             ),
             // 6
             RelativeBoundPair::new(
-                RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(205))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(205)).to_start_bound(),
                 RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(215))),
             ),
             // 8
             RelativeBoundPair::new(
-                RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(217))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(217)).to_start_bound(),
                 RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(223))),
             ),
         ];
@@ -253,15 +254,13 @@ mod rel {
         let second_layer_data = [
             // 1
             RelativeBoundPair::new(
-                RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(101))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_start_bound(),
                 RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(107))),
             ),
             // 3
             RelativeBoundPair::new(
-                RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                    SignedDuration::from_hours(110),
-                    BoundInclusivity::Exclusive,
-                )),
+                RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(110), BoundInclusivity::Exclusive)
+                    .to_start_bound(),
                 RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
                     SignedDuration::from_hours(115),
                     BoundInclusivity::Exclusive,
@@ -269,7 +268,7 @@ mod rel {
             ),
             // 4
             RelativeBoundPair::new(
-                RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(120))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(120)).to_start_bound(),
                 RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
                     SignedDuration::from_hours(125),
                     BoundInclusivity::Exclusive,
@@ -277,12 +276,12 @@ mod rel {
             ),
             // 5
             RelativeBoundPair::new(
-                RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(201))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(201)).to_start_bound(),
                 RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(205))),
             ),
             // 7
             RelativeBoundPair::new(
-                RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(215))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(215)).to_start_bound(),
                 RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(225))),
             ),
         ];
@@ -296,28 +295,30 @@ mod rel {
                 .collect::<Vec<_>>(),
             vec![
                 RelativeBoundPair::new(
-                    RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
+                    RelativeFiniteBound::new_with_inclusivity(
                         SignedDuration::from_hours(107),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_start_bound(),
                     RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(110))),
                 ),
                 RelativeBoundPair::new(
-                    RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(115))),
+                    RelativeFiniteBound::new(SignedDuration::from_hours(115)).to_start_bound(),
                     RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
                         SignedDuration::from_hours(120),
                         BoundInclusivity::Exclusive,
                     )),
                 ),
                 RelativeBoundPair::new(
-                    RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(125))),
+                    RelativeFiniteBound::new(SignedDuration::from_hours(125)).to_start_bound(),
                     RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(125))),
                 ),
                 RelativeBoundPair::new(
-                    RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
+                    RelativeFiniteBound::new_with_inclusivity(
                         SignedDuration::from_hours(205),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_start_bound(),
                     RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
                         SignedDuration::from_hours(215),
                         BoundInclusivity::Exclusive,

--- a/src/iter/intervals/layered_bounds_set_ops/diff_tests.rs
+++ b/src/iter/intervals/layered_bounds_set_ops/diff_tests.rs
@@ -5,7 +5,7 @@ use jiff::{SignedDuration, Zoned};
 use super::diff::*;
 use crate::intervals::absolute::{AbsoluteBoundPair, AbsoluteFiniteBound, AbsoluteStartBound};
 use crate::intervals::meta::BoundInclusivity;
-use crate::intervals::relative::{RelativeBoundPair, RelativeEndBound, RelativeFiniteBound, RelativeStartBound};
+use crate::intervals::relative::{RelativeBoundPair, RelativeFiniteBound, RelativeStartBound};
 use crate::iter::intervals::bounds::{AbsoluteBoundsIteratorDispatcher, RelativeBoundsIteratorDispatcher};
 use crate::iter::intervals::layered_bounds::{
     LayeredBoundsState,
@@ -204,9 +204,7 @@ mod rel {
             LayeredBoundsStateChangeAtRelativeBound::new(
                 LayeredBoundsState::FirstLayer,
                 LayeredBoundsState::SecondLayer,
-                Some(RelativeEndBound::Finite(RelativeFiniteBound::new(
-                    SignedDuration::from_hours(101),
-                ))),
+                Some(RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_end_bound()),
                 Some(
                     RelativeFiniteBound::new_with_inclusivity(
                         SignedDuration::from_hours(101),
@@ -218,10 +216,13 @@ mod rel {
             LayeredBoundsStateChangeAtRelativeBound::new(
                 LayeredBoundsState::SecondLayer,
                 LayeredBoundsState::NoLayers,
-                Some(RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                    SignedDuration::from_hours(501),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    RelativeFiniteBound::new_with_inclusivity(
+                        SignedDuration::from_hours(501),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_end_bound(),
+                ),
                 Some(RelativeFiniteBound::new(SignedDuration::from_hours(501)).to_start_bound()),
             ),
         ];
@@ -237,17 +238,17 @@ mod rel {
             // 2
             RelativeBoundPair::new(
                 RelativeFiniteBound::new(SignedDuration::from_hours(105)).to_start_bound(),
-                RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(125))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(125)).to_end_bound(),
             ),
             // 6
             RelativeBoundPair::new(
                 RelativeFiniteBound::new(SignedDuration::from_hours(205)).to_start_bound(),
-                RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(215))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(215)).to_end_bound(),
             ),
             // 8
             RelativeBoundPair::new(
                 RelativeFiniteBound::new(SignedDuration::from_hours(217)).to_start_bound(),
-                RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(223))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(223)).to_end_bound(),
             ),
         ];
 
@@ -255,34 +256,30 @@ mod rel {
             // 1
             RelativeBoundPair::new(
                 RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_start_bound(),
-                RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(107))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(107)).to_end_bound(),
             ),
             // 3
             RelativeBoundPair::new(
                 RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(110), BoundInclusivity::Exclusive)
                     .to_start_bound(),
-                RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                    SignedDuration::from_hours(115),
-                    BoundInclusivity::Exclusive,
-                )),
+                RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(115), BoundInclusivity::Exclusive)
+                    .to_end_bound(),
             ),
             // 4
             RelativeBoundPair::new(
                 RelativeFiniteBound::new(SignedDuration::from_hours(120)).to_start_bound(),
-                RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                    SignedDuration::from_hours(125),
-                    BoundInclusivity::Exclusive,
-                )),
+                RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(125), BoundInclusivity::Exclusive)
+                    .to_end_bound(),
             ),
             // 5
             RelativeBoundPair::new(
                 RelativeFiniteBound::new(SignedDuration::from_hours(201)).to_start_bound(),
-                RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(205))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(205)).to_end_bound(),
             ),
             // 7
             RelativeBoundPair::new(
                 RelativeFiniteBound::new(SignedDuration::from_hours(215)).to_start_bound(),
-                RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(225))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(225)).to_end_bound(),
             ),
         ];
 
@@ -300,18 +297,19 @@ mod rel {
                         BoundInclusivity::Exclusive,
                     )
                     .to_start_bound(),
-                    RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(110))),
+                    RelativeFiniteBound::new(SignedDuration::from_hours(110)).to_end_bound(),
                 ),
                 RelativeBoundPair::new(
                     RelativeFiniteBound::new(SignedDuration::from_hours(115)).to_start_bound(),
-                    RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
+                    RelativeFiniteBound::new_with_inclusivity(
                         SignedDuration::from_hours(120),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_end_bound(),
                 ),
                 RelativeBoundPair::new(
                     RelativeFiniteBound::new(SignedDuration::from_hours(125)).to_start_bound(),
-                    RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(125))),
+                    RelativeFiniteBound::new(SignedDuration::from_hours(125)).to_end_bound(),
                 ),
                 RelativeBoundPair::new(
                     RelativeFiniteBound::new_with_inclusivity(
@@ -319,10 +317,11 @@ mod rel {
                         BoundInclusivity::Exclusive,
                     )
                     .to_start_bound(),
-                    RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
+                    RelativeFiniteBound::new_with_inclusivity(
                         SignedDuration::from_hours(215),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_end_bound(),
                 ),
             ],
         );

--- a/src/iter/intervals/layered_bounds_set_ops/diff_tests.rs
+++ b/src/iter/intervals/layered_bounds_set_ops/diff_tests.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 use jiff::{SignedDuration, Zoned};
 
 use super::diff::*;
-use crate::intervals::absolute::{AbsoluteBoundPair, AbsoluteEndBound, AbsoluteFiniteBound, AbsoluteStartBound};
+use crate::intervals::absolute::{AbsoluteBoundPair, AbsoluteFiniteBound, AbsoluteStartBound};
 use crate::intervals::meta::BoundInclusivity;
 use crate::intervals::relative::{RelativeBoundPair, RelativeEndBound, RelativeFiniteBound, RelativeStartBound};
 use crate::iter::intervals::bounds::{AbsoluteBoundsIteratorDispatcher, RelativeBoundsIteratorDispatcher};
@@ -28,9 +28,10 @@ mod abs {
             LayeredBoundsStateChangeAtAbsoluteBound::new(
                 LayeredBoundsState::FirstLayer,
                 LayeredBoundsState::SecondLayer,
-                Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound(),
+                ),
                 Some(
                     AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
@@ -42,10 +43,13 @@ mod abs {
             LayeredBoundsStateChangeAtAbsoluteBound::new(
                 LayeredBoundsState::SecondLayer,
                 LayeredBoundsState::NoLayers,
-                Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-                    "2025-05-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new_with_inclusivity(
+                        "2025-05-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_end_bound(),
+                ),
                 Some(
                     AbsoluteFiniteBound::new("2025-05-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
@@ -68,25 +72,22 @@ mod abs {
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
             // 6
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-02-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-02-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
             // 8
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-02-17 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-02-23 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-02-23 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
         ];
 
@@ -95,9 +96,8 @@ mod abs {
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-07 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-07 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
             // 3
             AbsoluteBoundPair::new(
@@ -106,35 +106,35 @@ mod abs {
                     BoundInclusivity::Exclusive,
                 )
                 .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_end_bound(),
             ),
             // 4
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_end_bound(),
             ),
             // 5
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
             // 7
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-02-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-02-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-02-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
         ];
 
@@ -152,24 +152,23 @@ mod abs {
                         BoundInclusivity::Exclusive,
                     )
                     .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound(),
                 ),
                 AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_end_bound(),
                 ),
                 AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new("2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound(),
                 ),
                 AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new_with_inclusivity(
@@ -177,10 +176,11 @@ mod abs {
                         BoundInclusivity::Exclusive,
                     )
                     .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-02-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_end_bound(),
                 ),
             ],
         );

--- a/src/iter/intervals/layered_bounds_set_ops/intersect_tests.rs
+++ b/src/iter/intervals/layered_bounds_set_ops/intersect_tests.rs
@@ -177,10 +177,13 @@ mod rel {
                 Some(RelativeEndBound::Finite(RelativeFiniteBound::new(
                     SignedDuration::from_hours(101),
                 ))),
-                Some(RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                    SignedDuration::from_hours(101),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    RelativeFiniteBound::new_with_inclusivity(
+                        SignedDuration::from_hours(101),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_start_bound(),
+                ),
             ),
             LayeredBoundsStateChangeAtRelativeBound::new(
                 LayeredBoundsState::SecondLayer,
@@ -189,9 +192,7 @@ mod rel {
                     SignedDuration::from_hours(501),
                     BoundInclusivity::Exclusive,
                 ))),
-                Some(RelativeStartBound::Finite(RelativeFiniteBound::new(
-                    SignedDuration::from_hours(501),
-                ))),
+                Some(RelativeFiniteBound::new(SignedDuration::from_hours(501)).to_start_bound()),
             ),
         ];
 
@@ -205,17 +206,17 @@ mod rel {
         let first_layer_data = [
             // 1
             RelativeBoundPair::new(
-                RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(101))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_start_bound(),
                 RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(105))),
             ),
             // 3
             RelativeBoundPair::new(
-                RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(111))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(111)).to_start_bound(),
                 RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(115))),
             ),
             // 5
             RelativeBoundPair::new(
-                RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(120))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(120)).to_start_bound(),
                 RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
                     SignedDuration::from_hours(210),
                     BoundInclusivity::Exclusive,
@@ -226,20 +227,18 @@ mod rel {
         let second_layer_data = [
             // 2
             RelativeBoundPair::new(
-                RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(105))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(105)).to_start_bound(),
                 RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(110))),
             ),
             // 4
             RelativeBoundPair::new(
-                RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(120))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(120)).to_start_bound(),
                 RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(122))),
             ),
             // 6
             RelativeBoundPair::new(
-                RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                    SignedDuration::from_hours(201),
-                    BoundInclusivity::Exclusive,
-                )),
+                RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(201), BoundInclusivity::Exclusive)
+                    .to_start_bound(),
                 RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(215))),
             ),
         ];
@@ -253,18 +252,19 @@ mod rel {
                 .collect::<Vec<_>>(),
             vec![
                 RelativeBoundPair::new(
-                    RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(105))),
+                    RelativeFiniteBound::new(SignedDuration::from_hours(105)).to_start_bound(),
                     RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(105))),
                 ),
                 RelativeBoundPair::new(
-                    RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(120))),
+                    RelativeFiniteBound::new(SignedDuration::from_hours(120)).to_start_bound(),
                     RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(122))),
                 ),
                 RelativeBoundPair::new(
-                    RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
+                    RelativeFiniteBound::new_with_inclusivity(
                         SignedDuration::from_hours(201),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_start_bound(),
                     RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
                         SignedDuration::from_hours(210),
                         BoundInclusivity::Exclusive,

--- a/src/iter/intervals/layered_bounds_set_ops/intersect_tests.rs
+++ b/src/iter/intervals/layered_bounds_set_ops/intersect_tests.rs
@@ -31,10 +31,13 @@ mod abs {
                 Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 ))),
-                Some(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-                    "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new_with_inclusivity(
+                        "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_start_bound(),
+                ),
             ),
             LayeredBoundsStateChangeAtAbsoluteBound::new(
                 LayeredBoundsState::SecondLayer,
@@ -43,9 +46,10 @@ mod abs {
                     "2025-05-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
                 ))),
-                Some(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-05-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new("2025-05-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
+                ),
             ),
         ];
 
@@ -61,27 +65,24 @@ mod abs {
         let first_layer_data = [
             // 1
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 )),
             ),
             // 3
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-11 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-11 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 )),
             ),
             // 5
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-02-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
@@ -92,28 +93,27 @@ mod abs {
         let second_layer_data = [
             // 2
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 )),
             ),
             // 4
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-22 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 )),
             ),
             // 6
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-02-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 )),
@@ -129,26 +129,25 @@ mod abs {
                 .collect::<Vec<_>>(),
             vec![
                 AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                         "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                     )),
                 ),
                 AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                         "2025-01-22 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                     )),
                 ),
                 AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-02-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,

--- a/src/iter/intervals/layered_bounds_set_ops/intersect_tests.rs
+++ b/src/iter/intervals/layered_bounds_set_ops/intersect_tests.rs
@@ -5,7 +5,7 @@ use jiff::{SignedDuration, Zoned};
 use super::intersect::*;
 use crate::intervals::absolute::{AbsoluteBoundPair, AbsoluteFiniteBound, AbsoluteStartBound};
 use crate::intervals::meta::BoundInclusivity;
-use crate::intervals::relative::{RelativeBoundPair, RelativeEndBound, RelativeFiniteBound, RelativeStartBound};
+use crate::intervals::relative::{RelativeBoundPair, RelativeFiniteBound, RelativeStartBound};
 use crate::iter::intervals::bounds::{AbsoluteBoundsIteratorDispatcher, RelativeBoundsIteratorDispatcher};
 use crate::iter::intervals::layered_bounds::{
     LayeredBoundsState,
@@ -174,9 +174,7 @@ mod rel {
             LayeredBoundsStateChangeAtRelativeBound::new(
                 LayeredBoundsState::FirstLayer,
                 LayeredBoundsState::SecondLayer,
-                Some(RelativeEndBound::Finite(RelativeFiniteBound::new(
-                    SignedDuration::from_hours(101),
-                ))),
+                Some(RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_end_bound()),
                 Some(
                     RelativeFiniteBound::new_with_inclusivity(
                         SignedDuration::from_hours(101),
@@ -188,10 +186,13 @@ mod rel {
             LayeredBoundsStateChangeAtRelativeBound::new(
                 LayeredBoundsState::SecondLayer,
                 LayeredBoundsState::NoLayers,
-                Some(RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                    SignedDuration::from_hours(501),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    RelativeFiniteBound::new_with_inclusivity(
+                        SignedDuration::from_hours(501),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_end_bound(),
+                ),
                 Some(RelativeFiniteBound::new(SignedDuration::from_hours(501)).to_start_bound()),
             ),
         ];
@@ -207,20 +208,18 @@ mod rel {
             // 1
             RelativeBoundPair::new(
                 RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_start_bound(),
-                RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(105))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(105)).to_end_bound(),
             ),
             // 3
             RelativeBoundPair::new(
                 RelativeFiniteBound::new(SignedDuration::from_hours(111)).to_start_bound(),
-                RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(115))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(115)).to_end_bound(),
             ),
             // 5
             RelativeBoundPair::new(
                 RelativeFiniteBound::new(SignedDuration::from_hours(120)).to_start_bound(),
-                RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                    SignedDuration::from_hours(210),
-                    BoundInclusivity::Exclusive,
-                )),
+                RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(210), BoundInclusivity::Exclusive)
+                    .to_end_bound(),
             ),
         ];
 
@@ -228,18 +227,18 @@ mod rel {
             // 2
             RelativeBoundPair::new(
                 RelativeFiniteBound::new(SignedDuration::from_hours(105)).to_start_bound(),
-                RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(110))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(110)).to_end_bound(),
             ),
             // 4
             RelativeBoundPair::new(
                 RelativeFiniteBound::new(SignedDuration::from_hours(120)).to_start_bound(),
-                RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(122))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(122)).to_end_bound(),
             ),
             // 6
             RelativeBoundPair::new(
                 RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(201), BoundInclusivity::Exclusive)
                     .to_start_bound(),
-                RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(215))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(215)).to_end_bound(),
             ),
         ];
 
@@ -253,11 +252,11 @@ mod rel {
             vec![
                 RelativeBoundPair::new(
                     RelativeFiniteBound::new(SignedDuration::from_hours(105)).to_start_bound(),
-                    RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(105))),
+                    RelativeFiniteBound::new(SignedDuration::from_hours(105)).to_end_bound(),
                 ),
                 RelativeBoundPair::new(
                     RelativeFiniteBound::new(SignedDuration::from_hours(120)).to_start_bound(),
-                    RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(122))),
+                    RelativeFiniteBound::new(SignedDuration::from_hours(122)).to_end_bound(),
                 ),
                 RelativeBoundPair::new(
                     RelativeFiniteBound::new_with_inclusivity(
@@ -265,10 +264,11 @@ mod rel {
                         BoundInclusivity::Exclusive,
                     )
                     .to_start_bound(),
-                    RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
+                    RelativeFiniteBound::new_with_inclusivity(
                         SignedDuration::from_hours(210),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_end_bound(),
                 ),
             ],
         );

--- a/src/iter/intervals/layered_bounds_set_ops/intersect_tests.rs
+++ b/src/iter/intervals/layered_bounds_set_ops/intersect_tests.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 use jiff::{SignedDuration, Zoned};
 
 use super::intersect::*;
-use crate::intervals::absolute::{AbsoluteBoundPair, AbsoluteEndBound, AbsoluteFiniteBound, AbsoluteStartBound};
+use crate::intervals::absolute::{AbsoluteBoundPair, AbsoluteFiniteBound, AbsoluteStartBound};
 use crate::intervals::meta::BoundInclusivity;
 use crate::intervals::relative::{RelativeBoundPair, RelativeEndBound, RelativeFiniteBound, RelativeStartBound};
 use crate::iter::intervals::bounds::{AbsoluteBoundsIteratorDispatcher, RelativeBoundsIteratorDispatcher};
@@ -28,9 +28,10 @@ mod abs {
             LayeredBoundsStateChangeAtAbsoluteBound::new(
                 LayeredBoundsState::FirstLayer,
                 LayeredBoundsState::SecondLayer,
-                Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound(),
+                ),
                 Some(
                     AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
@@ -42,10 +43,13 @@ mod abs {
             LayeredBoundsStateChangeAtAbsoluteBound::new(
                 LayeredBoundsState::SecondLayer,
                 LayeredBoundsState::NoLayers,
-                Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-                    "2025-05-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new_with_inclusivity(
+                        "2025-05-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_end_bound(),
+                ),
                 Some(
                     AbsoluteFiniteBound::new("2025-05-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
@@ -67,26 +71,25 @@ mod abs {
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
             // 3
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-11 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
             // 5
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-02-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_end_bound(),
             ),
         ];
 
@@ -95,17 +98,15 @@ mod abs {
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
             // 4
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-22 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-22 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
             // 6
             AbsoluteBoundPair::new(
@@ -114,9 +115,8 @@ mod abs {
                     BoundInclusivity::Exclusive,
                 )
                 .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-02-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-02-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
         ];
 
@@ -131,16 +131,14 @@ mod abs {
                 AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound(),
                 ),
                 AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-22 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-22 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound(),
                 ),
                 AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new_with_inclusivity(
@@ -148,10 +146,11 @@ mod abs {
                         BoundInclusivity::Exclusive,
                     )
                     .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-02-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_end_bound(),
                 ),
             ],
         );

--- a/src/iter/intervals/layered_bounds_set_ops/sym_diff_tests.rs
+++ b/src/iter/intervals/layered_bounds_set_ops/sym_diff_tests.rs
@@ -31,10 +31,13 @@ mod abs {
                 Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 ))),
-                Some(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-                    "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new_with_inclusivity(
+                        "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_start_bound(),
+                ),
             ),
             LayeredBoundsStateChangeAtAbsoluteBound::new(
                 LayeredBoundsState::SecondLayer,
@@ -43,9 +46,10 @@ mod abs {
                     "2025-05-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
                 ))),
-                Some(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-05-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new("2025-05-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
+                ),
             ),
         ];
 
@@ -62,36 +66,32 @@ mod abs {
         let first_layer_data = [
             // 2
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 )),
             ),
             // 5
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-28 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 )),
             ),
             // 6
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 )),
             ),
             // 9
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-02-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-02-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-02-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 )),
@@ -101,28 +101,27 @@ mod abs {
         let second_layer_data = [
             // 1
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 )),
             ),
             // 3
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-12 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-12 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 )),
             ),
             // 4
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
@@ -130,10 +129,11 @@ mod abs {
             ),
             // 7
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
@@ -141,9 +141,8 @@ mod abs {
             ),
             // 8
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-02-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-02-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-02-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 )),
@@ -163,9 +162,8 @@ mod abs {
             vec![
                 // A
                 AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
@@ -173,10 +171,11 @@ mod abs {
                 ),
                 // B
                 AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-12 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
@@ -184,10 +183,11 @@ mod abs {
                 ),
                 // C
                 AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
@@ -195,10 +195,11 @@ mod abs {
                 ),
                 // D
                 AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-28 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
@@ -206,27 +207,24 @@ mod abs {
                 ),
                 // E
                 AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                         "2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                     )),
                 ),
                 // F
                 AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                         "2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                     )),
                 ),
                 // G
                 AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-02-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-02-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-02-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
@@ -234,10 +232,11 @@ mod abs {
                 ),
                 // H
                 AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-02-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                         "2025-02-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                     )),

--- a/src/iter/intervals/layered_bounds_set_ops/sym_diff_tests.rs
+++ b/src/iter/intervals/layered_bounds_set_ops/sym_diff_tests.rs
@@ -5,7 +5,7 @@ use jiff::{SignedDuration, Zoned};
 use super::sym_diff::*;
 use crate::intervals::absolute::{AbsoluteBoundPair, AbsoluteFiniteBound, AbsoluteStartBound};
 use crate::intervals::meta::BoundInclusivity;
-use crate::intervals::relative::{RelativeBoundPair, RelativeEndBound, RelativeFiniteBound, RelativeStartBound};
+use crate::intervals::relative::{RelativeBoundPair, RelativeFiniteBound, RelativeStartBound};
 use crate::iter::intervals::bounds::{AbsoluteBoundsIteratorDispatcher, RelativeBoundsIteratorDispatcher};
 use crate::iter::intervals::layered_bounds::{
     LayeredBoundsState,
@@ -264,9 +264,7 @@ mod rel {
             LayeredBoundsStateChangeAtRelativeBound::new(
                 LayeredBoundsState::FirstLayer,
                 LayeredBoundsState::SecondLayer,
-                Some(RelativeEndBound::Finite(RelativeFiniteBound::new(
-                    SignedDuration::from_hours(101),
-                ))),
+                Some(RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_end_bound()),
                 Some(
                     RelativeFiniteBound::new_with_inclusivity(
                         SignedDuration::from_hours(101),
@@ -278,10 +276,13 @@ mod rel {
             LayeredBoundsStateChangeAtRelativeBound::new(
                 LayeredBoundsState::SecondLayer,
                 LayeredBoundsState::NoLayers,
-                Some(RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                    SignedDuration::from_hours(501),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    RelativeFiniteBound::new_with_inclusivity(
+                        SignedDuration::from_hours(501),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_end_bound(),
+                ),
                 Some(RelativeFiniteBound::new(SignedDuration::from_hours(501)).to_start_bound()),
             ),
         ];
@@ -298,22 +299,22 @@ mod rel {
             // 2
             RelativeBoundPair::new(
                 RelativeFiniteBound::new(SignedDuration::from_hours(105)).to_start_bound(),
-                RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(120))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(120)).to_end_bound(),
             ),
             // 5
             RelativeBoundPair::new(
                 RelativeFiniteBound::new(SignedDuration::from_hours(125)).to_start_bound(),
-                RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(128))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(128)).to_end_bound(),
             ),
             // 6
             RelativeBoundPair::new(
                 RelativeFiniteBound::new(SignedDuration::from_hours(201)).to_start_bound(),
-                RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(205))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(205)).to_end_bound(),
             ),
             // 9
             RelativeBoundPair::new(
                 RelativeFiniteBound::new(SignedDuration::from_hours(215)).to_start_bound(),
-                RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(225))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(225)).to_end_bound(),
             ),
         ];
 
@@ -321,35 +322,31 @@ mod rel {
             // 1
             RelativeBoundPair::new(
                 RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_start_bound(),
-                RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(110))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(110)).to_end_bound(),
             ),
             // 3
             RelativeBoundPair::new(
                 RelativeFiniteBound::new(SignedDuration::from_hours(112)).to_start_bound(),
-                RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(115))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(115)).to_end_bound(),
             ),
             // 4
             RelativeBoundPair::new(
                 RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(120), BoundInclusivity::Exclusive)
                     .to_start_bound(),
-                RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                    SignedDuration::from_hours(130),
-                    BoundInclusivity::Exclusive,
-                )),
+                RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(130), BoundInclusivity::Exclusive)
+                    .to_end_bound(),
             ),
             // 7
             RelativeBoundPair::new(
                 RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(201), BoundInclusivity::Exclusive)
                     .to_start_bound(),
-                RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                    SignedDuration::from_hours(205),
-                    BoundInclusivity::Exclusive,
-                )),
+                RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(205), BoundInclusivity::Exclusive)
+                    .to_end_bound(),
             ),
             // 8
             RelativeBoundPair::new(
                 RelativeFiniteBound::new(SignedDuration::from_hours(210)).to_start_bound(),
-                RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(220))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(220)).to_end_bound(),
             ),
         ];
 
@@ -367,10 +364,11 @@ mod rel {
                 // A
                 RelativeBoundPair::new(
                     RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_start_bound(),
-                    RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
+                    RelativeFiniteBound::new_with_inclusivity(
                         SignedDuration::from_hours(105),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_end_bound(),
                 ),
                 // B
                 RelativeBoundPair::new(
@@ -379,10 +377,11 @@ mod rel {
                         BoundInclusivity::Exclusive,
                     )
                     .to_start_bound(),
-                    RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
+                    RelativeFiniteBound::new_with_inclusivity(
                         SignedDuration::from_hours(112),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_end_bound(),
                 ),
                 // C
                 RelativeBoundPair::new(
@@ -391,10 +390,11 @@ mod rel {
                         BoundInclusivity::Exclusive,
                     )
                     .to_start_bound(),
-                    RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
+                    RelativeFiniteBound::new_with_inclusivity(
                         SignedDuration::from_hours(125),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_end_bound(),
                 ),
                 // D
                 RelativeBoundPair::new(
@@ -403,28 +403,30 @@ mod rel {
                         BoundInclusivity::Exclusive,
                     )
                     .to_start_bound(),
-                    RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
+                    RelativeFiniteBound::new_with_inclusivity(
                         SignedDuration::from_hours(130),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_end_bound(),
                 ),
                 // E
                 RelativeBoundPair::new(
                     RelativeFiniteBound::new(SignedDuration::from_hours(201)).to_start_bound(),
-                    RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(201))),
+                    RelativeFiniteBound::new(SignedDuration::from_hours(201)).to_end_bound(),
                 ),
                 // F
                 RelativeBoundPair::new(
                     RelativeFiniteBound::new(SignedDuration::from_hours(205)).to_start_bound(),
-                    RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(205))),
+                    RelativeFiniteBound::new(SignedDuration::from_hours(205)).to_end_bound(),
                 ),
                 // G
                 RelativeBoundPair::new(
                     RelativeFiniteBound::new(SignedDuration::from_hours(210)).to_start_bound(),
-                    RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
+                    RelativeFiniteBound::new_with_inclusivity(
                         SignedDuration::from_hours(215),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_end_bound(),
                 ),
                 // H
                 RelativeBoundPair::new(
@@ -433,7 +435,7 @@ mod rel {
                         BoundInclusivity::Exclusive,
                     )
                     .to_start_bound(),
-                    RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(225))),
+                    RelativeFiniteBound::new(SignedDuration::from_hours(225)).to_end_bound(),
                 ),
             ],
         );

--- a/src/iter/intervals/layered_bounds_set_ops/sym_diff_tests.rs
+++ b/src/iter/intervals/layered_bounds_set_ops/sym_diff_tests.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 use jiff::{SignedDuration, Zoned};
 
 use super::sym_diff::*;
-use crate::intervals::absolute::{AbsoluteBoundPair, AbsoluteEndBound, AbsoluteFiniteBound, AbsoluteStartBound};
+use crate::intervals::absolute::{AbsoluteBoundPair, AbsoluteFiniteBound, AbsoluteStartBound};
 use crate::intervals::meta::BoundInclusivity;
 use crate::intervals::relative::{RelativeBoundPair, RelativeEndBound, RelativeFiniteBound, RelativeStartBound};
 use crate::iter::intervals::bounds::{AbsoluteBoundsIteratorDispatcher, RelativeBoundsIteratorDispatcher};
@@ -28,9 +28,10 @@ mod abs {
             LayeredBoundsStateChangeAtAbsoluteBound::new(
                 LayeredBoundsState::FirstLayer,
                 LayeredBoundsState::SecondLayer,
-                Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound(),
+                ),
                 Some(
                     AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
@@ -42,10 +43,13 @@ mod abs {
             LayeredBoundsStateChangeAtAbsoluteBound::new(
                 LayeredBoundsState::SecondLayer,
                 LayeredBoundsState::NoLayers,
-                Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-                    "2025-05-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new_with_inclusivity(
+                        "2025-05-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_end_bound(),
+                ),
                 Some(
                     AbsoluteFiniteBound::new("2025-05-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
@@ -68,33 +72,29 @@ mod abs {
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
             // 5
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-28 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-28 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
             // 6
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
             // 9
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-02-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-02-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-02-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
         ];
 
@@ -103,17 +103,15 @@ mod abs {
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
             // 3
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-12 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
             // 4
             AbsoluteBoundPair::new(
@@ -122,10 +120,11 @@ mod abs {
                     BoundInclusivity::Exclusive,
                 )
                 .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_end_bound(),
             ),
             // 7
             AbsoluteBoundPair::new(
@@ -134,18 +133,18 @@ mod abs {
                     BoundInclusivity::Exclusive,
                 )
                 .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_end_bound(),
             ),
             // 8
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-02-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-02-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-02-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
         ];
 
@@ -164,10 +163,11 @@ mod abs {
                 AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_end_bound(),
                 ),
                 // B
                 AbsoluteBoundPair::new(
@@ -176,10 +176,11 @@ mod abs {
                         BoundInclusivity::Exclusive,
                     )
                     .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-12 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_end_bound(),
                 ),
                 // C
                 AbsoluteBoundPair::new(
@@ -188,10 +189,11 @@ mod abs {
                         BoundInclusivity::Exclusive,
                     )
                     .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_end_bound(),
                 ),
                 // D
                 AbsoluteBoundPair::new(
@@ -200,35 +202,35 @@ mod abs {
                         BoundInclusivity::Exclusive,
                     )
                     .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_end_bound(),
                 ),
                 // E
                 AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new("2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound(),
                 ),
                 // F
                 AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new("2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound(),
                 ),
                 // G
                 AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new("2025-02-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-02-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_end_bound(),
                 ),
                 // H
                 AbsoluteBoundPair::new(
@@ -237,9 +239,8 @@ mod abs {
                         BoundInclusivity::Exclusive,
                     )
                     .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-02-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-02-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound(),
                 ),
             ],
         );

--- a/src/iter/intervals/layered_bounds_set_ops/sym_diff_tests.rs
+++ b/src/iter/intervals/layered_bounds_set_ops/sym_diff_tests.rs
@@ -267,10 +267,13 @@ mod rel {
                 Some(RelativeEndBound::Finite(RelativeFiniteBound::new(
                     SignedDuration::from_hours(101),
                 ))),
-                Some(RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                    SignedDuration::from_hours(101),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    RelativeFiniteBound::new_with_inclusivity(
+                        SignedDuration::from_hours(101),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_start_bound(),
+                ),
             ),
             LayeredBoundsStateChangeAtRelativeBound::new(
                 LayeredBoundsState::SecondLayer,
@@ -279,9 +282,7 @@ mod rel {
                     SignedDuration::from_hours(501),
                     BoundInclusivity::Exclusive,
                 ))),
-                Some(RelativeStartBound::Finite(RelativeFiniteBound::new(
-                    SignedDuration::from_hours(501),
-                ))),
+                Some(RelativeFiniteBound::new(SignedDuration::from_hours(501)).to_start_bound()),
             ),
         ];
 
@@ -296,22 +297,22 @@ mod rel {
         let first_layer_data = [
             // 2
             RelativeBoundPair::new(
-                RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(105))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(105)).to_start_bound(),
                 RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(120))),
             ),
             // 5
             RelativeBoundPair::new(
-                RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(125))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(125)).to_start_bound(),
                 RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(128))),
             ),
             // 6
             RelativeBoundPair::new(
-                RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(201))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(201)).to_start_bound(),
                 RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(205))),
             ),
             // 9
             RelativeBoundPair::new(
-                RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(215))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(215)).to_start_bound(),
                 RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(225))),
             ),
         ];
@@ -319,20 +320,18 @@ mod rel {
         let second_layer_data = [
             // 1
             RelativeBoundPair::new(
-                RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(101))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_start_bound(),
                 RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(110))),
             ),
             // 3
             RelativeBoundPair::new(
-                RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(112))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(112)).to_start_bound(),
                 RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(115))),
             ),
             // 4
             RelativeBoundPair::new(
-                RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                    SignedDuration::from_hours(120),
-                    BoundInclusivity::Exclusive,
-                )),
+                RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(120), BoundInclusivity::Exclusive)
+                    .to_start_bound(),
                 RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
                     SignedDuration::from_hours(130),
                     BoundInclusivity::Exclusive,
@@ -340,10 +339,8 @@ mod rel {
             ),
             // 7
             RelativeBoundPair::new(
-                RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                    SignedDuration::from_hours(201),
-                    BoundInclusivity::Exclusive,
-                )),
+                RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(201), BoundInclusivity::Exclusive)
+                    .to_start_bound(),
                 RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
                     SignedDuration::from_hours(205),
                     BoundInclusivity::Exclusive,
@@ -351,7 +348,7 @@ mod rel {
             ),
             // 8
             RelativeBoundPair::new(
-                RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(210))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(210)).to_start_bound(),
                 RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(220))),
             ),
         ];
@@ -369,7 +366,7 @@ mod rel {
             vec![
                 // A
                 RelativeBoundPair::new(
-                    RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(101))),
+                    RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_start_bound(),
                     RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
                         SignedDuration::from_hours(105),
                         BoundInclusivity::Exclusive,
@@ -377,10 +374,11 @@ mod rel {
                 ),
                 // B
                 RelativeBoundPair::new(
-                    RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
+                    RelativeFiniteBound::new_with_inclusivity(
                         SignedDuration::from_hours(110),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_start_bound(),
                     RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
                         SignedDuration::from_hours(112),
                         BoundInclusivity::Exclusive,
@@ -388,10 +386,11 @@ mod rel {
                 ),
                 // C
                 RelativeBoundPair::new(
-                    RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
+                    RelativeFiniteBound::new_with_inclusivity(
                         SignedDuration::from_hours(115),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_start_bound(),
                     RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
                         SignedDuration::from_hours(125),
                         BoundInclusivity::Exclusive,
@@ -399,10 +398,11 @@ mod rel {
                 ),
                 // D
                 RelativeBoundPair::new(
-                    RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
+                    RelativeFiniteBound::new_with_inclusivity(
                         SignedDuration::from_hours(128),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_start_bound(),
                     RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
                         SignedDuration::from_hours(130),
                         BoundInclusivity::Exclusive,
@@ -410,17 +410,17 @@ mod rel {
                 ),
                 // E
                 RelativeBoundPair::new(
-                    RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(201))),
+                    RelativeFiniteBound::new(SignedDuration::from_hours(201)).to_start_bound(),
                     RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(201))),
                 ),
                 // F
                 RelativeBoundPair::new(
-                    RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(205))),
+                    RelativeFiniteBound::new(SignedDuration::from_hours(205)).to_start_bound(),
                     RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(205))),
                 ),
                 // G
                 RelativeBoundPair::new(
-                    RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(210))),
+                    RelativeFiniteBound::new(SignedDuration::from_hours(210)).to_start_bound(),
                     RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
                         SignedDuration::from_hours(215),
                         BoundInclusivity::Exclusive,
@@ -428,10 +428,11 @@ mod rel {
                 ),
                 // H
                 RelativeBoundPair::new(
-                    RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
+                    RelativeFiniteBound::new_with_inclusivity(
                         SignedDuration::from_hours(220),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_start_bound(),
                     RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(225))),
                 ),
             ],

--- a/src/iter/intervals/layered_bounds_set_ops/unite_tests.rs
+++ b/src/iter/intervals/layered_bounds_set_ops/unite_tests.rs
@@ -183,10 +183,13 @@ mod rel {
                 Some(RelativeEndBound::Finite(RelativeFiniteBound::new(
                     SignedDuration::from_hours(101),
                 ))),
-                Some(RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                    SignedDuration::from_hours(101),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    RelativeFiniteBound::new_with_inclusivity(
+                        SignedDuration::from_hours(101),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_start_bound(),
+                ),
             ),
             LayeredBoundsStateChangeAtRelativeBound::new(
                 LayeredBoundsState::SecondLayer,
@@ -195,9 +198,7 @@ mod rel {
                     SignedDuration::from_hours(501),
                     BoundInclusivity::Exclusive,
                 ))),
-                Some(RelativeStartBound::Finite(RelativeFiniteBound::new(
-                    SignedDuration::from_hours(501),
-                ))),
+                Some(RelativeFiniteBound::new(SignedDuration::from_hours(501)).to_start_bound()),
             ),
         ];
 
@@ -211,17 +212,17 @@ mod rel {
         let first_layer_data = [
             // 1
             RelativeBoundPair::new(
-                RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(101))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_start_bound(),
                 RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(110))),
             ),
             // 3
             RelativeBoundPair::new(
-                RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(112))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(112)).to_start_bound(),
                 RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(115))),
             ),
             // 4
             RelativeBoundPair::new(
-                RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(120))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(120)).to_start_bound(),
                 RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
                     SignedDuration::from_hours(125),
                     BoundInclusivity::Exclusive,
@@ -229,7 +230,7 @@ mod rel {
             ),
             // 6
             RelativeBoundPair::new(
-                RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(201))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(201)).to_start_bound(),
                 RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(205))),
             ),
         ];
@@ -237,10 +238,8 @@ mod rel {
         let second_layer_data = [
             // 2
             RelativeBoundPair::new(
-                RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                    SignedDuration::from_hours(105),
-                    BoundInclusivity::Exclusive,
-                )),
+                RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(105), BoundInclusivity::Exclusive)
+                    .to_start_bound(),
                 RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
                     SignedDuration::from_hours(120),
                     BoundInclusivity::Exclusive,
@@ -248,10 +247,8 @@ mod rel {
             ),
             // 5
             RelativeBoundPair::new(
-                RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                    SignedDuration::from_hours(125),
-                    BoundInclusivity::Exclusive,
-                )),
+                RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(125), BoundInclusivity::Exclusive)
+                    .to_start_bound(),
                 RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(130))),
             ),
         ];
@@ -265,21 +262,22 @@ mod rel {
                 .collect::<Vec<_>>(),
             vec![
                 RelativeBoundPair::new(
-                    RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(101))),
+                    RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_start_bound(),
                     RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
                         SignedDuration::from_hours(125),
                         BoundInclusivity::Exclusive,
                     )),
                 ),
                 RelativeBoundPair::new(
-                    RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
+                    RelativeFiniteBound::new_with_inclusivity(
                         SignedDuration::from_hours(125),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_start_bound(),
                     RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(130))),
                 ),
                 RelativeBoundPair::new(
-                    RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(201))),
+                    RelativeFiniteBound::new(SignedDuration::from_hours(201)).to_start_bound(),
                     RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(205))),
                 ),
             ],

--- a/src/iter/intervals/layered_bounds_set_ops/unite_tests.rs
+++ b/src/iter/intervals/layered_bounds_set_ops/unite_tests.rs
@@ -31,10 +31,13 @@ mod abs {
                 Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 ))),
-                Some(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-                    "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new_with_inclusivity(
+                        "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_start_bound(),
+                ),
             ),
             LayeredBoundsStateChangeAtAbsoluteBound::new(
                 LayeredBoundsState::SecondLayer,
@@ -43,9 +46,10 @@ mod abs {
                     "2025-05-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
                 ))),
-                Some(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-05-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new("2025-05-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
+                ),
             ),
         ];
 
@@ -61,27 +65,24 @@ mod abs {
         let first_layer_data = [
             // 1
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 )),
             ),
             // 3
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-12 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-12 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 )),
             ),
             // 4
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
@@ -89,9 +90,8 @@ mod abs {
             ),
             // 6
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 )),
@@ -101,10 +101,11 @@ mod abs {
         let second_layer_data = [
             // 2
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
@@ -112,10 +113,11 @@ mod abs {
             ),
             // 5
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 )),
@@ -131,27 +133,26 @@ mod abs {
                 .collect::<Vec<_>>(),
             vec![
                 AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
                     )),
                 ),
                 AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                         "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                     )),
                 ),
                 AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                         "2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                     )),

--- a/src/iter/intervals/layered_bounds_set_ops/unite_tests.rs
+++ b/src/iter/intervals/layered_bounds_set_ops/unite_tests.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 use jiff::{SignedDuration, Zoned};
 
 use super::unite::*;
-use crate::intervals::absolute::{AbsoluteBoundPair, AbsoluteEndBound, AbsoluteFiniteBound, AbsoluteStartBound};
+use crate::intervals::absolute::{AbsoluteBoundPair, AbsoluteFiniteBound, AbsoluteStartBound};
 use crate::intervals::meta::BoundInclusivity;
 use crate::intervals::relative::{RelativeBoundPair, RelativeEndBound, RelativeFiniteBound, RelativeStartBound};
 use crate::iter::intervals::bounds::{AbsoluteBoundsIteratorDispatcher, RelativeBoundsIteratorDispatcher};
@@ -28,9 +28,10 @@ mod abs {
             LayeredBoundsStateChangeAtAbsoluteBound::new(
                 LayeredBoundsState::FirstLayer,
                 LayeredBoundsState::SecondLayer,
-                Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound(),
+                ),
                 Some(
                     AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
@@ -42,10 +43,13 @@ mod abs {
             LayeredBoundsStateChangeAtAbsoluteBound::new(
                 LayeredBoundsState::SecondLayer,
                 LayeredBoundsState::NoLayers,
-                Some(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-                    "2025-05-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    AbsoluteFiniteBound::new_with_inclusivity(
+                        "2025-05-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_end_bound(),
+                ),
                 Some(
                     AbsoluteFiniteBound::new("2025-05-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
@@ -67,34 +71,32 @@ mod abs {
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
             // 3
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-12 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
             // 4
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_end_bound(),
             ),
             // 6
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
         ];
 
@@ -106,10 +108,11 @@ mod abs {
                     BoundInclusivity::Exclusive,
                 )
                 .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_end_bound(),
             ),
             // 5
             AbsoluteBoundPair::new(
@@ -118,9 +121,8 @@ mod abs {
                     BoundInclusivity::Exclusive,
                 )
                 .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
         ];
 
@@ -135,10 +137,11 @@ mod abs {
                 AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_end_bound(),
                 ),
                 AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new_with_inclusivity(
@@ -146,16 +149,14 @@ mod abs {
                         BoundInclusivity::Exclusive,
                     )
                     .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound(),
                 ),
                 AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new("2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound(),
                 ),
             ],
         );

--- a/src/iter/intervals/layered_bounds_set_ops/unite_tests.rs
+++ b/src/iter/intervals/layered_bounds_set_ops/unite_tests.rs
@@ -5,7 +5,7 @@ use jiff::{SignedDuration, Zoned};
 use super::unite::*;
 use crate::intervals::absolute::{AbsoluteBoundPair, AbsoluteFiniteBound, AbsoluteStartBound};
 use crate::intervals::meta::BoundInclusivity;
-use crate::intervals::relative::{RelativeBoundPair, RelativeEndBound, RelativeFiniteBound, RelativeStartBound};
+use crate::intervals::relative::{RelativeBoundPair, RelativeFiniteBound, RelativeStartBound};
 use crate::iter::intervals::bounds::{AbsoluteBoundsIteratorDispatcher, RelativeBoundsIteratorDispatcher};
 use crate::iter::intervals::layered_bounds::{
     LayeredBoundsState,
@@ -180,9 +180,7 @@ mod rel {
             LayeredBoundsStateChangeAtRelativeBound::new(
                 LayeredBoundsState::FirstLayer,
                 LayeredBoundsState::SecondLayer,
-                Some(RelativeEndBound::Finite(RelativeFiniteBound::new(
-                    SignedDuration::from_hours(101),
-                ))),
+                Some(RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_end_bound()),
                 Some(
                     RelativeFiniteBound::new_with_inclusivity(
                         SignedDuration::from_hours(101),
@@ -194,10 +192,13 @@ mod rel {
             LayeredBoundsStateChangeAtRelativeBound::new(
                 LayeredBoundsState::SecondLayer,
                 LayeredBoundsState::NoLayers,
-                Some(RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                    SignedDuration::from_hours(501),
-                    BoundInclusivity::Exclusive,
-                ))),
+                Some(
+                    RelativeFiniteBound::new_with_inclusivity(
+                        SignedDuration::from_hours(501),
+                        BoundInclusivity::Exclusive,
+                    )
+                    .to_end_bound(),
+                ),
                 Some(RelativeFiniteBound::new(SignedDuration::from_hours(501)).to_start_bound()),
             ),
         ];
@@ -213,25 +214,23 @@ mod rel {
             // 1
             RelativeBoundPair::new(
                 RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_start_bound(),
-                RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(110))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(110)).to_end_bound(),
             ),
             // 3
             RelativeBoundPair::new(
                 RelativeFiniteBound::new(SignedDuration::from_hours(112)).to_start_bound(),
-                RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(115))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(115)).to_end_bound(),
             ),
             // 4
             RelativeBoundPair::new(
                 RelativeFiniteBound::new(SignedDuration::from_hours(120)).to_start_bound(),
-                RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                    SignedDuration::from_hours(125),
-                    BoundInclusivity::Exclusive,
-                )),
+                RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(125), BoundInclusivity::Exclusive)
+                    .to_end_bound(),
             ),
             // 6
             RelativeBoundPair::new(
                 RelativeFiniteBound::new(SignedDuration::from_hours(201)).to_start_bound(),
-                RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(205))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(205)).to_end_bound(),
             ),
         ];
 
@@ -240,16 +239,14 @@ mod rel {
             RelativeBoundPair::new(
                 RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(105), BoundInclusivity::Exclusive)
                     .to_start_bound(),
-                RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                    SignedDuration::from_hours(120),
-                    BoundInclusivity::Exclusive,
-                )),
+                RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(120), BoundInclusivity::Exclusive)
+                    .to_end_bound(),
             ),
             // 5
             RelativeBoundPair::new(
                 RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(125), BoundInclusivity::Exclusive)
                     .to_start_bound(),
-                RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(130))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(130)).to_end_bound(),
             ),
         ];
 
@@ -263,10 +260,11 @@ mod rel {
             vec![
                 RelativeBoundPair::new(
                     RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_start_bound(),
-                    RelativeEndBound::Finite(RelativeFiniteBound::new_with_inclusivity(
+                    RelativeFiniteBound::new_with_inclusivity(
                         SignedDuration::from_hours(125),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_end_bound(),
                 ),
                 RelativeBoundPair::new(
                     RelativeFiniteBound::new_with_inclusivity(
@@ -274,11 +272,11 @@ mod rel {
                         BoundInclusivity::Exclusive,
                     )
                     .to_start_bound(),
-                    RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(130))),
+                    RelativeFiniteBound::new(SignedDuration::from_hours(130)).to_end_bound(),
                 ),
                 RelativeBoundPair::new(
                     RelativeFiniteBound::new(SignedDuration::from_hours(201)).to_start_bound(),
-                    RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(205))),
+                    RelativeFiniteBound::new(SignedDuration::from_hours(205)).to_end_bound(),
                 ),
             ],
         );

--- a/src/iter/intervals/set_ops/diff_tests.rs
+++ b/src/iter/intervals/set_ops/diff_tests.rs
@@ -3,12 +3,7 @@ use std::error::Error;
 use jiff::Zoned;
 
 use super::diff::*;
-use crate::intervals::absolute::{
-    AbsoluteBoundPair,
-    AbsoluteEndBound,
-    AbsoluteFiniteBound,
-    EmptiableAbsoluteBoundPair,
-};
+use crate::intervals::absolute::{AbsoluteBoundPair, AbsoluteFiniteBound, EmptiableAbsoluteBoundPair};
 use crate::intervals::meta::BoundInclusivity;
 use crate::intervals::ops::overlap::{CanPositionOverlap, DEFAULT_OVERLAP_RULES, OverlapRuleSet};
 use crate::intervals::ops::remove_overlap_or_gap::{OverlapOrGapRemovalResult, RemovableOverlapOrGap};
@@ -23,53 +18,45 @@ fn peer_difference_run() -> Result<(), Box<dyn Error>> {
         // 1
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
         // 2
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         ),
         // 3
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
         // 4
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
         // 5
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-14 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         ),
         // 6
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
         // 7
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-23 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
     ];
 
@@ -81,17 +68,17 @@ fn peer_difference_run() -> Result<(), Box<dyn Error>> {
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_end_bound(),
                 )),
                 Some(EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound(),
                 ))),
             ),
             // 2, 3
@@ -99,10 +86,11 @@ fn peer_difference_run() -> Result<(), Box<dyn Error>> {
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_end_bound(),
                 )),
                 None,
             ),
@@ -111,10 +99,11 @@ fn peer_difference_run() -> Result<(), Box<dyn Error>> {
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_end_bound(),
                 )),
                 None,
             ),
@@ -123,17 +112,17 @@ fn peer_difference_run() -> Result<(), Box<dyn Error>> {
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new("2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-14 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_end_bound(),
                 )),
                 Some(EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound(),
                 ))),
             ),
             // 5, 6
@@ -141,10 +130,11 @@ fn peer_difference_run() -> Result<(), Box<dyn Error>> {
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new("2025-01-14 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_end_bound(),
                 )),
                 None,
             ),
@@ -153,10 +143,11 @@ fn peer_difference_run() -> Result<(), Box<dyn Error>> {
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-23 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_end_bound(),
                 )),
                 None,
             ),
@@ -175,25 +166,25 @@ fn peer_difference_with_run() -> Result<(), Box<dyn Error>> {
         // 1
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
         // 2
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         ),
         // 3
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         ),
         // 4
         AbsoluteBoundPair::new(
@@ -202,31 +193,26 @@ fn peer_difference_with_run() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Exclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
         // 5
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-14 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         ),
         // 6
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
         // 7
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-23 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
     ];
 
@@ -250,17 +236,17 @@ fn peer_difference_with_run() -> Result<(), Box<dyn Error>> {
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_end_bound(),
                 )),
                 Some(EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound(),
                 ))),
             ),
             // 2, 3
@@ -268,10 +254,11 @@ fn peer_difference_with_run() -> Result<(), Box<dyn Error>> {
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_end_bound(),
                 )),
                 None,
             ),
@@ -280,9 +267,8 @@ fn peer_difference_with_run() -> Result<(), Box<dyn Error>> {
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound(),
                 )),
                 None,
             ),
@@ -294,17 +280,17 @@ fn peer_difference_with_run() -> Result<(), Box<dyn Error>> {
                         BoundInclusivity::Exclusive,
                     )
                     .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-14 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_end_bound(),
                 )),
                 Some(EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound(),
                 ))),
             ),
             // 5, 6
@@ -312,10 +298,11 @@ fn peer_difference_with_run() -> Result<(), Box<dyn Error>> {
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new("2025-01-14 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_end_bound(),
                 )),
                 None,
             ),
@@ -324,10 +311,11 @@ fn peer_difference_with_run() -> Result<(), Box<dyn Error>> {
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-23 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_end_bound(),
                 )),
                 None,
             ),

--- a/src/iter/intervals/set_ops/diff_tests.rs
+++ b/src/iter/intervals/set_ops/diff_tests.rs
@@ -7,7 +7,6 @@ use crate::intervals::absolute::{
     AbsoluteBoundPair,
     AbsoluteEndBound,
     AbsoluteFiniteBound,
-    AbsoluteStartBound,
     EmptiableAbsoluteBoundPair,
 };
 use crate::intervals::meta::BoundInclusivity;
@@ -23,18 +22,14 @@ fn peer_difference_run() -> Result<(), Box<dyn Error>> {
     let bounds = [
         // 1
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
         ),
         // 2
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
@@ -42,27 +37,21 @@ fn peer_difference_run() -> Result<(), Box<dyn Error>> {
         ),
         // 3
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
         ),
         // 4
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
         ),
         // 5
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-14 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-14 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
@@ -70,18 +59,14 @@ fn peer_difference_run() -> Result<(), Box<dyn Error>> {
         ),
         // 6
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
         ),
         // 7
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-23 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-23 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
@@ -94,18 +79,16 @@ fn peer_difference_run() -> Result<(), Box<dyn Error>> {
             // 1, 2
             (
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
                     )),
                 )),
                 Some(EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                         "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                     )),
@@ -114,9 +97,8 @@ fn peer_difference_run() -> Result<(), Box<dyn Error>> {
             // 2, 3
             (
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
@@ -127,9 +109,8 @@ fn peer_difference_run() -> Result<(), Box<dyn Error>> {
             // 3, 4
             (
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
@@ -140,18 +121,16 @@ fn peer_difference_run() -> Result<(), Box<dyn Error>> {
             // 4, 5
             (
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-14 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
                     )),
                 )),
                 Some(EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                         "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                     )),
@@ -160,9 +139,8 @@ fn peer_difference_run() -> Result<(), Box<dyn Error>> {
             // 5, 6
             (
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-14 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-14 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
@@ -173,9 +151,8 @@ fn peer_difference_run() -> Result<(), Box<dyn Error>> {
             // 6, 7
             (
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-23 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
@@ -197,18 +174,14 @@ fn peer_difference_with_run() -> Result<(), Box<dyn Error>> {
     let bounds = [
         // 1
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
         ),
         // 2
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
@@ -216,9 +189,7 @@ fn peer_difference_with_run() -> Result<(), Box<dyn Error>> {
         ),
         // 3
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
@@ -226,19 +197,18 @@ fn peer_difference_with_run() -> Result<(), Box<dyn Error>> {
         ),
         // 4
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
         ),
         // 5
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-14 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-14 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
@@ -246,18 +216,14 @@ fn peer_difference_with_run() -> Result<(), Box<dyn Error>> {
         ),
         // 6
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
         ),
         // 7
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-23 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-23 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
@@ -282,18 +248,16 @@ fn peer_difference_with_run() -> Result<(), Box<dyn Error>> {
             // 1, 2
             (
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
                     )),
                 )),
                 Some(EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                         "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                     )),
@@ -302,9 +266,8 @@ fn peer_difference_with_run() -> Result<(), Box<dyn Error>> {
             // 2, 3
             (
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
@@ -315,9 +278,8 @@ fn peer_difference_with_run() -> Result<(), Box<dyn Error>> {
             // 3, 4
             (
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                         "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                     )),
@@ -327,19 +289,19 @@ fn peer_difference_with_run() -> Result<(), Box<dyn Error>> {
             // 4, 5
             (
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-14 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
                     )),
                 )),
                 Some(EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                         "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                     )),
@@ -348,9 +310,8 @@ fn peer_difference_with_run() -> Result<(), Box<dyn Error>> {
             // 5, 6
             (
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-14 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-14 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
@@ -361,9 +322,8 @@ fn peer_difference_with_run() -> Result<(), Box<dyn Error>> {
             // 6, 7
             (
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-23 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,

--- a/src/iter/intervals/set_ops/intersect_tests.rs
+++ b/src/iter/intervals/set_ops/intersect_tests.rs
@@ -7,7 +7,6 @@ use crate::intervals::absolute::{
     AbsoluteBoundPair,
     AbsoluteEndBound,
     AbsoluteFiniteBound,
-    AbsoluteStartBound,
     EmptiableAbsoluteBoundPair,
 };
 use crate::intervals::meta::BoundInclusivity;
@@ -23,37 +22,32 @@ fn peer_intersection_run() -> Result<(), Box<dyn Error>> {
     let bounds = [
         // 1
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
         ),
         // 2
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
         ),
         // 3
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
         ),
         // 4
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
@@ -61,10 +55,11 @@ fn peer_intersection_run() -> Result<(), Box<dyn Error>> {
         ),
         // 5
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
@@ -72,18 +67,14 @@ fn peer_intersection_run() -> Result<(), Box<dyn Error>> {
         ),
         // 6
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
         ),
         // 7
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
@@ -95,28 +86,27 @@ fn peer_intersection_run() -> Result<(), Box<dyn Error>> {
         vec![
             // 1, 2
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 )),
             ),
             // 2, 3
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 )),
             ),
             // 3, 4
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
@@ -124,10 +114,11 @@ fn peer_intersection_run() -> Result<(), Box<dyn Error>> {
             ),
             // 4, 5
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
@@ -135,9 +126,8 @@ fn peer_intersection_run() -> Result<(), Box<dyn Error>> {
             ),
             // 5, 6
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
@@ -145,9 +135,8 @@ fn peer_intersection_run() -> Result<(), Box<dyn Error>> {
             ),
             // 6, 7
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 )),
@@ -166,37 +155,32 @@ fn peer_intersection_with_run() -> Result<(), Box<dyn Error>> {
     let bounds = [
         // 1
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
         ),
         // 2
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
         ),
         // 3
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
         ),
         // 4
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
@@ -204,10 +188,11 @@ fn peer_intersection_with_run() -> Result<(), Box<dyn Error>> {
         ),
         // 5
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
@@ -215,18 +200,14 @@ fn peer_intersection_with_run() -> Result<(), Box<dyn Error>> {
         ),
         // 6
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
         ),
         // 7
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
@@ -247,28 +228,27 @@ fn peer_intersection_with_run() -> Result<(), Box<dyn Error>> {
         vec![
             // 1, 2
             EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 )),
             )),
             // 2, 3
             EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 )),
             )),
             // 3, 4
             EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
@@ -276,18 +256,16 @@ fn peer_intersection_with_run() -> Result<(), Box<dyn Error>> {
             )),
             // 4, 5
             EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 )),
             )),
             // 5, 6
             EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
@@ -295,9 +273,8 @@ fn peer_intersection_with_run() -> Result<(), Box<dyn Error>> {
             )),
             // 6, 7
             EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 )),

--- a/src/iter/intervals/set_ops/intersect_tests.rs
+++ b/src/iter/intervals/set_ops/intersect_tests.rs
@@ -3,12 +3,7 @@ use std::error::Error;
 use jiff::Zoned;
 
 use super::intersect::*;
-use crate::intervals::absolute::{
-    AbsoluteBoundPair,
-    AbsoluteEndBound,
-    AbsoluteFiniteBound,
-    EmptiableAbsoluteBoundPair,
-};
+use crate::intervals::absolute::{AbsoluteBoundPair, AbsoluteFiniteBound, EmptiableAbsoluteBoundPair};
 use crate::intervals::meta::BoundInclusivity;
 use crate::intervals::ops::abridge::Abridgable;
 use crate::intervals::ops::overlap::{CanPositionOverlap, DEFAULT_OVERLAP_RULES, OverlapRuleSet};
@@ -23,23 +18,17 @@ fn peer_intersection_run() -> Result<(), Box<dyn Error>> {
         // 1
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
         // 2
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
         // 3
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
         // 4
         AbsoluteBoundPair::new(
@@ -48,10 +37,11 @@ fn peer_intersection_run() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Exclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         ),
         // 5
         AbsoluteBoundPair::new(
@@ -60,24 +50,21 @@ fn peer_intersection_run() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Exclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         ),
         // 6
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
         // 7
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
     ];
 
@@ -88,17 +75,15 @@ fn peer_intersection_run() -> Result<(), Box<dyn Error>> {
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
             // 2, 3
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
             // 3, 4
             AbsoluteBoundPair::new(
@@ -107,10 +92,11 @@ fn peer_intersection_run() -> Result<(), Box<dyn Error>> {
                     BoundInclusivity::Exclusive,
                 )
                 .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_end_bound(),
             ),
             // 4, 5
             AbsoluteBoundPair::new(
@@ -119,27 +105,28 @@ fn peer_intersection_run() -> Result<(), Box<dyn Error>> {
                     BoundInclusivity::Exclusive,
                 )
                 .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_end_bound(),
             ),
             // 5, 6
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_end_bound(),
             ),
             // 6, 7
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
         ],
     );
@@ -156,23 +143,17 @@ fn peer_intersection_with_run() -> Result<(), Box<dyn Error>> {
         // 1
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
         // 2
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
         // 3
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
         // 4
         AbsoluteBoundPair::new(
@@ -181,10 +162,11 @@ fn peer_intersection_with_run() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Exclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         ),
         // 5
         AbsoluteBoundPair::new(
@@ -193,24 +175,21 @@ fn peer_intersection_with_run() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Exclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         ),
         // 6
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
         // 7
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
     ];
 
@@ -230,17 +209,15 @@ fn peer_intersection_with_run() -> Result<(), Box<dyn Error>> {
             EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             )),
             // 2, 3
             EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             )),
             // 3, 4
             EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
@@ -249,35 +226,35 @@ fn peer_intersection_with_run() -> Result<(), Box<dyn Error>> {
                     BoundInclusivity::Exclusive,
                 )
                 .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_end_bound(),
             )),
             // 4, 5
             EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             )),
             // 5, 6
             EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_end_bound(),
             )),
             // 6, 7
             EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             )),
         ],
     );

--- a/src/iter/intervals/set_ops/sym_diff_tests.rs
+++ b/src/iter/intervals/set_ops/sym_diff_tests.rs
@@ -3,12 +3,7 @@ use std::error::Error;
 use jiff::Zoned;
 
 use super::sym_diff::*;
-use crate::intervals::absolute::{
-    AbsoluteBoundPair,
-    AbsoluteEndBound,
-    AbsoluteFiniteBound,
-    EmptiableAbsoluteBoundPair,
-};
+use crate::intervals::absolute::{AbsoluteBoundPair, AbsoluteFiniteBound, EmptiableAbsoluteBoundPair};
 use crate::intervals::meta::BoundInclusivity;
 use crate::intervals::ops::overlap::{CanPositionOverlap, DEFAULT_OVERLAP_RULES, OverlapRuleSet};
 use crate::intervals::ops::remove_overlap_or_gap::{OverlapOrGapRemovalResult, RemovableOverlapOrGap};
@@ -23,53 +18,45 @@ fn peer_symmetric_difference_run() -> Result<(), Box<dyn Error>> {
         // 1
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
         // 2
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         ),
         // 3
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
         // 4
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
         // 5
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-14 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         ),
         // 6
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
         // 7
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-23 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
     ];
 
@@ -81,17 +68,17 @@ fn peer_symmetric_difference_run() -> Result<(), Box<dyn Error>> {
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_end_bound(),
                 )),
                 Some(EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound(),
                 ))),
             ),
             // 2, 3
@@ -99,17 +86,17 @@ fn peer_symmetric_difference_run() -> Result<(), Box<dyn Error>> {
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_end_bound(),
                 )),
                 Some(EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound(),
                 ))),
             ),
             // 3, 4
@@ -117,10 +104,11 @@ fn peer_symmetric_difference_run() -> Result<(), Box<dyn Error>> {
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_end_bound(),
                 )),
                 Some(EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new_with_inclusivity(
@@ -128,9 +116,8 @@ fn peer_symmetric_difference_run() -> Result<(), Box<dyn Error>> {
                         BoundInclusivity::Exclusive,
                     )
                     .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound(),
                 ))),
             ),
             // 4, 5
@@ -138,17 +125,17 @@ fn peer_symmetric_difference_run() -> Result<(), Box<dyn Error>> {
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new("2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-14 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_end_bound(),
                 )),
                 Some(EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound(),
                 ))),
             ),
             // 5, 6
@@ -156,17 +143,17 @@ fn peer_symmetric_difference_run() -> Result<(), Box<dyn Error>> {
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new("2025-01-14 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_end_bound(),
                 )),
                 Some(EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound(),
                 ))),
             ),
             // 6, 7
@@ -174,10 +161,11 @@ fn peer_symmetric_difference_run() -> Result<(), Box<dyn Error>> {
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-23 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_end_bound(),
                 )),
                 None,
             ),
@@ -196,25 +184,25 @@ fn peer_symmetric_difference_with_run() -> Result<(), Box<dyn Error>> {
         // 1
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
         // 2
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         ),
         // 3
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         ),
         // 4
         AbsoluteBoundPair::new(
@@ -223,31 +211,26 @@ fn peer_symmetric_difference_with_run() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Exclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
         // 5
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-14 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         ),
         // 6
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
         // 7
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-23 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
     ];
 
@@ -298,17 +281,17 @@ fn peer_symmetric_difference_with_run() -> Result<(), Box<dyn Error>> {
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_end_bound(),
                 )),
                 Some(EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound(),
                 ))),
             ),
             // 2, 3
@@ -316,18 +299,20 @@ fn peer_symmetric_difference_with_run() -> Result<(), Box<dyn Error>> {
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_end_bound(),
                 )),
                 Some(EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_end_bound(),
                 ))),
             ),
             // 3, 4
@@ -335,16 +320,14 @@ fn peer_symmetric_difference_with_run() -> Result<(), Box<dyn Error>> {
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound(),
                 )),
                 Some(EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new("2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound(),
                 ))),
             ),
             // 4, 5
@@ -355,17 +338,17 @@ fn peer_symmetric_difference_with_run() -> Result<(), Box<dyn Error>> {
                         BoundInclusivity::Exclusive,
                     )
                     .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-14 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_end_bound(),
                 )),
                 Some(EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound(),
                 ))),
             ),
             // 5, 6
@@ -373,17 +356,17 @@ fn peer_symmetric_difference_with_run() -> Result<(), Box<dyn Error>> {
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new("2025-01-14 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_end_bound(),
                 )),
                 Some(EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound(),
                 ))),
             ),
             // 6, 7
@@ -391,10 +374,11 @@ fn peer_symmetric_difference_with_run() -> Result<(), Box<dyn Error>> {
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
                     AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound(),
-                    AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-23 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_end_bound(),
                 )),
                 None,
             ),

--- a/src/iter/intervals/set_ops/sym_diff_tests.rs
+++ b/src/iter/intervals/set_ops/sym_diff_tests.rs
@@ -7,7 +7,6 @@ use crate::intervals::absolute::{
     AbsoluteBoundPair,
     AbsoluteEndBound,
     AbsoluteFiniteBound,
-    AbsoluteStartBound,
     EmptiableAbsoluteBoundPair,
 };
 use crate::intervals::meta::BoundInclusivity;
@@ -23,18 +22,14 @@ fn peer_symmetric_difference_run() -> Result<(), Box<dyn Error>> {
     let bounds = [
         // 1
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
         ),
         // 2
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
@@ -42,27 +37,21 @@ fn peer_symmetric_difference_run() -> Result<(), Box<dyn Error>> {
         ),
         // 3
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
         ),
         // 4
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
         ),
         // 5
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-14 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-14 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
@@ -70,18 +59,14 @@ fn peer_symmetric_difference_run() -> Result<(), Box<dyn Error>> {
         ),
         // 6
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
         ),
         // 7
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-23 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-23 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
@@ -94,18 +79,16 @@ fn peer_symmetric_difference_run() -> Result<(), Box<dyn Error>> {
             // 1, 2
             (
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
                     )),
                 )),
                 Some(EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                         "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                     )),
@@ -114,18 +97,16 @@ fn peer_symmetric_difference_run() -> Result<(), Box<dyn Error>> {
             // 2, 3
             (
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
                     )),
                 )),
                 Some(EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                         "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                     )),
@@ -134,19 +115,19 @@ fn peer_symmetric_difference_run() -> Result<(), Box<dyn Error>> {
             // 3, 4
             (
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
                     )),
                 )),
                 Some(EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                         "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                     )),
@@ -155,18 +136,16 @@ fn peer_symmetric_difference_run() -> Result<(), Box<dyn Error>> {
             // 4, 5
             (
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-14 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
                     )),
                 )),
                 Some(EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                         "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                     )),
@@ -175,18 +154,16 @@ fn peer_symmetric_difference_run() -> Result<(), Box<dyn Error>> {
             // 5, 6
             (
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-14 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-14 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
                     )),
                 )),
                 Some(EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                         "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                     )),
@@ -195,9 +172,8 @@ fn peer_symmetric_difference_run() -> Result<(), Box<dyn Error>> {
             // 6, 7
             (
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-23 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
@@ -219,18 +195,14 @@ fn peer_symmetric_difference_with_run() -> Result<(), Box<dyn Error>> {
     let bounds = [
         // 1
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
         ),
         // 2
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
@@ -238,9 +210,7 @@ fn peer_symmetric_difference_with_run() -> Result<(), Box<dyn Error>> {
         ),
         // 3
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
@@ -248,19 +218,18 @@ fn peer_symmetric_difference_with_run() -> Result<(), Box<dyn Error>> {
         ),
         // 4
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
         ),
         // 5
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-14 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-14 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
@@ -268,18 +237,14 @@ fn peer_symmetric_difference_with_run() -> Result<(), Box<dyn Error>> {
         ),
         // 6
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
         ),
         // 7
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-23 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-23 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
@@ -331,18 +296,16 @@ fn peer_symmetric_difference_with_run() -> Result<(), Box<dyn Error>> {
             // 1, 2
             (
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
                     )),
                 )),
                 Some(EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                         "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                     )),
@@ -351,18 +314,16 @@ fn peer_symmetric_difference_with_run() -> Result<(), Box<dyn Error>> {
             // 2, 3
             (
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-03 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
                     )),
                 )),
                 Some(EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
@@ -372,17 +333,15 @@ fn peer_symmetric_difference_with_run() -> Result<(), Box<dyn Error>> {
             // 3, 4
             (
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                         "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                     )),
                 )),
                 Some(EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                         "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                     )),
@@ -391,19 +350,19 @@ fn peer_symmetric_difference_with_run() -> Result<(), Box<dyn Error>> {
             // 4, 5
             (
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                    AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
-                    )),
+                    )
+                    .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-14 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
                     )),
                 )),
                 Some(EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                         "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                     )),
@@ -412,18 +371,16 @@ fn peer_symmetric_difference_with_run() -> Result<(), Box<dyn Error>> {
             // 5, 6
             (
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-14 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-14 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,
                     )),
                 )),
                 Some(EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                         "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                     )),
@@ -432,9 +389,8 @@ fn peer_symmetric_difference_with_run() -> Result<(), Box<dyn Error>> {
             // 6, 7
             (
                 EmptiableAbsoluteBoundPair::Bound(AbsoluteBoundPair::new(
-                    AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                        "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                    )),
+                    AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound(),
                     AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                         "2025-01-23 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                         BoundInclusivity::Exclusive,

--- a/src/iter/intervals/set_ops/unite_tests.rs
+++ b/src/iter/intervals/set_ops/unite_tests.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 use jiff::Zoned;
 
 use super::unite::*;
-use crate::intervals::absolute::{AbsoluteBoundPair, AbsoluteEndBound, AbsoluteFiniteBound, AbsoluteStartBound};
+use crate::intervals::absolute::{AbsoluteBoundPair, AbsoluteEndBound, AbsoluteFiniteBound};
 use crate::intervals::meta::BoundInclusivity;
 use crate::intervals::ops::extend::Extensible;
 use crate::intervals::ops::overlap::{CanPositionOverlap, DEFAULT_OVERLAP_RULES, OverlapRuleSet};
@@ -16,37 +16,32 @@ fn acc_union_run() -> Result<(), Box<dyn Error>> {
     let bounds = [
         // 1
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
         ),
         // 2
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
         ),
         // 3
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-08 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-08 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-12 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
         ),
         // 4
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
@@ -54,10 +49,11 @@ fn acc_union_run() -> Result<(), Box<dyn Error>> {
         ),
         // 5
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-16 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
@@ -65,10 +61,11 @@ fn acc_union_run() -> Result<(), Box<dyn Error>> {
         ),
         // 6
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
@@ -80,19 +77,19 @@ fn acc_union_run() -> Result<(), Box<dyn Error>> {
         bounds.acc_union().collect::<Vec<_>>(),
         vec![
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
                 )),
             ),
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
@@ -111,9 +108,7 @@ fn acc_union_with_run() -> Result<(), Box<dyn Error>> {
     let bounds = [
         // 1
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
@@ -121,28 +116,25 @@ fn acc_union_with_run() -> Result<(), Box<dyn Error>> {
         ),
         // 2
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
         ),
         // 3
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-08 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-08 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-12 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
         ),
         // 4
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
@@ -150,10 +142,11 @@ fn acc_union_with_run() -> Result<(), Box<dyn Error>> {
         ),
         // 5
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-16 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
@@ -161,10 +154,11 @@ fn acc_union_with_run() -> Result<(), Box<dyn Error>> {
         ),
         // 6
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
@@ -172,9 +166,7 @@ fn acc_union_with_run() -> Result<(), Box<dyn Error>> {
         ),
         // 7
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-02-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
@@ -193,18 +185,16 @@ fn acc_union_with_run() -> Result<(), Box<dyn Error>> {
         bounds.acc_union_with(custom_union_f).collect::<Vec<_>>(),
         vec![
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
                 )),
             ),
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-02-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 )),
@@ -223,37 +213,32 @@ fn peer_union_run() -> Result<(), Box<dyn Error>> {
     let bounds = [
         // 1
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
         ),
         // 2
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
         ),
         // 3
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-08 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-08 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-12 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
         ),
         // 4
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
@@ -261,10 +246,11 @@ fn peer_union_run() -> Result<(), Box<dyn Error>> {
         ),
         // 5
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-16 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
@@ -272,10 +258,11 @@ fn peer_union_run() -> Result<(), Box<dyn Error>> {
         ),
         // 6
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
@@ -288,37 +275,35 @@ fn peer_union_run() -> Result<(), Box<dyn Error>> {
         vec![
             // 1, 2
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 )),
             ),
             // 2, 3
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 )),
             ),
             // 3, 4
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-08 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-08 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-12 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 )),
             ),
             // 4, 5
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
@@ -326,10 +311,11 @@ fn peer_union_run() -> Result<(), Box<dyn Error>> {
             ),
             // 5, 6
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-16 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
@@ -349,9 +335,7 @@ fn peer_union_with_run() -> Result<(), Box<dyn Error>> {
     let bounds = [
         // 1
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
@@ -359,28 +343,25 @@ fn peer_union_with_run() -> Result<(), Box<dyn Error>> {
         ),
         // 2
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
         ),
         // 3
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-08 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-08 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-12 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
         ),
         // 4
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
@@ -388,10 +369,11 @@ fn peer_union_with_run() -> Result<(), Box<dyn Error>> {
         ),
         // 5
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-16 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
@@ -399,10 +381,11 @@ fn peer_union_with_run() -> Result<(), Box<dyn Error>> {
         ),
         // 6
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
@@ -410,9 +393,7 @@ fn peer_union_with_run() -> Result<(), Box<dyn Error>> {
         ),
         // 7
         AbsoluteBoundPair::new(
-            AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
             AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-02-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             )),
@@ -432,37 +413,35 @@ fn peer_union_with_run() -> Result<(), Box<dyn Error>> {
         vec![
             // 1, 2
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 )),
             ),
             // 2, 3
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 )),
             ),
             // 3, 4
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-08 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-08 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-12 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 )),
             ),
             // 4, 5
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
@@ -470,10 +449,11 @@ fn peer_union_with_run() -> Result<(), Box<dyn Error>> {
             ),
             // 5, 6
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-16 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
@@ -481,10 +461,11 @@ fn peer_union_with_run() -> Result<(), Box<dyn Error>> {
             ),
             // 6, 7
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,

--- a/src/iter/intervals/set_ops/unite_tests.rs
+++ b/src/iter/intervals/set_ops/unite_tests.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 use jiff::Zoned;
 
 use super::unite::*;
-use crate::intervals::absolute::{AbsoluteBoundPair, AbsoluteEndBound, AbsoluteFiniteBound};
+use crate::intervals::absolute::{AbsoluteBoundPair, AbsoluteFiniteBound};
 use crate::intervals::meta::BoundInclusivity;
 use crate::intervals::ops::extend::Extensible;
 use crate::intervals::ops::overlap::{CanPositionOverlap, DEFAULT_OVERLAP_RULES, OverlapRuleSet};
@@ -17,9 +17,7 @@ fn acc_union_run() -> Result<(), Box<dyn Error>> {
         // 1
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
         // 2
         AbsoluteBoundPair::new(
@@ -28,24 +26,21 @@ fn acc_union_run() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Exclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
         // 3
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-08 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-12 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-12 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
         // 4
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         ),
         // 5
         AbsoluteBoundPair::new(
@@ -54,10 +49,11 @@ fn acc_union_run() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Exclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         ),
         // 6
         AbsoluteBoundPair::new(
@@ -66,10 +62,11 @@ fn acc_union_run() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Exclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         ),
     ];
 
@@ -79,10 +76,11 @@ fn acc_union_run() -> Result<(), Box<dyn Error>> {
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_end_bound(),
             ),
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new_with_inclusivity(
@@ -90,10 +88,11 @@ fn acc_union_run() -> Result<(), Box<dyn Error>> {
                     BoundInclusivity::Exclusive,
                 )
                 .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_end_bound(),
             ),
         ],
     );
@@ -109,10 +108,11 @@ fn acc_union_with_run() -> Result<(), Box<dyn Error>> {
         // 1
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         ),
         // 2
         AbsoluteBoundPair::new(
@@ -121,24 +121,21 @@ fn acc_union_with_run() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Exclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
         // 3
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-08 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-12 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-12 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
         // 4
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         ),
         // 5
         AbsoluteBoundPair::new(
@@ -147,10 +144,11 @@ fn acc_union_with_run() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Exclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         ),
         // 6
         AbsoluteBoundPair::new(
@@ -159,17 +157,16 @@ fn acc_union_with_run() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Exclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         ),
         // 7
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-02-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-02-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
     ];
 
@@ -187,17 +184,17 @@ fn acc_union_with_run() -> Result<(), Box<dyn Error>> {
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_end_bound(),
             ),
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-02-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-02-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
         ],
     );
@@ -214,9 +211,7 @@ fn peer_union_run() -> Result<(), Box<dyn Error>> {
         // 1
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
         // 2
         AbsoluteBoundPair::new(
@@ -225,24 +220,21 @@ fn peer_union_run() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Exclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
         // 3
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-08 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-12 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-12 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
         // 4
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         ),
         // 5
         AbsoluteBoundPair::new(
@@ -251,10 +243,11 @@ fn peer_union_run() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Exclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         ),
         // 6
         AbsoluteBoundPair::new(
@@ -263,10 +256,11 @@ fn peer_union_run() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Exclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         ),
     ];
 
@@ -277,9 +271,8 @@ fn peer_union_run() -> Result<(), Box<dyn Error>> {
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
             // 2, 3
             AbsoluteBoundPair::new(
@@ -288,26 +281,25 @@ fn peer_union_run() -> Result<(), Box<dyn Error>> {
                     BoundInclusivity::Exclusive,
                 )
                 .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
             // 3, 4
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-08 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-12 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-12 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
             // 4, 5
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_end_bound(),
             ),
             // 5, 6
             AbsoluteBoundPair::new(
@@ -316,10 +308,11 @@ fn peer_union_run() -> Result<(), Box<dyn Error>> {
                     BoundInclusivity::Exclusive,
                 )
                 .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_end_bound(),
             ),
         ],
     );
@@ -336,10 +329,11 @@ fn peer_union_with_run() -> Result<(), Box<dyn Error>> {
         // 1
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         ),
         // 2
         AbsoluteBoundPair::new(
@@ -348,24 +342,21 @@ fn peer_union_with_run() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Exclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
         // 3
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-08 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-12 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-01-12 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
         // 4
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         ),
         // 5
         AbsoluteBoundPair::new(
@@ -374,10 +365,11 @@ fn peer_union_with_run() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Exclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         ),
         // 6
         AbsoluteBoundPair::new(
@@ -386,17 +378,16 @@ fn peer_union_with_run() -> Result<(), Box<dyn Error>> {
                 BoundInclusivity::Exclusive,
             )
             .to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+            AbsoluteFiniteBound::new_with_inclusivity(
                 "2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 BoundInclusivity::Exclusive,
-            )),
+            )
+            .to_end_bound(),
         ),
         // 7
         AbsoluteBoundPair::new(
             AbsoluteFiniteBound::new("2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_start_bound(),
-            AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-02-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            )),
+            AbsoluteFiniteBound::new("2025-02-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()).to_end_bound(),
         ),
     ];
 
@@ -415,9 +406,8 @@ fn peer_union_with_run() -> Result<(), Box<dyn Error>> {
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
             // 2, 3
             AbsoluteBoundPair::new(
@@ -426,26 +416,25 @@ fn peer_union_with_run() -> Result<(), Box<dyn Error>> {
                     BoundInclusivity::Exclusive,
                 )
                 .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
             // 3, 4
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-08 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-12 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                )),
+                AbsoluteFiniteBound::new("2025-01-12 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
             // 4, 5
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_end_bound(),
             ),
             // 5, 6
             AbsoluteBoundPair::new(
@@ -454,10 +443,11 @@ fn peer_union_with_run() -> Result<(), Box<dyn Error>> {
                     BoundInclusivity::Exclusive,
                 )
                 .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_end_bound(),
             ),
             // 6, 7
             AbsoluteBoundPair::new(
@@ -466,10 +456,11 @@ fn peer_union_with_run() -> Result<(), Box<dyn Error>> {
                     BoundInclusivity::Exclusive,
                 )
                 .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_end_bound(),
             ),
         ],
     );

--- a/src/iter/intervals/united_bounds_tests.rs
+++ b/src/iter/intervals/united_bounds_tests.rs
@@ -256,11 +256,11 @@ mod rel_united_bounds {
         let data = [
             RelativeBoundPair::new(
                 RelativeFiniteBound::new(SignedDuration::from_hours(11)).to_start_bound(),
-                RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(12))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(12)).to_end_bound(),
             ),
             RelativeBoundPair::new(
                 RelativeFiniteBound::new(SignedDuration::from_hours(16)).to_start_bound(),
-                RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(19))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(19)).to_end_bound(),
             ),
             RelativeBoundPair::new(
                 RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_start_bound(),
@@ -275,50 +275,30 @@ mod rel_united_bounds {
     fn run() {
         let mut data = [
             RelativeBound::Start(RelativeStartBound::InfinitePast),
-            RelativeBound::End(RelativeEndBound::Finite(RelativeFiniteBound::new(
-                SignedDuration::from_hours(1),
-            ))),
+            RelativeBound::End(RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_end_bound()),
             RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(12)).to_start_bound()),
-            RelativeBound::End(RelativeEndBound::Finite(RelativeFiniteBound::new(
-                SignedDuration::from_hours(15),
-            ))),
+            RelativeBound::End(RelativeFiniteBound::new(SignedDuration::from_hours(15)).to_end_bound()),
             RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(20)).to_start_bound()),
-            RelativeBound::End(RelativeEndBound::Finite(RelativeFiniteBound::new(
-                SignedDuration::from_hours(30),
-            ))),
+            RelativeBound::End(RelativeFiniteBound::new(SignedDuration::from_hours(30)).to_end_bound()),
             RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(20)).to_start_bound()),
-            RelativeBound::End(RelativeEndBound::Finite(RelativeFiniteBound::new(
-                SignedDuration::from_hours(22),
-            ))),
+            RelativeBound::End(RelativeFiniteBound::new(SignedDuration::from_hours(22)).to_end_bound()),
             RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(21)).to_start_bound()),
-            RelativeBound::End(RelativeEndBound::Finite(RelativeFiniteBound::new(
-                SignedDuration::from_hours(25),
-            ))),
+            RelativeBound::End(RelativeFiniteBound::new(SignedDuration::from_hours(25)).to_end_bound()),
             RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(23)).to_start_bound()),
-            RelativeBound::End(RelativeEndBound::Finite(RelativeFiniteBound::new(
-                SignedDuration::from_hours(27),
-            ))),
+            RelativeBound::End(RelativeFiniteBound::new(SignedDuration::from_hours(27)).to_end_bound()),
             RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(29)).to_start_bound()),
-            RelativeBound::End(RelativeEndBound::Finite(RelativeFiniteBound::new(
-                SignedDuration::from_hours(35),
-            ))),
+            RelativeBound::End(RelativeFiniteBound::new(SignedDuration::from_hours(35)).to_end_bound()),
             RelativeBound::Start(
                 RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(35), BoundInclusivity::Exclusive)
                     .to_start_bound(),
             ),
-            RelativeBound::End(RelativeEndBound::Finite(RelativeFiniteBound::new(
-                SignedDuration::from_hours(40),
-            ))),
+            RelativeBound::End(RelativeFiniteBound::new(SignedDuration::from_hours(40)).to_end_bound()),
             RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(50)).to_start_bound()),
-            RelativeBound::End(RelativeEndBound::Finite(RelativeFiniteBound::new(
-                SignedDuration::from_hours(55),
-            ))),
+            RelativeBound::End(RelativeFiniteBound::new(SignedDuration::from_hours(55)).to_end_bound()),
             RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(54)).to_start_bound()),
             RelativeBound::End(RelativeEndBound::InfiniteFuture),
             RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_start_bound()),
-            RelativeBound::End(RelativeEndBound::Finite(RelativeFiniteBound::new(
-                SignedDuration::from_hours(201),
-            ))),
+            RelativeBound::End(RelativeFiniteBound::new(SignedDuration::from_hours(201)).to_end_bound()),
         ];
 
         data.sort();
@@ -327,17 +307,11 @@ mod rel_united_bounds {
             RelativeUnitedBoundsIter::new(data.into_iter()).collect::<Vec<_>>(),
             vec![
                 RelativeBound::Start(RelativeStartBound::InfinitePast),
-                RelativeBound::End(RelativeEndBound::Finite(RelativeFiniteBound::new(
-                    SignedDuration::from_hours(1)
-                ))),
+                RelativeBound::End(RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_end_bound()),
                 RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(12)).to_start_bound()),
-                RelativeBound::End(RelativeEndBound::Finite(RelativeFiniteBound::new(
-                    SignedDuration::from_hours(15)
-                ))),
+                RelativeBound::End(RelativeFiniteBound::new(SignedDuration::from_hours(15)).to_end_bound()),
                 RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(20)).to_start_bound()),
-                RelativeBound::End(RelativeEndBound::Finite(RelativeFiniteBound::new(
-                    SignedDuration::from_hours(40)
-                ))),
+                RelativeBound::End(RelativeFiniteBound::new(SignedDuration::from_hours(40)).to_end_bound()),
                 RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(50)).to_start_bound()),
                 RelativeBound::End(RelativeEndBound::InfiniteFuture),
             ],
@@ -349,40 +323,40 @@ mod rel_united_bounds {
         let data = [
             RelativeBoundPair::new(
                 RelativeStartBound::InfinitePast,
-                RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_end_bound(),
             ),
             RelativeBoundPair::new(
                 RelativeFiniteBound::new(SignedDuration::from_hours(12)).to_start_bound(),
-                RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(15))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(15)).to_end_bound(),
             ),
             RelativeBoundPair::new(
                 RelativeFiniteBound::new(SignedDuration::from_hours(20)).to_start_bound(),
-                RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(30))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(30)).to_end_bound(),
             ),
             RelativeBoundPair::new(
                 RelativeFiniteBound::new(SignedDuration::from_hours(20)).to_start_bound(),
-                RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(22))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(22)).to_end_bound(),
             ),
             RelativeBoundPair::new(
                 RelativeFiniteBound::new(SignedDuration::from_hours(21)).to_start_bound(),
-                RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(25))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(25)).to_end_bound(),
             ),
             RelativeBoundPair::new(
                 RelativeFiniteBound::new(SignedDuration::from_hours(23)).to_start_bound(),
-                RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(27))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(27)).to_end_bound(),
             ),
             RelativeBoundPair::new(
                 RelativeFiniteBound::new(SignedDuration::from_hours(29)).to_start_bound(),
-                RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(35))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(35)).to_end_bound(),
             ),
             RelativeBoundPair::new(
                 RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(35), BoundInclusivity::Exclusive)
                     .to_start_bound(),
-                RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(40))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(40)).to_end_bound(),
             ),
             RelativeBoundPair::new(
                 RelativeFiniteBound::new(SignedDuration::from_hours(50)).to_start_bound(),
-                RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(55))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(55)).to_end_bound(),
             ),
             RelativeBoundPair::new(
                 RelativeFiniteBound::new(SignedDuration::from_hours(54)).to_start_bound(),
@@ -390,7 +364,7 @@ mod rel_united_bounds {
             ),
             RelativeBoundPair::new(
                 RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_start_bound(),
-                RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(201))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(201)).to_end_bound(),
             ),
         ];
 
@@ -398,17 +372,11 @@ mod rel_united_bounds {
             data.rel_bounds_iter().unite_bounds().collect::<Vec<_>>(),
             vec![
                 RelativeBound::Start(RelativeStartBound::InfinitePast),
-                RelativeBound::End(RelativeEndBound::Finite(RelativeFiniteBound::new(
-                    SignedDuration::from_hours(1)
-                ))),
+                RelativeBound::End(RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_end_bound()),
                 RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(12)).to_start_bound()),
-                RelativeBound::End(RelativeEndBound::Finite(RelativeFiniteBound::new(
-                    SignedDuration::from_hours(15)
-                ))),
+                RelativeBound::End(RelativeFiniteBound::new(SignedDuration::from_hours(15)).to_end_bound()),
                 RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(20)).to_start_bound()),
-                RelativeBound::End(RelativeEndBound::Finite(RelativeFiniteBound::new(
-                    SignedDuration::from_hours(40)
-                ))),
+                RelativeBound::End(RelativeFiniteBound::new(SignedDuration::from_hours(40)).to_end_bound()),
                 RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(50)).to_start_bound()),
                 RelativeBound::End(RelativeEndBound::InfiniteFuture),
             ],

--- a/src/iter/intervals/united_bounds_tests.rs
+++ b/src/iter/intervals/united_bounds_tests.rs
@@ -27,25 +27,22 @@ mod abs_united_bounds {
     fn create() -> Result<(), Box<dyn Error>> {
         let data = [
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 )),
             ),
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-06 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-06 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 )),
             ),
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2024-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2024-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::InfiniteFuture,
             ),
         ];
@@ -62,62 +59,74 @@ mod abs_united_bounds {
             AbsoluteBound::End(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2024-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             ))),
-            AbsoluteBound::Start(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            ))),
+            AbsoluteBound::Start(
+                AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
+            ),
             AbsoluteBound::End(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             ))),
-            AbsoluteBound::Start(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            ))),
+            AbsoluteBound::Start(
+                AbsoluteFiniteBound::new("2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
+            ),
             AbsoluteBound::End(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             ))),
-            AbsoluteBound::Start(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            ))),
+            AbsoluteBound::Start(
+                AbsoluteFiniteBound::new("2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
+            ),
             AbsoluteBound::End(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-12 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             ))),
-            AbsoluteBound::Start(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-11 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            ))),
+            AbsoluteBound::Start(
+                AbsoluteFiniteBound::new("2025-01-11 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
+            ),
             AbsoluteBound::End(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             ))),
-            AbsoluteBound::Start(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-13 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            ))),
+            AbsoluteBound::Start(
+                AbsoluteFiniteBound::new("2025-01-13 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
+            ),
             AbsoluteBound::End(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-17 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             ))),
-            AbsoluteBound::Start(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-19 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            ))),
+            AbsoluteBound::Start(
+                AbsoluteFiniteBound::new("2025-01-19 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
+            ),
             AbsoluteBound::End(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             ))),
-            AbsoluteBound::Start(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
-                "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                BoundInclusivity::Exclusive,
-            ))),
+            AbsoluteBound::Start(
+                AbsoluteFiniteBound::new_with_inclusivity(
+                    "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                    BoundInclusivity::Exclusive,
+                )
+                .to_start_bound(),
+            ),
             AbsoluteBound::End(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             ))),
-            AbsoluteBound::Start(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            ))),
+            AbsoluteBound::Start(
+                AbsoluteFiniteBound::new("2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
+            ),
             AbsoluteBound::End(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             ))),
-            AbsoluteBound::Start(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-02-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            ))),
+            AbsoluteBound::Start(
+                AbsoluteFiniteBound::new("2025-02-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
+            ),
             AbsoluteBound::End(AbsoluteEndBound::InfiniteFuture),
-            AbsoluteBound::Start(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                "2025-05-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            ))),
+            AbsoluteBound::Start(
+                AbsoluteFiniteBound::new("2025-05-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
+            ),
             AbsoluteBound::End(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                 "2025-06-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
             ))),
@@ -132,21 +141,24 @@ mod abs_united_bounds {
                 AbsoluteBound::End(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2024-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 ))),
-                AbsoluteBound::Start(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                ))),
+                AbsoluteBound::Start(
+                    AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound()
+                ),
                 AbsoluteBound::End(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 ))),
-                AbsoluteBound::Start(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                ))),
+                AbsoluteBound::Start(
+                    AbsoluteFiniteBound::new("2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound()
+                ),
                 AbsoluteBound::End(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 ))),
-                AbsoluteBound::Start(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                ))),
+                AbsoluteBound::Start(
+                    AbsoluteFiniteBound::new("2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound()
+                ),
                 AbsoluteBound::End(AbsoluteEndBound::InfiniteFuture),
             ],
         );
@@ -165,80 +177,72 @@ mod abs_united_bounds {
                 )),
             ),
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 )),
             ),
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 )),
             ),
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-12 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 )),
             ),
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-11 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-11 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 )),
             ),
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-13 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-13 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-17 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 )),
             ),
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-19 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-19 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 )),
             ),
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new_with_inclusivity(
+                AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                     BoundInclusivity::Exclusive,
-                )),
+                )
+                .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 )),
             ),
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 )),
             ),
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-02-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-02-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::InfiniteFuture,
             ),
             AbsoluteBoundPair::new(
-                AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-05-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-05-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound(),
                 AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-06-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
                 )),
@@ -252,21 +256,24 @@ mod abs_united_bounds {
                 AbsoluteBound::End(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2024-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 ))),
-                AbsoluteBound::Start(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                ))),
+                AbsoluteBound::Start(
+                    AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound()
+                ),
                 AbsoluteBound::End(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 ))),
-                AbsoluteBound::Start(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                ))),
+                AbsoluteBound::Start(
+                    AbsoluteFiniteBound::new("2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound()
+                ),
                 AbsoluteBound::End(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
                     "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
                 ))),
-                AbsoluteBound::Start(AbsoluteStartBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                ))),
+                AbsoluteBound::Start(
+                    AbsoluteFiniteBound::new("2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_start_bound()
+                ),
                 AbsoluteBound::End(AbsoluteEndBound::InfiniteFuture),
             ],
         );

--- a/src/iter/intervals/united_bounds_tests.rs
+++ b/src/iter/intervals/united_bounds_tests.rs
@@ -255,15 +255,15 @@ mod rel_united_bounds {
     fn create() {
         let data = [
             RelativeBoundPair::new(
-                RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(11))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(11)).to_start_bound(),
                 RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(12))),
             ),
             RelativeBoundPair::new(
-                RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(16))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(16)).to_start_bound(),
                 RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(19))),
             ),
             RelativeBoundPair::new(
-                RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_start_bound(),
                 RelativeEndBound::InfiniteFuture,
             ),
         ];
@@ -278,62 +278,44 @@ mod rel_united_bounds {
             RelativeBound::End(RelativeEndBound::Finite(RelativeFiniteBound::new(
                 SignedDuration::from_hours(1),
             ))),
-            RelativeBound::Start(RelativeStartBound::Finite(RelativeFiniteBound::new(
-                SignedDuration::from_hours(12),
-            ))),
+            RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(12)).to_start_bound()),
             RelativeBound::End(RelativeEndBound::Finite(RelativeFiniteBound::new(
                 SignedDuration::from_hours(15),
             ))),
-            RelativeBound::Start(RelativeStartBound::Finite(RelativeFiniteBound::new(
-                SignedDuration::from_hours(20),
-            ))),
+            RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(20)).to_start_bound()),
             RelativeBound::End(RelativeEndBound::Finite(RelativeFiniteBound::new(
                 SignedDuration::from_hours(30),
             ))),
-            RelativeBound::Start(RelativeStartBound::Finite(RelativeFiniteBound::new(
-                SignedDuration::from_hours(20),
-            ))),
+            RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(20)).to_start_bound()),
             RelativeBound::End(RelativeEndBound::Finite(RelativeFiniteBound::new(
                 SignedDuration::from_hours(22),
             ))),
-            RelativeBound::Start(RelativeStartBound::Finite(RelativeFiniteBound::new(
-                SignedDuration::from_hours(21),
-            ))),
+            RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(21)).to_start_bound()),
             RelativeBound::End(RelativeEndBound::Finite(RelativeFiniteBound::new(
                 SignedDuration::from_hours(25),
             ))),
-            RelativeBound::Start(RelativeStartBound::Finite(RelativeFiniteBound::new(
-                SignedDuration::from_hours(23),
-            ))),
+            RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(23)).to_start_bound()),
             RelativeBound::End(RelativeEndBound::Finite(RelativeFiniteBound::new(
                 SignedDuration::from_hours(27),
             ))),
-            RelativeBound::Start(RelativeStartBound::Finite(RelativeFiniteBound::new(
-                SignedDuration::from_hours(29),
-            ))),
+            RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(29)).to_start_bound()),
             RelativeBound::End(RelativeEndBound::Finite(RelativeFiniteBound::new(
                 SignedDuration::from_hours(35),
             ))),
-            RelativeBound::Start(RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                SignedDuration::from_hours(35),
-                BoundInclusivity::Exclusive,
-            ))),
+            RelativeBound::Start(
+                RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(35), BoundInclusivity::Exclusive)
+                    .to_start_bound(),
+            ),
             RelativeBound::End(RelativeEndBound::Finite(RelativeFiniteBound::new(
                 SignedDuration::from_hours(40),
             ))),
-            RelativeBound::Start(RelativeStartBound::Finite(RelativeFiniteBound::new(
-                SignedDuration::from_hours(50),
-            ))),
+            RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(50)).to_start_bound()),
             RelativeBound::End(RelativeEndBound::Finite(RelativeFiniteBound::new(
                 SignedDuration::from_hours(55),
             ))),
-            RelativeBound::Start(RelativeStartBound::Finite(RelativeFiniteBound::new(
-                SignedDuration::from_hours(54),
-            ))),
+            RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(54)).to_start_bound()),
             RelativeBound::End(RelativeEndBound::InfiniteFuture),
-            RelativeBound::Start(RelativeStartBound::Finite(RelativeFiniteBound::new(
-                SignedDuration::from_hours(101),
-            ))),
+            RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_start_bound()),
             RelativeBound::End(RelativeEndBound::Finite(RelativeFiniteBound::new(
                 SignedDuration::from_hours(201),
             ))),
@@ -348,21 +330,15 @@ mod rel_united_bounds {
                 RelativeBound::End(RelativeEndBound::Finite(RelativeFiniteBound::new(
                     SignedDuration::from_hours(1)
                 ))),
-                RelativeBound::Start(RelativeStartBound::Finite(RelativeFiniteBound::new(
-                    SignedDuration::from_hours(12)
-                ))),
+                RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(12)).to_start_bound()),
                 RelativeBound::End(RelativeEndBound::Finite(RelativeFiniteBound::new(
                     SignedDuration::from_hours(15)
                 ))),
-                RelativeBound::Start(RelativeStartBound::Finite(RelativeFiniteBound::new(
-                    SignedDuration::from_hours(20)
-                ))),
+                RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(20)).to_start_bound()),
                 RelativeBound::End(RelativeEndBound::Finite(RelativeFiniteBound::new(
                     SignedDuration::from_hours(40)
                 ))),
-                RelativeBound::Start(RelativeStartBound::Finite(RelativeFiniteBound::new(
-                    SignedDuration::from_hours(50)
-                ))),
+                RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(50)).to_start_bound()),
                 RelativeBound::End(RelativeEndBound::InfiniteFuture),
             ],
         );
@@ -376,46 +352,44 @@ mod rel_united_bounds {
                 RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(1))),
             ),
             RelativeBoundPair::new(
-                RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(12))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(12)).to_start_bound(),
                 RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(15))),
             ),
             RelativeBoundPair::new(
-                RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(20))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(20)).to_start_bound(),
                 RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(30))),
             ),
             RelativeBoundPair::new(
-                RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(20))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(20)).to_start_bound(),
                 RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(22))),
             ),
             RelativeBoundPair::new(
-                RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(21))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(21)).to_start_bound(),
                 RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(25))),
             ),
             RelativeBoundPair::new(
-                RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(23))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(23)).to_start_bound(),
                 RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(27))),
             ),
             RelativeBoundPair::new(
-                RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(29))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(29)).to_start_bound(),
                 RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(35))),
             ),
             RelativeBoundPair::new(
-                RelativeStartBound::Finite(RelativeFiniteBound::new_with_inclusivity(
-                    SignedDuration::from_hours(35),
-                    BoundInclusivity::Exclusive,
-                )),
+                RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(35), BoundInclusivity::Exclusive)
+                    .to_start_bound(),
                 RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(40))),
             ),
             RelativeBoundPair::new(
-                RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(50))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(50)).to_start_bound(),
                 RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(55))),
             ),
             RelativeBoundPair::new(
-                RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(54))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(54)).to_start_bound(),
                 RelativeEndBound::InfiniteFuture,
             ),
             RelativeBoundPair::new(
-                RelativeStartBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(101))),
+                RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_start_bound(),
                 RelativeEndBound::Finite(RelativeFiniteBound::new(SignedDuration::from_hours(201))),
             ),
         ];
@@ -427,21 +401,15 @@ mod rel_united_bounds {
                 RelativeBound::End(RelativeEndBound::Finite(RelativeFiniteBound::new(
                     SignedDuration::from_hours(1)
                 ))),
-                RelativeBound::Start(RelativeStartBound::Finite(RelativeFiniteBound::new(
-                    SignedDuration::from_hours(12)
-                ))),
+                RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(12)).to_start_bound()),
                 RelativeBound::End(RelativeEndBound::Finite(RelativeFiniteBound::new(
                     SignedDuration::from_hours(15)
                 ))),
-                RelativeBound::Start(RelativeStartBound::Finite(RelativeFiniteBound::new(
-                    SignedDuration::from_hours(20)
-                ))),
+                RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(20)).to_start_bound()),
                 RelativeBound::End(RelativeEndBound::Finite(RelativeFiniteBound::new(
                     SignedDuration::from_hours(40)
                 ))),
-                RelativeBound::Start(RelativeStartBound::Finite(RelativeFiniteBound::new(
-                    SignedDuration::from_hours(50)
-                ))),
+                RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(50)).to_start_bound()),
                 RelativeBound::End(RelativeEndBound::InfiniteFuture),
             ],
         );

--- a/src/iter/intervals/united_bounds_tests.rs
+++ b/src/iter/intervals/united_bounds_tests.rs
@@ -3,13 +3,7 @@ use std::error::Error;
 use jiff::{SignedDuration, Zoned};
 
 use super::united_bounds::*;
-use crate::intervals::absolute::{
-    AbsoluteBound,
-    AbsoluteBoundPair,
-    AbsoluteEndBound,
-    AbsoluteFiniteBound,
-    AbsoluteStartBound,
-};
+use crate::intervals::absolute::{AbsoluteBoundPair, AbsoluteEndBound, AbsoluteFiniteBound, AbsoluteStartBound};
 use crate::intervals::meta::BoundInclusivity;
 use crate::intervals::relative::{
     RelativeBound,
@@ -53,91 +47,71 @@ mod abs_united_bounds {
     #[test]
     fn run() -> Result<(), Box<dyn Error>> {
         let mut data = [
-            AbsoluteBound::Start(AbsoluteStartBound::InfinitePast),
-            AbsoluteBound::End(
-                AbsoluteFiniteBound::new("2024-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
-                    .to_end_bound(),
-            ),
-            AbsoluteBound::Start(
-                AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
-                    .to_start_bound(),
-            ),
-            AbsoluteBound::End(
-                AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
-                    .to_end_bound(),
-            ),
-            AbsoluteBound::Start(
-                AbsoluteFiniteBound::new("2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
-                    .to_start_bound(),
-            ),
-            AbsoluteBound::End(
-                AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
-                    .to_end_bound(),
-            ),
-            AbsoluteBound::Start(
-                AbsoluteFiniteBound::new("2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
-                    .to_start_bound(),
-            ),
-            AbsoluteBound::End(
-                AbsoluteFiniteBound::new("2025-01-12 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
-                    .to_end_bound(),
-            ),
-            AbsoluteBound::Start(
-                AbsoluteFiniteBound::new("2025-01-11 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
-                    .to_start_bound(),
-            ),
-            AbsoluteBound::End(
-                AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
-                    .to_end_bound(),
-            ),
-            AbsoluteBound::Start(
-                AbsoluteFiniteBound::new("2025-01-13 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
-                    .to_start_bound(),
-            ),
-            AbsoluteBound::End(
-                AbsoluteFiniteBound::new("2025-01-17 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
-                    .to_end_bound(),
-            ),
-            AbsoluteBound::Start(
-                AbsoluteFiniteBound::new("2025-01-19 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
-                    .to_start_bound(),
-            ),
-            AbsoluteBound::End(
-                AbsoluteFiniteBound::new("2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
-                    .to_end_bound(),
-            ),
-            AbsoluteBound::Start(
-                AbsoluteFiniteBound::new_with_inclusivity(
-                    "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                    BoundInclusivity::Exclusive,
-                )
-                .to_start_bound(),
-            ),
-            AbsoluteBound::End(
-                AbsoluteFiniteBound::new("2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
-                    .to_end_bound(),
-            ),
-            AbsoluteBound::Start(
-                AbsoluteFiniteBound::new("2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
-                    .to_start_bound(),
-            ),
-            AbsoluteBound::End(
-                AbsoluteFiniteBound::new("2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
-                    .to_end_bound(),
-            ),
-            AbsoluteBound::Start(
-                AbsoluteFiniteBound::new("2025-02-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
-                    .to_start_bound(),
-            ),
-            AbsoluteBound::End(AbsoluteEndBound::InfiniteFuture),
-            AbsoluteBound::Start(
-                AbsoluteFiniteBound::new("2025-05-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
-                    .to_start_bound(),
-            ),
-            AbsoluteBound::End(
-                AbsoluteFiniteBound::new("2025-06-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
-                    .to_end_bound(),
-            ),
+            AbsoluteStartBound::InfinitePast.to_bound(),
+            AbsoluteFiniteBound::new("2024-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                .to_end_bound()
+                .to_bound(),
+            AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                .to_start_bound()
+                .to_bound(),
+            AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                .to_end_bound()
+                .to_bound(),
+            AbsoluteFiniteBound::new("2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                .to_start_bound()
+                .to_bound(),
+            AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                .to_end_bound()
+                .to_bound(),
+            AbsoluteFiniteBound::new("2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                .to_start_bound()
+                .to_bound(),
+            AbsoluteFiniteBound::new("2025-01-12 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                .to_end_bound()
+                .to_bound(),
+            AbsoluteFiniteBound::new("2025-01-11 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                .to_start_bound()
+                .to_bound(),
+            AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                .to_end_bound()
+                .to_bound(),
+            AbsoluteFiniteBound::new("2025-01-13 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                .to_start_bound()
+                .to_bound(),
+            AbsoluteFiniteBound::new("2025-01-17 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                .to_end_bound()
+                .to_bound(),
+            AbsoluteFiniteBound::new("2025-01-19 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                .to_start_bound()
+                .to_bound(),
+            AbsoluteFiniteBound::new("2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                .to_end_bound()
+                .to_bound(),
+            AbsoluteFiniteBound::new_with_inclusivity(
+                "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
+                BoundInclusivity::Exclusive,
+            )
+            .to_start_bound()
+            .to_bound(),
+            AbsoluteFiniteBound::new("2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                .to_end_bound()
+                .to_bound(),
+            AbsoluteFiniteBound::new("2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                .to_start_bound()
+                .to_bound(),
+            AbsoluteFiniteBound::new("2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                .to_end_bound()
+                .to_bound(),
+            AbsoluteFiniteBound::new("2025-02-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                .to_start_bound()
+                .to_bound(),
+            AbsoluteEndBound::InfiniteFuture.to_bound(),
+            AbsoluteFiniteBound::new("2025-05-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                .to_start_bound()
+                .to_bound(),
+            AbsoluteFiniteBound::new("2025-06-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                .to_end_bound()
+                .to_bound(),
         ];
 
         data.sort();
@@ -145,32 +119,26 @@ mod abs_united_bounds {
         assert_eq!(
             AbsoluteUnitedBoundsIter::new(data.into_iter()).collect::<Vec<_>>(),
             vec![
-                AbsoluteBound::Start(AbsoluteStartBound::InfinitePast),
-                AbsoluteBound::End(
-                    AbsoluteFiniteBound::new("2024-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
-                        .to_end_bound()
-                ),
-                AbsoluteBound::Start(
-                    AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
-                        .to_start_bound()
-                ),
-                AbsoluteBound::End(
-                    AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
-                        .to_end_bound()
-                ),
-                AbsoluteBound::Start(
-                    AbsoluteFiniteBound::new("2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
-                        .to_start_bound()
-                ),
-                AbsoluteBound::End(
-                    AbsoluteFiniteBound::new("2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
-                        .to_end_bound()
-                ),
-                AbsoluteBound::Start(
-                    AbsoluteFiniteBound::new("2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
-                        .to_start_bound()
-                ),
-                AbsoluteBound::End(AbsoluteEndBound::InfiniteFuture),
+                AbsoluteStartBound::InfinitePast.to_bound(),
+                AbsoluteFiniteBound::new("2024-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound()
+                    .to_bound(),
+                AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound()
+                    .to_bound(),
+                AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound()
+                    .to_bound(),
+                AbsoluteFiniteBound::new("2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound()
+                    .to_bound(),
+                AbsoluteFiniteBound::new("2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound()
+                    .to_bound(),
+                AbsoluteFiniteBound::new("2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound()
+                    .to_bound(),
+                AbsoluteEndBound::InfiniteFuture.to_bound(),
             ],
         );
 
@@ -253,32 +221,26 @@ mod abs_united_bounds {
         assert_eq!(
             data.abs_bounds_iter().unite_bounds().collect::<Vec<_>>(),
             vec![
-                AbsoluteBound::Start(AbsoluteStartBound::InfinitePast),
-                AbsoluteBound::End(
-                    AbsoluteFiniteBound::new("2024-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
-                        .to_end_bound()
-                ),
-                AbsoluteBound::Start(
-                    AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
-                        .to_start_bound()
-                ),
-                AbsoluteBound::End(
-                    AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
-                        .to_end_bound()
-                ),
-                AbsoluteBound::Start(
-                    AbsoluteFiniteBound::new("2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
-                        .to_start_bound()
-                ),
-                AbsoluteBound::End(
-                    AbsoluteFiniteBound::new("2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
-                        .to_end_bound()
-                ),
-                AbsoluteBound::Start(
-                    AbsoluteFiniteBound::new("2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
-                        .to_start_bound()
-                ),
-                AbsoluteBound::End(AbsoluteEndBound::InfiniteFuture),
+                AbsoluteStartBound::InfinitePast.to_bound(),
+                AbsoluteFiniteBound::new("2024-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound()
+                    .to_bound(),
+                AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound()
+                    .to_bound(),
+                AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound()
+                    .to_bound(),
+                AbsoluteFiniteBound::new("2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound()
+                    .to_bound(),
+                AbsoluteFiniteBound::new("2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound()
+                    .to_bound(),
+                AbsoluteFiniteBound::new("2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_start_bound()
+                    .to_bound(),
+                AbsoluteEndBound::InfiniteFuture.to_bound(),
             ],
         );
 

--- a/src/iter/intervals/united_bounds_tests.rs
+++ b/src/iter/intervals/united_bounds_tests.rs
@@ -29,16 +29,14 @@ mod abs_united_bounds {
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-06 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2024-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
@@ -56,51 +54,58 @@ mod abs_united_bounds {
     fn run() -> Result<(), Box<dyn Error>> {
         let mut data = [
             AbsoluteBound::Start(AbsoluteStartBound::InfinitePast),
-            AbsoluteBound::End(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2024-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            ))),
+            AbsoluteBound::End(
+                AbsoluteFiniteBound::new("2024-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
+            ),
             AbsoluteBound::Start(
                 AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
             ),
-            AbsoluteBound::End(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            ))),
+            AbsoluteBound::End(
+                AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
+            ),
             AbsoluteBound::Start(
                 AbsoluteFiniteBound::new("2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
             ),
-            AbsoluteBound::End(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            ))),
+            AbsoluteBound::End(
+                AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
+            ),
             AbsoluteBound::Start(
                 AbsoluteFiniteBound::new("2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
             ),
-            AbsoluteBound::End(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-12 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            ))),
+            AbsoluteBound::End(
+                AbsoluteFiniteBound::new("2025-01-12 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
+            ),
             AbsoluteBound::Start(
                 AbsoluteFiniteBound::new("2025-01-11 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
             ),
-            AbsoluteBound::End(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            ))),
+            AbsoluteBound::End(
+                AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
+            ),
             AbsoluteBound::Start(
                 AbsoluteFiniteBound::new("2025-01-13 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
             ),
-            AbsoluteBound::End(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-17 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            ))),
+            AbsoluteBound::End(
+                AbsoluteFiniteBound::new("2025-01-17 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
+            ),
             AbsoluteBound::Start(
                 AbsoluteFiniteBound::new("2025-01-19 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
             ),
-            AbsoluteBound::End(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            ))),
+            AbsoluteBound::End(
+                AbsoluteFiniteBound::new("2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
+            ),
             AbsoluteBound::Start(
                 AbsoluteFiniteBound::new_with_inclusivity(
                     "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
@@ -108,16 +113,18 @@ mod abs_united_bounds {
                 )
                 .to_start_bound(),
             ),
-            AbsoluteBound::End(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            ))),
+            AbsoluteBound::End(
+                AbsoluteFiniteBound::new("2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
+            ),
             AbsoluteBound::Start(
                 AbsoluteFiniteBound::new("2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
             ),
-            AbsoluteBound::End(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            ))),
+            AbsoluteBound::End(
+                AbsoluteFiniteBound::new("2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
+            ),
             AbsoluteBound::Start(
                 AbsoluteFiniteBound::new("2025-02-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
@@ -127,9 +134,10 @@ mod abs_united_bounds {
                 AbsoluteFiniteBound::new("2025-05-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
             ),
-            AbsoluteBound::End(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                "2025-06-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-            ))),
+            AbsoluteBound::End(
+                AbsoluteFiniteBound::new("2025-06-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
+            ),
         ];
 
         data.sort();
@@ -138,23 +146,26 @@ mod abs_united_bounds {
             AbsoluteUnitedBoundsIter::new(data.into_iter()).collect::<Vec<_>>(),
             vec![
                 AbsoluteBound::Start(AbsoluteStartBound::InfinitePast),
-                AbsoluteBound::End(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2024-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                ))),
+                AbsoluteBound::End(
+                    AbsoluteFiniteBound::new("2024-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound()
+                ),
                 AbsoluteBound::Start(
                     AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound()
                 ),
-                AbsoluteBound::End(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                ))),
+                AbsoluteBound::End(
+                    AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound()
+                ),
                 AbsoluteBound::Start(
                     AbsoluteFiniteBound::new("2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound()
                 ),
-                AbsoluteBound::End(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                ))),
+                AbsoluteBound::End(
+                    AbsoluteFiniteBound::new("2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound()
+                ),
                 AbsoluteBound::Start(
                     AbsoluteFiniteBound::new("2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound()
@@ -172,51 +183,44 @@ mod abs_united_bounds {
         let data = [
             AbsoluteBoundPair::new(
                 AbsoluteStartBound::InfinitePast,
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2024-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2024-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-20 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-12 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-12 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-11 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-15 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-13 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-17 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-17 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-01-19 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-25 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new_with_inclusivity(
@@ -224,16 +228,14 @@ mod abs_united_bounds {
                     BoundInclusivity::Exclusive,
                 )
                 .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-02-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-02-04 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
@@ -243,9 +245,8 @@ mod abs_united_bounds {
             AbsoluteBoundPair::new(
                 AbsoluteFiniteBound::new("2025-05-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                     .to_start_bound(),
-                AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-06-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp(),
-                )),
+                AbsoluteFiniteBound::new("2025-06-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                    .to_end_bound(),
             ),
         ];
 
@@ -253,23 +254,26 @@ mod abs_united_bounds {
             data.abs_bounds_iter().unite_bounds().collect::<Vec<_>>(),
             vec![
                 AbsoluteBound::Start(AbsoluteStartBound::InfinitePast),
-                AbsoluteBound::End(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2024-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                ))),
+                AbsoluteBound::End(
+                    AbsoluteFiniteBound::new("2024-01-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound()
+                ),
                 AbsoluteBound::Start(
                     AbsoluteFiniteBound::new("2025-01-02 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound()
                 ),
-                AbsoluteBound::End(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                ))),
+                AbsoluteBound::End(
+                    AbsoluteFiniteBound::new("2025-01-05 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound()
+                ),
                 AbsoluteBound::Start(
                     AbsoluteFiniteBound::new("2025-01-10 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound()
                 ),
-                AbsoluteBound::End(AbsoluteEndBound::Finite(AbsoluteFiniteBound::new(
-                    "2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp()
-                ))),
+                AbsoluteBound::End(
+                    AbsoluteFiniteBound::new("2025-01-30 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
+                        .to_end_bound()
+                ),
                 AbsoluteBound::Start(
                     AbsoluteFiniteBound::new("2025-02-01 00:00:00[Europe/Oslo]".parse::<Zoned>()?.timestamp())
                         .to_start_bound()

--- a/src/iter/intervals/united_bounds_tests.rs
+++ b/src/iter/intervals/united_bounds_tests.rs
@@ -5,13 +5,7 @@ use jiff::{SignedDuration, Zoned};
 use super::united_bounds::*;
 use crate::intervals::absolute::{AbsoluteBoundPair, AbsoluteEndBound, AbsoluteFiniteBound, AbsoluteStartBound};
 use crate::intervals::meta::BoundInclusivity;
-use crate::intervals::relative::{
-    RelativeBound,
-    RelativeBoundPair,
-    RelativeEndBound,
-    RelativeFiniteBound,
-    RelativeStartBound,
-};
+use crate::intervals::relative::{RelativeBoundPair, RelativeEndBound, RelativeFiniteBound, RelativeStartBound};
 use crate::iter::intervals::bounds::{AbsoluteBoundsIteratorDispatcher, RelativeBoundsIteratorDispatcher};
 
 mod abs_united_bounds {
@@ -274,31 +268,68 @@ mod rel_united_bounds {
     #[test]
     fn run() {
         let mut data = [
-            RelativeBound::Start(RelativeStartBound::InfinitePast),
-            RelativeBound::End(RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_end_bound()),
-            RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(12)).to_start_bound()),
-            RelativeBound::End(RelativeFiniteBound::new(SignedDuration::from_hours(15)).to_end_bound()),
-            RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(20)).to_start_bound()),
-            RelativeBound::End(RelativeFiniteBound::new(SignedDuration::from_hours(30)).to_end_bound()),
-            RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(20)).to_start_bound()),
-            RelativeBound::End(RelativeFiniteBound::new(SignedDuration::from_hours(22)).to_end_bound()),
-            RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(21)).to_start_bound()),
-            RelativeBound::End(RelativeFiniteBound::new(SignedDuration::from_hours(25)).to_end_bound()),
-            RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(23)).to_start_bound()),
-            RelativeBound::End(RelativeFiniteBound::new(SignedDuration::from_hours(27)).to_end_bound()),
-            RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(29)).to_start_bound()),
-            RelativeBound::End(RelativeFiniteBound::new(SignedDuration::from_hours(35)).to_end_bound()),
-            RelativeBound::Start(
-                RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(35), BoundInclusivity::Exclusive)
-                    .to_start_bound(),
-            ),
-            RelativeBound::End(RelativeFiniteBound::new(SignedDuration::from_hours(40)).to_end_bound()),
-            RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(50)).to_start_bound()),
-            RelativeBound::End(RelativeFiniteBound::new(SignedDuration::from_hours(55)).to_end_bound()),
-            RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(54)).to_start_bound()),
-            RelativeBound::End(RelativeEndBound::InfiniteFuture),
-            RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(101)).to_start_bound()),
-            RelativeBound::End(RelativeFiniteBound::new(SignedDuration::from_hours(201)).to_end_bound()),
+            RelativeStartBound::InfinitePast.to_bound(),
+            RelativeFiniteBound::new(SignedDuration::from_hours(1))
+                .to_end_bound()
+                .to_bound(),
+            RelativeFiniteBound::new(SignedDuration::from_hours(12))
+                .to_start_bound()
+                .to_bound(),
+            RelativeFiniteBound::new(SignedDuration::from_hours(15))
+                .to_end_bound()
+                .to_bound(),
+            RelativeFiniteBound::new(SignedDuration::from_hours(20))
+                .to_start_bound()
+                .to_bound(),
+            RelativeFiniteBound::new(SignedDuration::from_hours(30))
+                .to_end_bound()
+                .to_bound(),
+            RelativeFiniteBound::new(SignedDuration::from_hours(20))
+                .to_start_bound()
+                .to_bound(),
+            RelativeFiniteBound::new(SignedDuration::from_hours(22))
+                .to_end_bound()
+                .to_bound(),
+            RelativeFiniteBound::new(SignedDuration::from_hours(21))
+                .to_start_bound()
+                .to_bound(),
+            RelativeFiniteBound::new(SignedDuration::from_hours(25))
+                .to_end_bound()
+                .to_bound(),
+            RelativeFiniteBound::new(SignedDuration::from_hours(23))
+                .to_start_bound()
+                .to_bound(),
+            RelativeFiniteBound::new(SignedDuration::from_hours(27))
+                .to_end_bound()
+                .to_bound(),
+            RelativeFiniteBound::new(SignedDuration::from_hours(29))
+                .to_start_bound()
+                .to_bound(),
+            RelativeFiniteBound::new(SignedDuration::from_hours(35))
+                .to_end_bound()
+                .to_bound(),
+            RelativeFiniteBound::new_with_inclusivity(SignedDuration::from_hours(35), BoundInclusivity::Exclusive)
+                .to_start_bound()
+                .to_bound(),
+            RelativeFiniteBound::new(SignedDuration::from_hours(40))
+                .to_end_bound()
+                .to_bound(),
+            RelativeFiniteBound::new(SignedDuration::from_hours(50))
+                .to_start_bound()
+                .to_bound(),
+            RelativeFiniteBound::new(SignedDuration::from_hours(55))
+                .to_end_bound()
+                .to_bound(),
+            RelativeFiniteBound::new(SignedDuration::from_hours(54))
+                .to_start_bound()
+                .to_bound(),
+            RelativeEndBound::InfiniteFuture.to_bound(),
+            RelativeFiniteBound::new(SignedDuration::from_hours(101))
+                .to_start_bound()
+                .to_bound(),
+            RelativeFiniteBound::new(SignedDuration::from_hours(201))
+                .to_end_bound()
+                .to_bound(),
         ];
 
         data.sort();
@@ -306,14 +337,26 @@ mod rel_united_bounds {
         assert_eq!(
             RelativeUnitedBoundsIter::new(data.into_iter()).collect::<Vec<_>>(),
             vec![
-                RelativeBound::Start(RelativeStartBound::InfinitePast),
-                RelativeBound::End(RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_end_bound()),
-                RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(12)).to_start_bound()),
-                RelativeBound::End(RelativeFiniteBound::new(SignedDuration::from_hours(15)).to_end_bound()),
-                RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(20)).to_start_bound()),
-                RelativeBound::End(RelativeFiniteBound::new(SignedDuration::from_hours(40)).to_end_bound()),
-                RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(50)).to_start_bound()),
-                RelativeBound::End(RelativeEndBound::InfiniteFuture),
+                RelativeStartBound::InfinitePast.to_bound(),
+                RelativeFiniteBound::new(SignedDuration::from_hours(1))
+                    .to_end_bound()
+                    .to_bound(),
+                RelativeFiniteBound::new(SignedDuration::from_hours(12))
+                    .to_start_bound()
+                    .to_bound(),
+                RelativeFiniteBound::new(SignedDuration::from_hours(15))
+                    .to_end_bound()
+                    .to_bound(),
+                RelativeFiniteBound::new(SignedDuration::from_hours(20))
+                    .to_start_bound()
+                    .to_bound(),
+                RelativeFiniteBound::new(SignedDuration::from_hours(40))
+                    .to_end_bound()
+                    .to_bound(),
+                RelativeFiniteBound::new(SignedDuration::from_hours(50))
+                    .to_start_bound()
+                    .to_bound(),
+                RelativeEndBound::InfiniteFuture.to_bound(),
             ],
         );
     }
@@ -371,14 +414,26 @@ mod rel_united_bounds {
         assert_eq!(
             data.rel_bounds_iter().unite_bounds().collect::<Vec<_>>(),
             vec![
-                RelativeBound::Start(RelativeStartBound::InfinitePast),
-                RelativeBound::End(RelativeFiniteBound::new(SignedDuration::from_hours(1)).to_end_bound()),
-                RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(12)).to_start_bound()),
-                RelativeBound::End(RelativeFiniteBound::new(SignedDuration::from_hours(15)).to_end_bound()),
-                RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(20)).to_start_bound()),
-                RelativeBound::End(RelativeFiniteBound::new(SignedDuration::from_hours(40)).to_end_bound()),
-                RelativeBound::Start(RelativeFiniteBound::new(SignedDuration::from_hours(50)).to_start_bound()),
-                RelativeBound::End(RelativeEndBound::InfiniteFuture),
+                RelativeStartBound::InfinitePast.to_bound(),
+                RelativeFiniteBound::new(SignedDuration::from_hours(1))
+                    .to_end_bound()
+                    .to_bound(),
+                RelativeFiniteBound::new(SignedDuration::from_hours(12))
+                    .to_start_bound()
+                    .to_bound(),
+                RelativeFiniteBound::new(SignedDuration::from_hours(15))
+                    .to_end_bound()
+                    .to_bound(),
+                RelativeFiniteBound::new(SignedDuration::from_hours(20))
+                    .to_start_bound()
+                    .to_bound(),
+                RelativeFiniteBound::new(SignedDuration::from_hours(40))
+                    .to_end_bound()
+                    .to_bound(),
+                RelativeFiniteBound::new(SignedDuration::from_hours(50))
+                    .to_start_bound()
+                    .to_bound(),
+                RelativeEndBound::InfiniteFuture.to_bound(),
             ],
         );
     }


### PR DESCRIPTION
# Explanation

In order to keep the examples relevant to the newer code and in order to make
the tests more concise, which helps with readability, using the newer chain calls
like `to_interval` instead of `AbsoluteInterval::from` was necessary.

<details>
<summary><h1>Changelog</h1></summary>

## Added

- Added `to_interval` on `AbsoluteBoundPair`
- Added `to_emptiable_interval` on `AbsoluteBoundPair`
- Added `to_emptiable_interval` on `EmptiableAbsoluteBoundPair`

- Added `to_interval` on `RelativeBoundPair`
- Added `to_emptiable_interval` on `RelativeBoundPair`
- Added `to_emptiable_interval` on `EmptiableRelativeBoundPair`

## Changed

- Changed all usages of `AbsoluteStartBound::Finite(x)` to `x.to_start_bound()`
- Changed all usages of `AbsoluteEndBound::Finite(x)` to `x.to_end_bound()`
- Changed all usages of `AbsoluteBound::Start(x)` to `x.to_bound()`
- Changed all usages of `AbsoluteBound::End(x)` to `x.to_bound()`
- Changed all usages of `AbsoluteInterval::from(x)` to `x.to_interval()`
- Changed all usages of `EmptiableAbsoluteInterval::from(x)` to `x.to_emptiable_interval()`

- Changed all usages of `RelativeStartBound::Finite(x)` to `x.to_start_bound()`
- Changed all usages of `RelativeEndBound::Finite(x)` to `x.to_end_bound()`
- Changed all usages of `RelativeBound::Start(x)` to `x.to_bound()`
- Changed all usages of `RelativeBound::End(x)` to `x.to_bound()`
- Changed all usages of `RelativeInterval::from(x)` to `x.to_interval()`
- Changed all usages of `EmptiableRelativeInterval::from(x)` to `x.to_emptiable_interval()`

</details>