### PR TITLE
Improved: Since/Until this (offset or not) week for half-bounded intervals

### DIFF
--- a/branch-changelog.md
+++ b/branch-changelog.md
@@ -8,29 +8,15 @@ Explain the motivation for this PR and what it does/solves
 
 # Notes
 
-Where should the actual logic for conversion be located? Either within the item's `impl`
-or the relevant `From`/`TryFrom` impl? I believe that, where possible, logic should be implemented
-in the item's `impl` under an explicit name, which is later used in the `From`/`TryFrom` impl.
-
 <details>
 <summary><h1>Changelog</h1></summary>
 
 ## Added
 
-- Implemented `unchecked_new_with_offset` on `OffsetIsoWeek`
-- Implemented `from_date_with_offset` and `from_date` on `OffsetIsoWeek`
-- Added `Computation` variant to `OffsetIsoWeekCreationError`
-- Implemented `zero_based_nth_day` and `one_based_nth_day` on `OffsetIsoWeek`
-- Implemented `start_weekday` and `end_weekday` on `OffsetIsoWeek`
-- Implemented `weekday_date` on `OffsetIsoWeek`
-- Implemented `TryFrom<Date>` and `TryFrom<(Date, i8)>` on `OffsetIsoWeek`
-- Implemented `offset_week_after_duration_from_date`, `offset_week_before_duration_from_date`,
-  `week_after_duration_from_date`, and `week_before_duration_from_date` on `OffsetIsoWeek`
-- Implemented `offset_week_after_duration_from_today`, `week_after_duration_from_today`,
-  `offset_week_before_duration_from_today`, and `week_before_duration_from_today` on `OffsetIsoWeek`
-- Implemented `this_week`, `this_offset_week`, `next_week`, `next_offset_week`, `previous_week`,
-  and `previous_offset_week` on `OffsetIsoWeek`
-- Implemented `TryFrom<Date>` on `Month`
+- Implemented `since_this_week` on `HalfBoundedAbsoluteInterval`
+- Implemented `since_this_offset_week` on `HalfBoundedAbsoluteInterval`
+- Implemented `until_this_week` on `HalfBoundedAbsoluteInterval`
+- Implemented `until_this_offset_week` on `HalfBoundedAbsoluteInterval`
 
 ## Changed
 

