### PR TITLE
Improved: Removed useless impls that always returned an error

### DIFF
--- a/branch-changelog.md
+++ b/branch-changelog.md
@@ -9,33 +9,13 @@ Explain the motivation for this PR and what it does/solves
 <details>
 <summary><h1>Changelog</h1></summary>
 
-Remove the sections that don't apply to your PR
-
 ## Added
 
-- Added `to_interval` on `AbsoluteBoundPair`
-- Added `to_emptiable_interval` on `AbsoluteBoundPair`
-- Added `to_emptiable_interval` on `EmptiableAbsoluteBoundPair`
-
-- Added `to_interval` on `RelativeBoundPair`
-- Added `to_emptiable_interval` on `RelativeBoundPair`
-- Added `to_emptiable_interval` on `EmptiableRelativeBoundPair`
+-
 
 ## Changed
 
-- Changed all usages of `AbsoluteStartBound::Finite(x)` to `x.to_start_bound()`
-- Changed all usages of `AbsoluteEndBound::Finite(x)` to `x.to_end_bound()`
-- Changed all usages of `AbsoluteBound::Start(x)` to `x.to_bound()`
-- Changed all usages of `AbsoluteBound::End(x)` to `x.to_bound()`
-- Changed all usages of `AbsoluteInterval::from(x)` to `x.to_interval()`
-- Changed all usages of `EmptiableAbsoluteInterval::from(x)` to `x.to_emptiable_interval()`
-
-- Changed all usages of `RelativeStartBound::Finite(x)` to `x.to_start_bound()`
-- Changed all usages of `RelativeEndBound::Finite(x)` to `x.to_end_bound()`
-- Changed all usages of `RelativeBound::Start(x)` to `x.to_bound()`
-- Changed all usages of `RelativeBound::End(x)` to `x.to_bound()`
-- Changed all usages of `RelativeInterval::from(x)` to `x.to_interval()`
-- Changed all usages of `EmptiableRelativeInterval::from(x)` to `x.to_emptiable_interval()`
+-
 
 ## Deprecated
 
@@ -43,7 +23,7 @@ Remove the sections that don't apply to your PR
 
 ## Removed
 
-- Things you've removed
+- Removed `GapFillable` implementation on `UnboundedInterval` as it always returned an error
 
 ## Fixed
 

--- a/src/intervals/ops/fill_gap.rs
+++ b/src/intervals/ops/fill_gap.rs
@@ -95,7 +95,7 @@ use crate::intervals::relative::{
     RelativeInterval,
     RelativeStartBound,
 };
-use crate::intervals::special::{EmptyInterval, UnboundedInterval};
+use crate::intervals::special::EmptyInterval;
 
 /// The two given intervals were overlapping when using [`GapFillable`]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -323,17 +323,6 @@ where
     fn fill_gap(&self, rhs: &Rhs) -> Result<Self::Output, GapFillOverlapFoundError> {
         fill_gap_rel_bound_pair_with_emptiable_rel_bound_pair(&self.rel_bound_pair(), &rhs.emptiable_rel_bound_pair())
             .map(Self::Output::from)
-    }
-}
-
-impl<Rhs> GapFillable<Rhs> for UnboundedInterval
-where
-    Rhs: Interval,
-{
-    type Output = UnboundedInterval;
-
-    fn fill_gap(&self, _rhs: &Rhs) -> Result<Self::Output, GapFillOverlapFoundError> {
-        Err(GapFillOverlapFoundError)
     }
 }
 


### PR DESCRIPTION
# Explanation

It does not make sense to have a fallible implementation on a type on which
we know that it will always return in an error.

<details>
<summary><h1>Changelog</h1></summary>

## Removed

- Removed `GapFillable` implementation on `UnboundedInterval` as it always returned an error

</details>