--- a/src/intervals/convenience/absolute/half_bounded_interval.rs
+++ b/src/intervals/convenience/absolute/half_bounded_interval.rs
@@ -11,6 +11,7 @@ use crate::time::{
     CalendarAnchorOffsetDateError,
     MonthInYear,
     OffsetIsoWeek,
+    OffsetIsoWeekCreationError,
     checked_add_calendar_anchor_offset_to_date,
     checked_sub_calendar_anchor_offset_to_date,
     date_today,
@@ -448,6 +449,148 @@ impl HalfBoundedAbsoluteInterval {
         Self::until_date(
             week.first_day()
                 .or(Err(HalfBoundedAbsoluteIntervalCreationError::OutOfRangeReference))?,
+            tz,
+        )
+    }
+
+    /// Creates a new [`HalfBoundedAbsoluteInterval`] that spans since the current week in the given timezone
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ComputationError`](HalfBoundedAbsoluteIntervalCreationError::ComputationError)
+    /// if [`OffsetIsoWeek::from_date`] returned an error.
+    ///
+    /// Returns any error that [`since_week`](Self::since_week) may return.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::error::Error;
+    /// # use jiff::tz::TimeZone;
+    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// let interval = HalfBoundedAbsoluteInterval::since_this_week(TimeZone::get("Europe/Oslo")?)?;
+    /// # Ok::<(), Box<dyn Error>>(())
+    /// ```
+    pub fn since_this_week(tz: TimeZone) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError> {
+        Self::since_week(
+            OffsetIsoWeek::from_date(date_today(tz.clone()))
+                .or(Err(HalfBoundedAbsoluteIntervalCreationError::ComputationError))?,
+            tz,
+        )
+    }
+
+    /// Creates a new [`HalfBoundedAbsoluteInterval`] that spans since the current offset week in the given timezone
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ComputationError`](HalfBoundedAbsoluteIntervalCreationError::ComputationError)
+    /// if [`OffsetIsoWeek::from_date_with_offset`]
+    /// returned [`OffsetIsoWeekCreationError::Computation`]
+    /// or [`OffsetIsoWeekCreationError::OutOfRangeOffset`].
+    ///
+    /// Returns [`OutOfRangeReference`](HalfBoundedAbsoluteIntervalCreationError::OutOfRangeReference)
+    /// if [`OffsetIsoWeek::from_date_with_offset`]
+    /// returned [`OffsetIsoWeekCreationError::OutOfRangeWeek`]
+    /// or [`OffsetIsoWeekCreationError::OutOfRangeYear`].
+    ///
+    /// Returns any error that [`since_week`](Self::since_week) may return.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::error::Error;
+    /// # use jiff::tz::TimeZone;
+    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// let interval =
+    ///     HalfBoundedAbsoluteInterval::since_this_offset_week(-1, TimeZone::get("Europe/Oslo")?)?;
+    /// # Ok::<(), Box<dyn Error>>(())
+    /// ```
+    pub fn since_this_offset_week(
+        week_start_offset: i8,
+        tz: TimeZone,
+    ) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError> {
+        Self::since_week(
+            OffsetIsoWeek::from_date_with_offset(date_today(tz.clone()), week_start_offset).map_err(
+                |err| match err {
+                    OffsetIsoWeekCreationError::Computation | OffsetIsoWeekCreationError::OutOfRangeOffset => {
+                        HalfBoundedAbsoluteIntervalCreationError::ComputationError
+                    },
+                    OffsetIsoWeekCreationError::OutOfRangeWeek | OffsetIsoWeekCreationError::OutOfRangeYear => {
+                        HalfBoundedAbsoluteIntervalCreationError::OutOfRangeReference
+                    },
+                },
+            )?,
+            tz,
+        )
+    }
+
+    /// Creates a new [`HalfBoundedAbsoluteInterval`] that spans until the current week in the given timezone
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ComputationError`](HalfBoundedAbsoluteIntervalCreationError::ComputationError)
+    /// if [`OffsetIsoWeek::from_date`] returned an error.
+    ///
+    /// Returns any error that [`until_week`](Self::until_week) may return.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::error::Error;
+    /// # use jiff::tz::TimeZone;
+    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// let interval = HalfBoundedAbsoluteInterval::until_this_week(TimeZone::get("Europe/Oslo")?)?;
+    /// # Ok::<(), Box<dyn Error>>(())
+    /// ```
+    pub fn until_this_week(tz: TimeZone) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError> {
+        Self::until_week(
+            OffsetIsoWeek::from_date(date_today(tz.clone()))
+                .or(Err(HalfBoundedAbsoluteIntervalCreationError::ComputationError))?,
+            tz,
+        )
+    }
+
+    /// Creates a new [`HalfBoundedAbsoluteInterval`] that spans until the current offset week in the given timezone
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ComputationError`](HalfBoundedAbsoluteIntervalCreationError::ComputationError)
+    /// if [`OffsetIsoWeek::from_date_with_offset`]
+    /// returned [`OffsetIsoWeekCreationError::Computation`]
+    /// or [`OffsetIsoWeekCreationError::OutOfRangeOffset`].
+    ///
+    /// Returns [`OutOfRangeReference`](HalfBoundedAbsoluteIntervalCreationError::OutOfRangeReference)
+    /// if [`OffsetIsoWeek::from_date_with_offset`]
+    /// returned [`OffsetIsoWeekCreationError::OutOfRangeWeek`]
+    /// or [`OffsetIsoWeekCreationError::OutOfRangeYear`].
+    ///
+    /// Returns any error that [`until_week`](Self::until_week) may return.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::error::Error;
+    /// # use jiff::tz::TimeZone;
+    /// # use periodical::intervals::absolute::HalfBoundedAbsoluteInterval;
+    /// let interval =
+    ///     HalfBoundedAbsoluteInterval::until_this_offset_week(-1, TimeZone::get("Europe/Oslo")?)?;
+    /// # Ok::<(), Box<dyn Error>>(())
+    /// ```
+    pub fn until_this_offset_week(
+        week_start_offset: i8,
+        tz: TimeZone,
+    ) -> Result<Self, HalfBoundedAbsoluteIntervalCreationError> {
+        Self::until_week(
+            OffsetIsoWeek::from_date_with_offset(date_today(tz.clone()), week_start_offset).map_err(
+                |err| match err {
+                    OffsetIsoWeekCreationError::Computation | OffsetIsoWeekCreationError::OutOfRangeOffset => {
+                        HalfBoundedAbsoluteIntervalCreationError::ComputationError
+                    },
+                    OffsetIsoWeekCreationError::OutOfRangeWeek | OffsetIsoWeekCreationError::OutOfRangeYear => {
+                        HalfBoundedAbsoluteIntervalCreationError::OutOfRangeReference
+                    },
+                },
+            )?,
             tz,
         )
     }


### PR DESCRIPTION
# Explanation

To be consistent with bounded interval convenience methods, additional methods were implemented for half-bounded intervals

<details>
<summary><h1>Changelog</h1></summary>

## Added

- Implemented `since_this_week` on `HalfBoundedAbsoluteInterval`
- Implemented `since_this_offset_week` on `HalfBoundedAbsoluteInterval`
- Implemented `until_this_week` on `HalfBoundedAbsoluteInterval`
- Implemented `until_this_offset_week` on `HalfBoundedAbsoluteInterval`

</details>
