### PR TITLE
Improved: Relative precision operations

### DIFF
--- a/branch-changelog.md
+++ b/branch-changelog.md
@@ -13,13 +13,14 @@ Explain the motivation for this PR and what it does/solves
 
 ## Added
 
-- Implemented `since_this_week` on `HalfBoundedAbsoluteInterval`
-- Implemented `since_this_offset_week` on `HalfBoundedAbsoluteInterval`
-- Implemented `until_this_week` on `HalfBoundedAbsoluteInterval`
-- Implemented `until_this_offset_week` on `HalfBoundedAbsoluteInterval`
+- Implemented `precise_duration_with_base_offset` on `Precision`
+- Implemented `precise_duration_with_base_offset_via_signed` on `Precision`
+- Implemented `precise_signed_duration_with_base_offset` on `Precision`
 
 ## Changed
 
+- Renamed `PrecisionOutOfRangeDateError` to `PrecisionOutOfRangeError` to make the error more generic.
+  Adjusted the error's message in consequence.
 -
 
 ## Deprecated

--- a/branch-changelog.md
+++ b/branch-changelog.md
@@ -16,12 +16,12 @@ Explain the motivation for this PR and what it does/solves
 - Implemented `precise_duration_with_base_offset` on `Precision`
 - Implemented `precise_duration_with_base_offset_via_signed` on `Precision`
 - Implemented `precise_signed_duration_with_base_offset` on `Precision`
+- Implemented relative version of `PreciseAbsoluteBound` and `PreciseAbsoluteInterval`
 
 ## Changed
 
 - Renamed `PrecisionOutOfRangeDateError` to `PrecisionOutOfRangeError` to make the error more generic.
   Adjusted the error's message in consequence.
--
 
 ## Deprecated
 

--- a/src/intervals/ops.rs
+++ b/src/intervals/ops.rs
@@ -84,7 +84,7 @@ inline_docs! {
         CanPositionPointContainment, DEFAULT_POINT_CONTAINMENT_RULES, DisambiguatedPointContainmentPosition,
         PointContainmentPosition, PointContainmentRule, PointContainmentRuleSet,
     };
-    pub use precision::{PreciseAbsoluteInterval, PreciseAbsoluteBound};
+    pub use precision::{PreciseAbsoluteInterval, PreciseAbsoluteBound, PreciseRelativeInterval, PreciseRelativeBound};
     pub use relativity_conversion::{ToAbsolute, ToRelative};
     pub use remove_overlap::{OverlapRemovable, OverlapRemovalResult};
     pub use remove_overlap_or_gap::{OverlapOrGapRemovalResult, RemovableOverlapOrGap};

--- a/src/intervals/ops/precision.rs
+++ b/src/intervals/ops/precision.rs
@@ -66,5 +66,5 @@ pub mod relative;
 
 inline_docs! {
     pub use absolute::{PreciseAbsoluteBound, PreciseAbsoluteInterval};
-    // pub use relative::{PreciseRelativeBound, PreciseRelativeInterval};
+    pub use relative::{PreciseRelativeBound, PreciseRelativeInterval};
 }

--- a/src/intervals/ops/precision/absolute/bound.rs
+++ b/src/intervals/ops/precision/absolute/bound.rs
@@ -5,7 +5,7 @@ use jiff::tz::TimeZone;
 
 use crate::intervals::absolute::{AbsoluteBoundPair, AbsoluteEndBound, AbsoluteFiniteBound, AbsoluteStartBound};
 use crate::intervals::meta::HasBoundInclusivity;
-use crate::ops::{Precision, PrecisionOutOfRangeDateError};
+use crate::ops::{Precision, PrecisionOutOfRangeError};
 
 /// Ability to precise absolute bounds
 ///
@@ -140,7 +140,7 @@ pub trait PreciseAbsoluteBound {
 }
 
 impl PreciseAbsoluteBound for AbsoluteFiniteBound {
-    type PrecisedBoundOutput = Result<Self, PrecisionOutOfRangeDateError>;
+    type PrecisedBoundOutput = Result<Self, PrecisionOutOfRangeError>;
 
     fn precise_bound(&self, tz: TimeZone, precision: Precision) -> Self::PrecisedBoundOutput {
         precise_abs_finite_bound(self, tz, precision)
@@ -157,7 +157,7 @@ impl PreciseAbsoluteBound for AbsoluteFiniteBound {
 }
 
 impl PreciseAbsoluteBound for AbsoluteStartBound {
-    type PrecisedBoundOutput = Result<Self, PrecisionOutOfRangeDateError>;
+    type PrecisedBoundOutput = Result<Self, PrecisionOutOfRangeError>;
 
     fn precise_bound(&self, tz: TimeZone, precision: Precision) -> Self::PrecisedBoundOutput {
         precise_abs_start_bound(self, tz, precision)
@@ -174,7 +174,7 @@ impl PreciseAbsoluteBound for AbsoluteStartBound {
 }
 
 impl PreciseAbsoluteBound for AbsoluteEndBound {
-    type PrecisedBoundOutput = Result<Self, PrecisionOutOfRangeDateError>;
+    type PrecisedBoundOutput = Result<Self, PrecisionOutOfRangeError>;
 
     fn precise_bound(&self, tz: TimeZone, precision: Precision) -> Self::PrecisedBoundOutput {
         precise_abs_end_bound(self, tz, precision)
@@ -200,7 +200,7 @@ pub fn precise_abs_bound_pair(
     tz: TimeZone,
     precision_start: Precision,
     precision_end: Precision,
-) -> Result<AbsoluteBoundPair, PrecisionOutOfRangeDateError> {
+) -> Result<AbsoluteBoundPair, PrecisionOutOfRangeError> {
     Ok(AbsoluteBoundPair::new(
         precise_abs_start_bound(&bounds.start(), tz.clone(), precision_start)?,
         precise_abs_end_bound(&bounds.end(), tz, precision_end)?,
@@ -216,12 +216,12 @@ pub fn precise_abs_finite_bound(
     bound: &AbsoluteFiniteBound,
     tz: TimeZone,
     precision: Precision,
-) -> Result<AbsoluteFiniteBound, PrecisionOutOfRangeDateError> {
+) -> Result<AbsoluteFiniteBound, PrecisionOutOfRangeError> {
     Ok(AbsoluteFiniteBound::new_with_inclusivity(
         precision
             .precise_time(&bound.time().to_zoned(tz))?
             .compatible()
-            .or(Err(PrecisionOutOfRangeDateError))?
+            .or(Err(PrecisionOutOfRangeError))?
             .timestamp(),
         bound.inclusivity(),
     ))
@@ -236,7 +236,7 @@ pub fn precise_abs_start_bound(
     bound: &AbsoluteStartBound,
     tz: TimeZone,
     precision: Precision,
-) -> Result<AbsoluteStartBound, PrecisionOutOfRangeDateError> {
+) -> Result<AbsoluteStartBound, PrecisionOutOfRangeError> {
     match bound {
         AbsoluteStartBound::InfinitePast => Ok(*bound),
         AbsoluteStartBound::Finite(finite_bound) => {
@@ -254,7 +254,7 @@ pub fn precise_abs_end_bound(
     bound: &AbsoluteEndBound,
     tz: TimeZone,
     precision: Precision,
-) -> Result<AbsoluteEndBound, PrecisionOutOfRangeDateError> {
+) -> Result<AbsoluteEndBound, PrecisionOutOfRangeError> {
     match bound {
         AbsoluteEndBound::InfiniteFuture => Ok(*bound),
         AbsoluteEndBound::Finite(finite_bound) => {
@@ -275,7 +275,7 @@ pub fn precise_abs_bound_pair_with_base_time(
     base_start: Timestamp,
     precision_end: Precision,
     base_end: Timestamp,
-) -> Result<AbsoluteBoundPair, PrecisionOutOfRangeDateError> {
+) -> Result<AbsoluteBoundPair, PrecisionOutOfRangeError> {
     Ok(AbsoluteBoundPair::new(
         precise_abs_start_bound_with_base_time(&bounds.start(), tz.clone(), precision_start, base_start)?,
         precise_abs_end_bound_with_base_time(&bounds.end(), tz, precision_end, base_end)?,
@@ -292,7 +292,7 @@ pub fn precise_abs_finite_bound_with_base_time(
     tz: TimeZone,
     precision: Precision,
     base: Timestamp,
-) -> Result<AbsoluteFiniteBound, PrecisionOutOfRangeDateError> {
+) -> Result<AbsoluteFiniteBound, PrecisionOutOfRangeError> {
     Ok(AbsoluteFiniteBound::new_with_inclusivity(
         precision
             .precise_time_with_base_time(&bound.time().to_zoned(tz), base)?
@@ -311,7 +311,7 @@ pub fn precise_abs_start_bound_with_base_time(
     tz: TimeZone,
     precision: Precision,
     base: Timestamp,
-) -> Result<AbsoluteStartBound, PrecisionOutOfRangeDateError> {
+) -> Result<AbsoluteStartBound, PrecisionOutOfRangeError> {
     match bound {
         AbsoluteStartBound::InfinitePast => Ok(*bound),
         AbsoluteStartBound::Finite(finite_bound) => {
@@ -330,7 +330,7 @@ pub fn precise_abs_end_bound_with_base_time(
     tz: TimeZone,
     precision: Precision,
     base: Timestamp,
-) -> Result<AbsoluteEndBound, PrecisionOutOfRangeDateError> {
+) -> Result<AbsoluteEndBound, PrecisionOutOfRangeError> {
     match bound {
         AbsoluteEndBound::InfiniteFuture => Ok(*bound),
         AbsoluteEndBound::Finite(finite_bound) => {

--- a/src/intervals/ops/precision/absolute/bound.rs
+++ b/src/intervals/ops/precision/absolute/bound.rs
@@ -3,7 +3,7 @@
 use jiff::Timestamp;
 use jiff::tz::TimeZone;
 
-use crate::intervals::absolute::{AbsoluteBoundPair, AbsoluteEndBound, AbsoluteFiniteBound, AbsoluteStartBound};
+use crate::intervals::absolute::{AbsoluteEndBound, AbsoluteFiniteBound, AbsoluteStartBound};
 use crate::intervals::meta::HasBoundInclusivity;
 use crate::ops::{Precision, PrecisionOutOfRangeError};
 
@@ -21,7 +21,7 @@ use crate::ops::{Precision, PrecisionOutOfRangeError};
 /// # use periodical::ops::{Precision, PrecisionMode};
 /// # use periodical::intervals::absolute::AbsoluteFiniteBound;
 /// # use periodical::intervals::meta::BoundInclusivity;
-/// # use periodical::intervals::ops::precision::PreciseAbsoluteBound;
+/// # use periodical::intervals::ops::PreciseAbsoluteBound;
 /// let bound = AbsoluteFiniteBound::new_with_inclusivity(
 ///     "2025-01-01 08:24:41[Europe/Oslo]"
 ///         .parse::<Zoned>()?
@@ -46,6 +46,7 @@ use crate::ops::{Precision, PrecisionOutOfRangeError};
 /// # Ok::<(), Box<dyn Error>>(())
 /// ```
 pub trait PreciseAbsoluteBound {
+    /// Output of methods precising a bound
     type PrecisedBoundOutput;
 
     /// Precises the bound with the given precision
@@ -62,7 +63,7 @@ pub trait PreciseAbsoluteBound {
     /// # use periodical::ops::{Precision, PrecisionMode};
     /// # use periodical::intervals::absolute::AbsoluteFiniteBound;
     /// # use periodical::intervals::meta::BoundInclusivity;
-    /// # use periodical::intervals::ops::precision::PreciseAbsoluteBound;
+    /// # use periodical::intervals::ops::PreciseAbsoluteBound;
     /// let bound = AbsoluteFiniteBound::new_with_inclusivity(
     ///     "2025-01-01 08:24:41[Europe/Oslo]"
     ///         .parse::<Zoned>()?
@@ -103,7 +104,7 @@ pub trait PreciseAbsoluteBound {
     /// # use periodical::ops::{Precision, PrecisionMode};
     /// # use periodical::intervals::absolute::AbsoluteFiniteBound;
     /// # use periodical::intervals::meta::BoundInclusivity;
-    /// # use periodical::intervals::ops::precision::PreciseAbsoluteBound;
+    /// # use periodical::intervals::ops::PreciseAbsoluteBound;
     /// let bound = AbsoluteFiniteBound::new_with_inclusivity(
     ///     "2025-01-01 08:24:41[Europe/Oslo]"
     ///         .parse::<Zoned>()?
@@ -190,23 +191,6 @@ impl PreciseAbsoluteBound for AbsoluteEndBound {
     }
 }
 
-/// Precises [`AbsoluteBoundPair`] with the given [`Precision`]s
-///
-/// # Errors
-///
-/// See [`Precision::precise_time`]
-pub fn precise_abs_bound_pair(
-    bounds: &AbsoluteBoundPair,
-    tz: TimeZone,
-    precision_start: Precision,
-    precision_end: Precision,
-) -> Result<AbsoluteBoundPair, PrecisionOutOfRangeError> {
-    Ok(AbsoluteBoundPair::new(
-        precise_abs_start_bound(&bounds.start(), tz.clone(), precision_start)?,
-        precise_abs_end_bound(&bounds.end(), tz, precision_end)?,
-    ))
-}
-
 /// Precises an [`AbsoluteFiniteBound`] with the given [`Precision`]
 ///
 /// # Errors
@@ -240,7 +224,7 @@ pub fn precise_abs_start_bound(
     match bound {
         AbsoluteStartBound::InfinitePast => Ok(*bound),
         AbsoluteStartBound::Finite(finite_bound) => {
-            precise_abs_finite_bound(finite_bound, tz, precision).map(AbsoluteStartBound::Finite)
+            precise_abs_finite_bound(finite_bound, tz, precision).map(AbsoluteFiniteBound::to_start_bound)
         },
     }
 }
@@ -258,31 +242,12 @@ pub fn precise_abs_end_bound(
     match bound {
         AbsoluteEndBound::InfiniteFuture => Ok(*bound),
         AbsoluteEndBound::Finite(finite_bound) => {
-            precise_abs_finite_bound(finite_bound, tz, precision).map(AbsoluteEndBound::Finite)
+            precise_abs_finite_bound(finite_bound, tz, precision).map(AbsoluteFiniteBound::to_end_bound)
         },
     }
 }
 
-/// Precises [`AbsoluteBoundPair`] with the given [`Precision`]s and base times
-///
-/// # Errors
-///
-/// See [`Precision::precise_time_with_base_time`]
-pub fn precise_abs_bound_pair_with_base_time(
-    bounds: &AbsoluteBoundPair,
-    tz: TimeZone,
-    precision_start: Precision,
-    base_start: Timestamp,
-    precision_end: Precision,
-    base_end: Timestamp,
-) -> Result<AbsoluteBoundPair, PrecisionOutOfRangeError> {
-    Ok(AbsoluteBoundPair::new(
-        precise_abs_start_bound_with_base_time(&bounds.start(), tz.clone(), precision_start, base_start)?,
-        precise_abs_end_bound_with_base_time(&bounds.end(), tz, precision_end, base_end)?,
-    ))
-}
-
-/// Precises an [`AbsoluteFiniteBound`] with the given [`Precision`]
+/// Precises an [`AbsoluteFiniteBound`] with the given [`Precision`] and base time
 ///
 /// # Errors
 ///
@@ -301,7 +266,7 @@ pub fn precise_abs_finite_bound_with_base_time(
     ))
 }
 
-/// Precises an [`AbsoluteStartBound`] with the given [`Precision`]
+/// Precises an [`AbsoluteStartBound`] with the given [`Precision`] and base time
 ///
 /// # Errors
 ///
@@ -315,12 +280,13 @@ pub fn precise_abs_start_bound_with_base_time(
     match bound {
         AbsoluteStartBound::InfinitePast => Ok(*bound),
         AbsoluteStartBound::Finite(finite_bound) => {
-            precise_abs_finite_bound_with_base_time(finite_bound, tz, precision, base).map(AbsoluteStartBound::Finite)
+            precise_abs_finite_bound_with_base_time(finite_bound, tz, precision, base)
+                .map(AbsoluteFiniteBound::to_start_bound)
         },
     }
 }
 
-/// Precises an [`AbsoluteEndBound`] with the given [`Precision`]
+/// Precises an [`AbsoluteEndBound`] with the given [`Precision`] and base time
 ///
 /// # Errors
 ///
@@ -334,7 +300,8 @@ pub fn precise_abs_end_bound_with_base_time(
     match bound {
         AbsoluteEndBound::InfiniteFuture => Ok(*bound),
         AbsoluteEndBound::Finite(finite_bound) => {
-            precise_abs_finite_bound_with_base_time(finite_bound, tz, precision, base).map(AbsoluteEndBound::Finite)
+            precise_abs_finite_bound_with_base_time(finite_bound, tz, precision, base)
+                .map(AbsoluteFiniteBound::to_end_bound)
         },
     }
 }

--- a/src/intervals/ops/precision/absolute/interval.rs
+++ b/src/intervals/ops/precision/absolute/interval.rs
@@ -12,8 +12,10 @@ use crate::intervals::absolute::{
     HasEmptiableAbsoluteBoundPair,
 };
 use crate::intervals::ops::precision::absolute::bound::{
-    precise_abs_bound_pair,
-    precise_abs_bound_pair_with_base_time,
+    precise_abs_end_bound,
+    precise_abs_end_bound_with_base_time,
+    precise_abs_start_bound,
+    precise_abs_start_bound_with_base_time,
 };
 use crate::intervals::special::EmptyInterval;
 use crate::ops::{Precision, PrecisionOutOfRangeError};
@@ -75,6 +77,8 @@ pub trait PreciseAbsoluteInterval {
 
     /// Precises the start and end bounds with different [`Precision`]s
     ///
+    /// See [`Precision::precise_time`] for more information.
+    ///
     /// # Examples
     ///
     /// ```
@@ -132,6 +136,8 @@ pub trait PreciseAbsoluteInterval {
     ) -> Self::PrecisedIntervalOutput;
 
     /// Precises the start and end bounds with the given [`Precision`]
+    ///
+    /// See [`Precision::precise_time`] for more information.
     ///
     /// # Examples
     ///
@@ -352,16 +358,11 @@ impl PreciseAbsoluteInterval for EmptiableAbsoluteBoundPair {
         start_precision: Precision,
         end_precision: Precision,
     ) -> Self::PrecisedIntervalOutput {
-        if let EmptiableAbsoluteBoundPair::Bound(abs_bound_pair) = self {
-            return Ok(EmptiableAbsoluteBoundPair::Bound(precise_abs_bound_pair(
-                abs_bound_pair,
-                tz,
-                start_precision,
-                end_precision,
-            )?));
+        if let Self::Bound(abs_bound_pair) = self {
+            Ok(precise_abs_bound_pair(abs_bound_pair, tz, start_precision, end_precision)?.to_emptiable())
+        } else {
+            Ok(Self::Empty)
         }
-
-        Ok(EmptiableAbsoluteBoundPair::Empty)
     }
 
     fn precise_interval_with_different_precisions_with_base_time(
@@ -372,20 +373,19 @@ impl PreciseAbsoluteInterval for EmptiableAbsoluteBoundPair {
         precision_end: Precision,
         base_end: Timestamp,
     ) -> Self::PrecisedIntervalOutput {
-        if let EmptiableAbsoluteBoundPair::Bound(abs_bound_pair) = self {
-            return Ok(EmptiableAbsoluteBoundPair::Bound(
-                precise_abs_bound_pair_with_base_time(
-                    abs_bound_pair,
-                    tz,
-                    precision_start,
-                    base_start,
-                    precision_end,
-                    base_end,
-                )?,
-            ));
+        if let Self::Bound(abs_bound_pair) = self {
+            Ok(precise_abs_bound_pair_with_base_time(
+                abs_bound_pair,
+                tz,
+                precision_start,
+                base_start,
+                precision_end,
+                base_end,
+            )?
+            .to_emptiable())
+        } else {
+            Ok(Self::Empty)
         }
-
-        Ok(EmptiableAbsoluteBoundPair::Empty)
     }
 }
 
@@ -431,12 +431,10 @@ impl PreciseAbsoluteInterval for EmptiableAbsoluteInterval {
         precision_end: Precision,
     ) -> Self::PrecisedIntervalOutput {
         if let EmptiableAbsoluteBoundPair::Bound(ref abs_bound_pair) = self.emptiable_abs_bound_pair() {
-            return Ok(
-                precise_abs_bound_pair(abs_bound_pair, tz, precision_start, precision_end)?.to_emptiable_interval(),
-            );
+            Ok(precise_abs_bound_pair(abs_bound_pair, tz, precision_start, precision_end)?.to_emptiable_interval())
+        } else {
+            Ok(Self::Empty(EmptyInterval))
         }
-
-        Ok(EmptiableAbsoluteInterval::Empty(EmptyInterval))
     }
 
     fn precise_interval_with_different_precisions_with_base_time(
@@ -448,7 +446,7 @@ impl PreciseAbsoluteInterval for EmptiableAbsoluteInterval {
         base_end: Timestamp,
     ) -> Self::PrecisedIntervalOutput {
         if let EmptiableAbsoluteBoundPair::Bound(ref abs_bound_pair) = self.emptiable_abs_bound_pair() {
-            return Ok(precise_abs_bound_pair_with_base_time(
+            Ok(precise_abs_bound_pair_with_base_time(
                 abs_bound_pair,
                 tz,
                 precision_start,
@@ -456,9 +454,45 @@ impl PreciseAbsoluteInterval for EmptiableAbsoluteInterval {
                 precision_end,
                 base_end,
             )?
-            .to_emptiable_interval());
+            .to_emptiable_interval())
+        } else {
+            Ok(Self::Empty(EmptyInterval))
         }
-
-        Ok(EmptiableAbsoluteInterval::Empty(EmptyInterval))
     }
+}
+
+/// Precises [`AbsoluteBoundPair`] with the given [`Precision`]s
+///
+/// # Errors
+///
+/// See [`Precision::precise_time`]
+pub fn precise_abs_bound_pair(
+    bound_pair: &AbsoluteBoundPair,
+    tz: TimeZone,
+    precision_start: Precision,
+    precision_end: Precision,
+) -> Result<AbsoluteBoundPair, PrecisionOutOfRangeError> {
+    Ok(AbsoluteBoundPair::new(
+        precise_abs_start_bound(&bound_pair.start(), tz.clone(), precision_start)?,
+        precise_abs_end_bound(&bound_pair.end(), tz, precision_end)?,
+    ))
+}
+
+/// Precises [`AbsoluteBoundPair`] with the given [`Precision`]s and base times
+///
+/// # Errors
+///
+/// See [`Precision::precise_time_with_base_time`]
+pub fn precise_abs_bound_pair_with_base_time(
+    bound_pair: &AbsoluteBoundPair,
+    tz: TimeZone,
+    precision_start: Precision,
+    base_start: Timestamp,
+    precision_end: Precision,
+    base_end: Timestamp,
+) -> Result<AbsoluteBoundPair, PrecisionOutOfRangeError> {
+    Ok(AbsoluteBoundPair::new(
+        precise_abs_start_bound_with_base_time(&bound_pair.start(), tz.clone(), precision_start, base_start)?,
+        precise_abs_end_bound_with_base_time(&bound_pair.end(), tz, precision_end, base_end)?,
+    ))
 }

--- a/src/intervals/ops/precision/absolute/interval.rs
+++ b/src/intervals/ops/precision/absolute/interval.rs
@@ -16,7 +16,7 @@ use crate::intervals::ops::precision::absolute::bound::{
     precise_abs_bound_pair_with_base_time,
 };
 use crate::intervals::special::EmptyInterval;
-use crate::ops::{Precision, PrecisionOutOfRangeDateError};
+use crate::ops::{Precision, PrecisionOutOfRangeError};
 
 /// Ability to precise absolute intervals
 ///
@@ -320,7 +320,7 @@ pub trait PreciseAbsoluteInterval {
 }
 
 impl PreciseAbsoluteInterval for AbsoluteBoundPair {
-    type PrecisedIntervalOutput = Result<Self, PrecisionOutOfRangeDateError>;
+    type PrecisedIntervalOutput = Result<Self, PrecisionOutOfRangeError>;
 
     fn precise_interval_with_different_precisions(
         &self,
@@ -344,7 +344,7 @@ impl PreciseAbsoluteInterval for AbsoluteBoundPair {
 }
 
 impl PreciseAbsoluteInterval for EmptiableAbsoluteBoundPair {
-    type PrecisedIntervalOutput = Result<Self, PrecisionOutOfRangeDateError>;
+    type PrecisedIntervalOutput = Result<Self, PrecisionOutOfRangeError>;
 
     fn precise_interval_with_different_precisions(
         &self,
@@ -390,7 +390,7 @@ impl PreciseAbsoluteInterval for EmptiableAbsoluteBoundPair {
 }
 
 impl PreciseAbsoluteInterval for AbsoluteInterval {
-    type PrecisedIntervalOutput = Result<Self, PrecisionOutOfRangeDateError>;
+    type PrecisedIntervalOutput = Result<Self, PrecisionOutOfRangeError>;
 
     fn precise_interval_with_different_precisions(
         &self,
@@ -422,7 +422,7 @@ impl PreciseAbsoluteInterval for AbsoluteInterval {
 }
 
 impl PreciseAbsoluteInterval for EmptiableAbsoluteInterval {
-    type PrecisedIntervalOutput = Result<Self, PrecisionOutOfRangeDateError>;
+    type PrecisedIntervalOutput = Result<Self, PrecisionOutOfRangeError>;
 
     fn precise_interval_with_different_precisions(
         &self,

--- a/src/intervals/ops/precision/relative.rs
+++ b/src/intervals/ops/precision/relative.rs
@@ -10,7 +10,7 @@ tests! {
     mod interval_tests;
 }
 
-// inline_docs! {
-//     pub use bound::PreciseRelativeBound;
-//     pub use interval::PreciseRelativeInterval;
-// }
+inline_docs! {
+    pub use bound::PreciseRelativeBound;
+    pub use interval::PreciseRelativeInterval;
+}

--- a/src/intervals/ops/precision/relative/bound.rs
+++ b/src/intervals/ops/precision/relative/bound.rs
@@ -1,1 +1,18 @@
+//! Precision change for relative bounds
 
+use jiff::SignedDuration;
+
+use crate::ops::Precision;
+
+/// Ability to precise relative bounds
+///
+/// The precision itself is defined by [`Precision`].
+pub trait PreciseRelativeBound {
+    type PrecisedBoundOutput;
+
+    #[must_use]
+    fn precise_bounds(&self, precision: Precision) -> Self::PrecisedBoundOutput;
+
+    #[must_use]
+    fn precise_bound_with_base_offset(&self, precision: Precision, base: SignedDuration) -> Self::PrecisedBoundOutput;
+}

--- a/src/intervals/ops/precision/relative/bound.rs
+++ b/src/intervals/ops/precision/relative/bound.rs
@@ -2,17 +2,255 @@
 
 use jiff::SignedDuration;
 
-use crate::ops::Precision;
+use crate::intervals::relative::{RelativeEndBound, RelativeFiniteBound, RelativeStartBound};
+use crate::ops::{Precision, PrecisionOutOfRangeError};
+use crate::prelude::HasBoundInclusivity;
 
 /// Ability to precise relative bounds
 ///
 /// The precision itself is defined by [`Precision`].
+///
+/// # Examples
+///
+/// ```
+/// # use std::error::Error;
+/// # use std::time::Duration;
+/// # use jiff::SignedDuration;
+/// # use periodical::ops::{Precision, PrecisionMode};
+/// # use periodical::intervals::relative::RelativeFiniteBound;
+/// # use periodical::intervals::meta::BoundInclusivity;
+/// # use periodical::intervals::ops::PreciseRelativeBound;
+/// let bound = RelativeFiniteBound::new_with_inclusivity(
+///     SignedDuration::from_mins(24),
+///     BoundInclusivity::Exclusive,
+/// )
+/// .to_start_bound();
+///
+/// assert_eq!(
+///     bound.precise_bound(Precision::new(
+///         Duration::from_mins(5),
+///         PrecisionMode::ToFuture
+///     )?),
+///     Ok(RelativeFiniteBound::new_with_inclusivity(
+///         SignedDuration::from_mins(25),
+///         BoundInclusivity::Exclusive,
+///     )
+///     .to_start_bound())
+/// );
+/// # Ok::<(), Box<dyn Error>>(())
+/// ```
 pub trait PreciseRelativeBound {
+    /// Output of methods precising a bound
     type PrecisedBoundOutput;
 
+    /// Precises the bound with the given precision
+    ///
+    /// See [`Precision::precise_signed_duration`] for more information.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::error::Error;
+    /// # use std::time::Duration;
+    /// # use jiff::SignedDuration;
+    /// # use periodical::ops::{Precision, PrecisionMode};
+    /// # use periodical::intervals::relative::RelativeFiniteBound;
+    /// # use periodical::intervals::meta::BoundInclusivity;
+    /// # use periodical::intervals::ops::PreciseRelativeBound;
+    /// let bound = RelativeFiniteBound::new_with_inclusivity(
+    ///     SignedDuration::from_mins(24),
+    ///     BoundInclusivity::Exclusive,
+    /// )
+    /// .to_start_bound();
+    ///
+    /// assert_eq!(
+    ///     bound.precise_bound(Precision::new(
+    ///         Duration::from_mins(5),
+    ///         PrecisionMode::ToFuture
+    ///     )?),
+    ///     Ok(RelativeFiniteBound::new_with_inclusivity(
+    ///         SignedDuration::from_mins(25),
+    ///         BoundInclusivity::Exclusive,
+    ///     )
+    ///     .to_start_bound())
+    /// );
+    /// # Ok::<(), Box<dyn Error>>(())
+    /// ```
     #[must_use]
-    fn precise_bounds(&self, precision: Precision) -> Self::PrecisedBoundOutput;
+    fn precise_bound(&self, precision: Precision) -> Self::PrecisedBoundOutput;
 
+    /// Precises the bound with the given precision and base offset
+    ///
+    /// See [`Precision::precise_signed_duration_with_base_offset`] for more information.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::error::Error;
+    /// # use std::time::Duration;
+    /// # use jiff::SignedDuration;
+    /// # use periodical::ops::{Precision, PrecisionMode};
+    /// # use periodical::intervals::relative::RelativeFiniteBound;
+    /// # use periodical::intervals::meta::BoundInclusivity;
+    /// # use periodical::intervals::ops::PreciseRelativeBound;
+    /// let bound = RelativeFiniteBound::new_with_inclusivity(
+    ///     SignedDuration::from_mins(24),
+    ///     BoundInclusivity::Exclusive,
+    /// )
+    /// .to_start_bound();
+    ///
+    /// assert_eq!(
+    ///     bound.precise_bound_with_base_offset(
+    ///         Precision::new(Duration::from_mins(5), PrecisionMode::ToFuture)?,
+    ///         SignedDuration::from_mins(2)
+    ///     ),
+    ///     Ok(RelativeFiniteBound::new_with_inclusivity(
+    ///         SignedDuration::from_mins(27),
+    ///         BoundInclusivity::Exclusive,
+    ///     )
+    ///     .to_start_bound())
+    /// );
+    /// # Ok::<(), Box<dyn Error>>(())
+    /// ```
     #[must_use]
     fn precise_bound_with_base_offset(&self, precision: Precision, base: SignedDuration) -> Self::PrecisedBoundOutput;
+}
+
+impl PreciseRelativeBound for RelativeFiniteBound {
+    type PrecisedBoundOutput = Result<Self, PrecisionOutOfRangeError>;
+
+    fn precise_bound(&self, precision: Precision) -> Self::PrecisedBoundOutput {
+        precise_rel_finite_bound(self, precision)
+    }
+
+    fn precise_bound_with_base_offset(&self, precision: Precision, base: SignedDuration) -> Self::PrecisedBoundOutput {
+        precise_rel_finite_bound_with_base_offset(self, precision, base)
+    }
+}
+
+impl PreciseRelativeBound for RelativeStartBound {
+    type PrecisedBoundOutput = Result<Self, PrecisionOutOfRangeError>;
+
+    fn precise_bound(&self, precision: Precision) -> Self::PrecisedBoundOutput {
+        precise_rel_start_bound(self, precision)
+    }
+
+    fn precise_bound_with_base_offset(&self, precision: Precision, base: SignedDuration) -> Self::PrecisedBoundOutput {
+        precise_rel_start_bound_with_base_offset(self, precision, base)
+    }
+}
+
+impl PreciseRelativeBound for RelativeEndBound {
+    type PrecisedBoundOutput = Result<Self, PrecisionOutOfRangeError>;
+
+    fn precise_bound(&self, precision: Precision) -> Self::PrecisedBoundOutput {
+        precise_rel_end_bound(self, precision)
+    }
+
+    fn precise_bound_with_base_offset(&self, precision: Precision, base: SignedDuration) -> Self::PrecisedBoundOutput {
+        precise_rel_end_bound_with_base_offset(self, precision, base)
+    }
+}
+
+/// Precises an [`RelativeFiniteBound`] with the given [`Precision`]
+///
+/// # Errors
+///
+/// See [`Precision::precise_signed_duration`]
+pub fn precise_rel_finite_bound(
+    bound: &RelativeFiniteBound,
+    precision: Precision,
+) -> Result<RelativeFiniteBound, PrecisionOutOfRangeError> {
+    Ok(RelativeFiniteBound::new_with_inclusivity(
+        precision.precise_signed_duration(bound.offset())?,
+        bound.inclusivity(),
+    ))
+}
+
+/// Precises an [`RelativeStartBound`] with the given [`Precision`]
+///
+/// # Errors
+///
+/// See [`Precision::precise_signed_duration`]
+pub fn precise_rel_start_bound(
+    bound: &RelativeStartBound,
+    precision: Precision,
+) -> Result<RelativeStartBound, PrecisionOutOfRangeError> {
+    match bound {
+        RelativeStartBound::InfinitePast => Ok(*bound),
+        RelativeStartBound::Finite(finite_bound) => {
+            precise_rel_finite_bound(finite_bound, precision).map(RelativeFiniteBound::to_start_bound)
+        },
+    }
+}
+
+/// Precises an [`RelativeEndBound`] with the given [`Precision`]
+///
+/// # Errors
+///
+/// See [`Precision::precise_signed_duration`]
+pub fn precise_rel_end_bound(
+    bound: &RelativeEndBound,
+    precision: Precision,
+) -> Result<RelativeEndBound, PrecisionOutOfRangeError> {
+    match bound {
+        RelativeEndBound::InfiniteFuture => Ok(*bound),
+        RelativeEndBound::Finite(finite_bound) => {
+            precise_rel_finite_bound(finite_bound, precision).map(RelativeFiniteBound::to_end_bound)
+        },
+    }
+}
+
+/// Precises an [`RelativeFiniteBound`] with the given [`Precision`] and base time
+///
+/// # Errors
+///
+/// See [`Precision::precise_signed_duration_with_base_offset`]
+pub fn precise_rel_finite_bound_with_base_offset(
+    bound: &RelativeFiniteBound,
+    precision: Precision,
+    base: SignedDuration,
+) -> Result<RelativeFiniteBound, PrecisionOutOfRangeError> {
+    Ok(RelativeFiniteBound::new_with_inclusivity(
+        precision.precise_signed_duration_with_base_offset(bound.offset(), base)?,
+        bound.inclusivity(),
+    ))
+}
+
+/// Precises an [`RelativeStartBound`] with the given [`Precision`] and base time
+///
+/// # Errors
+///
+/// See [`Precision::precise_signed_duration_with_base_offset`]
+pub fn precise_rel_start_bound_with_base_offset(
+    bound: &RelativeStartBound,
+    precision: Precision,
+    base: SignedDuration,
+) -> Result<RelativeStartBound, PrecisionOutOfRangeError> {
+    match bound {
+        RelativeStartBound::InfinitePast => Ok(*bound),
+        RelativeStartBound::Finite(finite_bound) => {
+            precise_rel_finite_bound_with_base_offset(finite_bound, precision, base)
+                .map(RelativeFiniteBound::to_start_bound)
+        },
+    }
+}
+
+/// Precises an [`RelativeEndBound`] with the given [`Precision`] and base time
+///
+/// # Errors
+///
+/// See [`Precision::precise_signed_duration_with_base_offset`]
+pub fn precise_rel_end_bound_with_base_offset(
+    bound: &RelativeEndBound,
+    precision: Precision,
+    base: SignedDuration,
+) -> Result<RelativeEndBound, PrecisionOutOfRangeError> {
+    match bound {
+        RelativeEndBound::InfiniteFuture => Ok(*bound),
+        RelativeEndBound::Finite(finite_bound) => {
+            precise_rel_finite_bound_with_base_offset(finite_bound, precision, base)
+                .map(RelativeFiniteBound::to_end_bound)
+        },
+    }
 }

--- a/src/intervals/ops/precision/relative/interval.rs
+++ b/src/intervals/ops/precision/relative/interval.rs
@@ -1,1 +1,374 @@
+use jiff::SignedDuration;
 
+use crate::intervals::ops::precision::relative::bound::{
+    precise_rel_end_bound,
+    precise_rel_end_bound_with_base_offset,
+    precise_rel_start_bound,
+    precise_rel_start_bound_with_base_offset,
+};
+use crate::intervals::relative::{
+    EmptiableRelativeBoundPair,
+    EmptiableRelativeInterval,
+    HasEmptiableRelativeBoundPair,
+    HasRelativeBoundPair,
+    RelativeBoundPair,
+    RelativeInterval,
+};
+use crate::intervals::special::EmptyInterval;
+use crate::ops::{Precision, PrecisionOutOfRangeError};
+
+/// Ability to precise relative intervals
+///
+/// The precision itself is defined by [`Precision`].
+///
+/// # Examples
+///
+/// ```
+/// # use std::error::Error;
+/// # use std::time::Duration;
+/// # use jiff::SignedDuration;
+/// # use periodical::ops::{Precision, PrecisionMode};
+/// # use periodical::intervals::relative::{RelativeBoundPair, RelativeFiniteBound};
+/// # use periodical::intervals::ops::PreciseRelativeInterval;
+/// let interval = RelativeBoundPair::new(
+///     RelativeFiniteBound::new(SignedDuration::from_mins(3)).to_start_bound(),
+///     RelativeFiniteBound::new(SignedDuration::from_hours(7) + SignedDuration::from_mins(57))
+///         .to_end_bound(),
+/// );
+///
+/// assert_eq!(
+///     interval.precise_interval(Precision::new(
+///         Duration::from_mins(5),
+///         PrecisionMode::ToPast
+///     )?),
+///     Ok(RelativeBoundPair::new(
+///         RelativeFiniteBound::new(SignedDuration::ZERO).to_start_bound(),
+///         RelativeFiniteBound::new(SignedDuration::from_hours(7) + SignedDuration::from_mins(55))
+///             .to_end_bound(),
+///     )),
+/// );
+/// # Ok::<(), Box<dyn Error>>(())
+/// ```
+pub trait PreciseRelativeInterval {
+    /// Output of methods precising an interval
+    type PrecisedIntervalOutput;
+
+    /// Precises the start and end bounds with different [`Precision`]s
+    ///
+    /// See [`Precision::precise_signed_duration`] for more information.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::error::Error;
+    /// # use std::time::Duration;
+    /// # use jiff::SignedDuration;
+    /// # use periodical::ops::{Precision, PrecisionMode};
+    /// # use periodical::intervals::relative::{RelativeBoundPair, RelativeFiniteBound};
+    /// # use periodical::intervals::ops::PreciseRelativeInterval;
+    /// let interval = RelativeBoundPair::new(
+    ///     RelativeFiniteBound::new(SignedDuration::from_mins(3)).to_start_bound(),
+    ///     RelativeFiniteBound::new(SignedDuration::from_hours(7) + SignedDuration::from_mins(57))
+    ///         .to_end_bound(),
+    /// );
+    ///
+    /// assert_eq!(
+    ///     interval.precise_interval_with_different_precisions(
+    ///         Precision::new(Duration::from_mins(5), PrecisionMode::ToPast)?,
+    ///         Precision::new(Duration::from_mins(5), PrecisionMode::ToFuture)?,
+    ///     ),
+    ///     Ok(RelativeBoundPair::new(
+    ///         RelativeFiniteBound::new(SignedDuration::ZERO).to_start_bound(),
+    ///         RelativeFiniteBound::new(SignedDuration::from_hours(8)).to_end_bound(),
+    ///     )),
+    /// );
+    /// # Ok::<(), Box<dyn Error>>(())
+    /// ```
+    #[must_use]
+    fn precise_interval_with_different_precisions(
+        &self,
+        precision_start: Precision,
+        precision_end: Precision,
+    ) -> Self::PrecisedIntervalOutput;
+
+    /// Precises the start and end bounds with the given [`Precision`]
+    ///
+    /// See [`Precision::precise_signed_duration`] for more information.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::error::Error;
+    /// # use std::time::Duration;
+    /// # use jiff::SignedDuration;
+    /// # use periodical::ops::{Precision, PrecisionMode};
+    /// # use periodical::intervals::relative::{RelativeBoundPair, RelativeFiniteBound};
+    /// # use periodical::intervals::ops::PreciseRelativeInterval;
+    /// let interval = RelativeBoundPair::new(
+    ///     RelativeFiniteBound::new(SignedDuration::from_mins(3)).to_start_bound(),
+    ///     RelativeFiniteBound::new(SignedDuration::from_hours(7) + SignedDuration::from_mins(57))
+    ///         .to_end_bound(),
+    /// );
+    ///
+    /// assert_eq!(
+    ///     interval.precise_interval(Precision::new(
+    ///         Duration::from_mins(5),
+    ///         PrecisionMode::ToPast
+    ///     )?),
+    ///     Ok(RelativeBoundPair::new(
+    ///         RelativeFiniteBound::new(SignedDuration::ZERO).to_start_bound(),
+    ///         RelativeFiniteBound::new(SignedDuration::from_hours(7) + SignedDuration::from_mins(55))
+    ///             .to_end_bound(),
+    ///     )),
+    /// );
+    /// # Ok::<(), Box<dyn Error>>(())
+    /// ```
+    #[must_use]
+    fn precise_interval(&self, precision: Precision) -> Self::PrecisedIntervalOutput {
+        self.precise_interval_with_different_precisions(precision, precision)
+    }
+
+    /// Precises the start and end bounds with different precisions and base
+    /// offsets for both of them
+    ///
+    /// See [`Precision::precise_signed_duration_with_base_offset`] for more information.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::error::Error;
+    /// # use std::time::Duration;
+    /// # use jiff::SignedDuration;
+    /// # use periodical::ops::{Precision, PrecisionMode};
+    /// # use periodical::intervals::relative::{RelativeBoundPair, RelativeFiniteBound};
+    /// # use periodical::intervals::ops::PreciseRelativeInterval;
+    /// let interval = RelativeBoundPair::new(
+    ///     RelativeFiniteBound::new(SignedDuration::from_mins(13)).to_start_bound(),
+    ///     RelativeFiniteBound::new(SignedDuration::from_hours(7) + SignedDuration::from_mins(57))
+    ///         .to_end_bound(),
+    /// );
+    ///
+    /// assert_eq!(
+    ///     interval.precise_interval_with_different_precisions_with_base_offset(
+    ///         Precision::new(Duration::from_mins(5), PrecisionMode::ToPast)?,
+    ///         SignedDuration::from_mins(2),
+    ///         Precision::new(Duration::from_mins(5), PrecisionMode::ToFuture)?,
+    ///         SignedDuration::from_mins(1),
+    ///     ),
+    ///     Ok(RelativeBoundPair::new(
+    ///         RelativeFiniteBound::new(SignedDuration::from_mins(12)).to_start_bound(),
+    ///         RelativeFiniteBound::new(SignedDuration::from_hours(8) + SignedDuration::from_mins(1))
+    ///             .to_end_bound(),
+    ///     )),
+    /// );
+    /// # Ok::<(), Box<dyn Error>>(())
+    /// ```
+    #[must_use]
+    fn precise_interval_with_different_precisions_with_base_offset(
+        &self,
+        precision_start: Precision,
+        base_start: SignedDuration,
+        precision_end: Precision,
+        base_end: SignedDuration,
+    ) -> Self::PrecisedIntervalOutput;
+
+    /// Precises the start and end bound with the given precision and base time
+    ///
+    /// See [`Precision::precise_signed_duration_with_base_offset`] for more information.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::error::Error;
+    /// # use std::time::Duration;
+    /// # use jiff::SignedDuration;
+    /// # use periodical::ops::{Precision, PrecisionMode};
+    /// # use periodical::intervals::relative::{RelativeBoundPair, RelativeFiniteBound};
+    /// # use periodical::intervals::ops::PreciseRelativeInterval;
+    /// let interval = RelativeBoundPair::new(
+    ///     RelativeFiniteBound::new(SignedDuration::from_mins(13)).to_start_bound(),
+    ///     RelativeFiniteBound::new(SignedDuration::from_hours(7) + SignedDuration::from_mins(58))
+    ///         .to_end_bound(),
+    /// );
+    ///
+    /// assert_eq!(
+    ///     interval.precise_interval_with_base_offset(
+    ///         Precision::new(Duration::from_mins(5), PrecisionMode::ToPast)?,
+    ///         SignedDuration::from_mins(2),
+    ///     ),
+    ///     Ok(RelativeBoundPair::new(
+    ///         RelativeFiniteBound::new(SignedDuration::from_mins(12)).to_start_bound(),
+    ///         RelativeFiniteBound::new(SignedDuration::from_hours(7) + SignedDuration::from_mins(57))
+    ///             .to_end_bound(),
+    ///     )),
+    /// );
+    /// # Ok::<(), Box<dyn Error>>(())
+    /// ```
+    #[must_use]
+    fn precise_interval_with_base_offset(
+        &self,
+        precision: Precision,
+        base: SignedDuration,
+    ) -> Self::PrecisedIntervalOutput {
+        self.precise_interval_with_different_precisions_with_base_offset(precision, base, precision, base)
+    }
+}
+
+impl PreciseRelativeInterval for RelativeBoundPair {
+    type PrecisedIntervalOutput = Result<Self, PrecisionOutOfRangeError>;
+
+    fn precise_interval_with_different_precisions(
+        &self,
+        precision_start: Precision,
+        precision_end: Precision,
+    ) -> Self::PrecisedIntervalOutput {
+        precise_rel_bound_pair(self, precision_start, precision_end)
+    }
+
+    fn precise_interval_with_different_precisions_with_base_offset(
+        &self,
+        precision_start: Precision,
+        base_start: SignedDuration,
+        precision_end: Precision,
+        base_end: SignedDuration,
+    ) -> Self::PrecisedIntervalOutput {
+        precise_rel_bound_pair_with_base_offset(self, precision_start, base_start, precision_end, base_end)
+    }
+}
+
+impl PreciseRelativeInterval for EmptiableRelativeBoundPair {
+    type PrecisedIntervalOutput = Result<Self, PrecisionOutOfRangeError>;
+
+    fn precise_interval_with_different_precisions(
+        &self,
+        precision_start: Precision,
+        precision_end: Precision,
+    ) -> Self::PrecisedIntervalOutput {
+        if let Self::Bound(rel_bound_pair) = self {
+            Ok(precise_rel_bound_pair(rel_bound_pair, precision_start, precision_end)?.to_emptiable())
+        } else {
+            Ok(Self::Empty)
+        }
+    }
+
+    fn precise_interval_with_different_precisions_with_base_offset(
+        &self,
+        precision_start: Precision,
+        base_start: SignedDuration,
+        precision_end: Precision,
+        base_end: SignedDuration,
+    ) -> Self::PrecisedIntervalOutput {
+        if let Self::Bound(rel_bound_pair) = self {
+            Ok(precise_rel_bound_pair_with_base_offset(
+                rel_bound_pair,
+                precision_start,
+                base_start,
+                precision_end,
+                base_end,
+            )?
+            .to_emptiable())
+        } else {
+            Ok(Self::Empty)
+        }
+    }
+}
+
+impl PreciseRelativeInterval for RelativeInterval {
+    type PrecisedIntervalOutput = Result<Self, PrecisionOutOfRangeError>;
+
+    fn precise_interval_with_different_precisions(
+        &self,
+        precision_start: Precision,
+        precision_end: Precision,
+    ) -> Self::PrecisedIntervalOutput {
+        Ok(precise_rel_bound_pair(&self.rel_bound_pair(), precision_start, precision_end)?.to_interval())
+    }
+
+    fn precise_interval_with_different_precisions_with_base_offset(
+        &self,
+        precision_start: Precision,
+        base_start: SignedDuration,
+        precision_end: Precision,
+        base_end: SignedDuration,
+    ) -> Self::PrecisedIntervalOutput {
+        Ok(precise_rel_bound_pair_with_base_offset(
+            &self.rel_bound_pair(),
+            precision_start,
+            base_start,
+            precision_end,
+            base_end,
+        )?
+        .to_interval())
+    }
+}
+
+impl PreciseRelativeInterval for EmptiableRelativeInterval {
+    type PrecisedIntervalOutput = Result<Self, PrecisionOutOfRangeError>;
+
+    fn precise_interval_with_different_precisions(
+        &self,
+        precision_start: Precision,
+        precision_end: Precision,
+    ) -> Self::PrecisedIntervalOutput {
+        if let EmptiableRelativeBoundPair::Bound(ref rel_bound_pair) = self.emptiable_rel_bound_pair() {
+            Ok(precise_rel_bound_pair(rel_bound_pair, precision_start, precision_end)?.to_emptiable_interval())
+        } else {
+            Ok(Self::Empty(EmptyInterval))
+        }
+    }
+
+    fn precise_interval_with_different_precisions_with_base_offset(
+        &self,
+        precision_start: Precision,
+        base_start: SignedDuration,
+        precision_end: Precision,
+        base_end: SignedDuration,
+    ) -> Self::PrecisedIntervalOutput {
+        if let EmptiableRelativeBoundPair::Bound(ref rel_bound_pair) = self.emptiable_rel_bound_pair() {
+            Ok(precise_rel_bound_pair_with_base_offset(
+                rel_bound_pair,
+                precision_start,
+                base_start,
+                precision_end,
+                base_end,
+            )?
+            .to_emptiable_interval())
+        } else {
+            Ok(Self::Empty(EmptyInterval))
+        }
+    }
+}
+
+/// Precises [`RelativeBoundPair`] with the given [`Precision`]s
+///
+/// # Errors
+///
+/// See [`Precision::precise_signed_duration`]
+pub fn precise_rel_bound_pair(
+    bound_pair: &RelativeBoundPair,
+    precision_start: Precision,
+    precision_end: Precision,
+) -> Result<RelativeBoundPair, PrecisionOutOfRangeError> {
+    Ok(RelativeBoundPair::new(
+        precise_rel_start_bound(&bound_pair.start(), precision_start)?,
+        precise_rel_end_bound(&bound_pair.end(), precision_end)?,
+    ))
+}
+
+/// Precises [`RelativeBoundPair`] with the given [`Precision`]s and base offsets
+///
+/// # Errors
+///
+/// See [`Precision::precise_signed_duration_with_base_offset`]
+pub fn precise_rel_bound_pair_with_base_offset(
+    bound_pair: &RelativeBoundPair,
+    precision_start: Precision,
+    base_start: SignedDuration,
+    precision_end: Precision,
+    base_end: SignedDuration,
+) -> Result<RelativeBoundPair, PrecisionOutOfRangeError> {
+    Ok(RelativeBoundPair::new(
+        precise_rel_start_bound_with_base_offset(&bound_pair.start(), precision_start, base_start)?,
+        precise_rel_end_bound_with_base_offset(&bound_pair.end(), precision_end, base_end)?,
+    ))
+}

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -264,11 +264,11 @@ impl Precision {
 
     /// Applies the precision to a given [`Duration`](StdDuration)
     ///
-    /// Since a duration is relative, rounding is based on the multiple of the precision's duration.
+    /// Rounding is based on the multiple of the precision's duration.
     ///
     /// # Errors
     ///
-    /// Returns [`PrecisionOutOfRangeDateError`] if the computed new duration has an amount of seconds superior
+    /// Returns [`PrecisionOutOfRangeError`] if the computed new duration has an amount of seconds superior
     /// to what [`u64`] can store.
     ///
     /// # Panics
@@ -289,14 +289,123 @@ impl Precision {
     /// );
     /// # Ok::<(), Box<dyn Error>>(())
     /// ```
-    pub fn precise_duration(&self, duration: StdDuration) -> Result<StdDuration, PrecisionOutOfRangeDateError> {
+    pub fn precise_duration(&self, duration: StdDuration) -> Result<StdDuration, PrecisionOutOfRangeError> {
         let new_timestamp = self.precise_unsigned_nanos(duration.as_nanos());
 
         // Polyfill for StdDuration::from_nanos_u128() to avoid bumping MSRV
         // & StdDuration::try_from_nanos_u128() doesn't yet exist
         let nanos_per_sec = StdDuration::from_secs(1).as_nanos();
-        let secs_component = u64::try_from(new_timestamp / nanos_per_sec).or(Err(PrecisionOutOfRangeDateError))?;
-        let nanos_component = u32::try_from(new_timestamp % nanos_per_sec).or(Err(PrecisionOutOfRangeDateError))?;
+        let secs_component = u64::try_from(new_timestamp / nanos_per_sec).or(Err(PrecisionOutOfRangeError))?;
+        let nanos_component = u32::try_from(new_timestamp % nanos_per_sec).or(Err(PrecisionOutOfRangeError))?;
+
+        Ok(StdDuration::new(secs_component, nanos_component))
+    }
+
+    /// Applies the precision to a given [`Duration`](StdDuration) based on a given offset
+    ///
+    /// Rounding is based on the multiple of the precision's duration relative to the given base offset.
+    ///
+    /// Use [`precise_duration_with_base_offset_via_signed`](Self::precise_duration_with_base_offset_via_signed)
+    /// if you expect the given duration to possibly be lower than the given base offset.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PrecisionOutOfRangeError`] for any of the following reasons:
+    /// - The base offset could not be subtracted from the duration without underflow
+    /// - [`precise_duration`](Self::precise_duration) returned an error
+    /// - The resulting precised duration relative to the base offset overflowed after adding the base offset back
+    ///
+    /// # Panics
+    ///
+    /// See [`precise_duration`](Self::precise_duration).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::error::Error;
+    /// # use std::time::Duration;
+    /// # use periodical::ops::{Precision, PrecisionMode};
+    /// let precision = Precision::new(Duration::from_mins(15), PrecisionMode::ToPast)?;
+    ///
+    /// assert_eq!(
+    ///     precision
+    ///         .precise_duration_with_base_offset(Duration::from_mins(77), Duration::from_mins(3))?,
+    ///     Duration::from_mins(63),
+    /// );
+    /// # Ok::<(), Box<dyn Error>>(())
+    /// ```
+    pub fn precise_duration_with_base_offset(
+        &self,
+        duration: StdDuration,
+        base: StdDuration,
+    ) -> Result<StdDuration, PrecisionOutOfRangeError> {
+        base.checked_add(self.precise_duration(duration.checked_sub(base).ok_or(PrecisionOutOfRangeError)?)?)
+            .ok_or(PrecisionOutOfRangeError)
+    }
+
+    /// Applies the precision to a given [`Duration`](StdDuration) based on a given offset via [`SignedDuration`]
+    /// conversions
+    ///
+    /// Similar to [`precise_duration_with_base_offset`](Self::precise_duration_with_base_offset), but converts
+    /// the base and the offset to [`SignedDuration`]s to do the computation, before converting the result back
+    /// into a [`Duration`](StdDuration).
+    ///
+    /// This is useful when you expect the given [`Duration`](StdDuration) to be lower than the given base offset.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PrecisionOutOfRangeError`] for any of the following reasons:
+    /// - The duration could not be converted to a [`SignedDuration`]
+    /// - The base offset could not be converted to a [`SignedDuration`]
+    /// - [`precise_signed_duration_with_base_offset`](Self::precise_signed_duration_with_base_offset) returned an error
+    /// - The resulting precised duration could not be converted back to a [`Duration`](StdDuration)
+    ///
+    /// # Panics
+    ///
+    /// See [`precise_signed_duration_with_base_offset`](Self::precise_signed_duration_with_base_offset).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::error::Error;
+    /// # use std::time::Duration;
+    /// # use periodical::ops::{Precision, PrecisionMode};
+    /// let precision = Precision::new(Duration::from_mins(3), PrecisionMode::ToFuture)?;
+    ///
+    /// assert_eq!(
+    ///     precision.precise_duration_with_base_offset_via_signed(
+    ///         Duration::from_mins(1),
+    ///         Duration::from_mins(2)
+    ///     )?,
+    ///     Duration::from_mins(2),
+    /// );
+    /// # Ok::<(), Box<dyn Error>>(())
+    /// ```
+    pub fn precise_duration_with_base_offset_via_signed(
+        &self,
+        duration: StdDuration,
+        base: StdDuration,
+    ) -> Result<StdDuration, PrecisionOutOfRangeError> {
+        let signed_duration =
+            SignedDuration::try_from_nanos_i128(i128::try_from(duration.as_nanos()).or(Err(PrecisionOutOfRangeError))?)
+                .ok_or(PrecisionOutOfRangeError)?;
+        let signed_base =
+            SignedDuration::try_from_nanos_i128(i128::try_from(base.as_nanos()).or(Err(PrecisionOutOfRangeError))?)
+                .ok_or(PrecisionOutOfRangeError)?;
+
+        let unsigned_precised_duration = u128::try_from(
+            self.precise_signed_duration_with_base_offset(signed_duration, signed_base)?
+                .as_nanos(),
+        )
+        .or(Err(PrecisionOutOfRangeError))?;
+
+        // Polyfill for StdDuration::from_nanos_u128() to avoid bumping MSRV
+        // & StdDuration::try_from_nanos_u128() doesn't yet exist
+        let nanos_per_sec = StdDuration::from_secs(1).as_nanos();
+        let secs_component =
+            u64::try_from(unsigned_precised_duration / nanos_per_sec).or(Err(PrecisionOutOfRangeError))?;
+        let nanos_component =
+            u32::try_from(unsigned_precised_duration % nanos_per_sec).or(Err(PrecisionOutOfRangeError))?;
 
         Ok(StdDuration::new(secs_component, nanos_component))
     }
@@ -307,7 +416,7 @@ impl Precision {
     ///
     /// # Errors
     ///
-    /// Returns [`PrecisionOutOfRangeDateError`] if the computed new duration exceeded what [`i128`] can store.
+    /// Returns [`PrecisionOutOfRangeError`] if the computed new duration exceeded what [`i128`] can store.
     ///
     /// # Panics
     ///
@@ -331,10 +440,52 @@ impl Precision {
     pub fn precise_signed_duration(
         &self,
         signed_duration: SignedDuration,
-    ) -> Result<SignedDuration, PrecisionOutOfRangeDateError> {
+    ) -> Result<SignedDuration, PrecisionOutOfRangeError> {
         Ok(SignedDuration::from_nanos_i128(
             self.precise_signed_nanos(signed_duration.as_nanos()),
         ))
+    }
+
+    /// Applies the precision to a given [`SignedDuration`] based on a given offset
+    ///
+    /// Rounding is based on the multiple of the precision's duration relative to the given base offset.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PrecisionOutOfRangeError`] for any of the following reasons:
+    /// - The base offset could not be subtracted from the duration without underflow
+    /// - [`precise_signed_duration`](Self::precise_signed_duration) returned an error
+    /// - The resulting precised duration relative to the base offset overflowed after adding the base offset back
+    ///
+    /// # Panics
+    ///
+    /// See [`precise_signed_duration`](Self::precise_signed_duration).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::error::Error;
+    /// # use std::time::Duration;
+    /// # use jiff::SignedDuration;
+    /// # use periodical::ops::{Precision, PrecisionMode};
+    /// let precision = Precision::new(Duration::from_mins(15), PrecisionMode::ToPast)?;
+    ///
+    /// assert_eq!(
+    ///     precision.precise_signed_duration_with_base_offset(
+    ///         SignedDuration::from_mins(-77),
+    ///         SignedDuration::from_mins(-3)
+    ///     )?,
+    ///     SignedDuration::from_mins(-78),
+    /// );
+    /// # Ok::<(), Box<dyn Error>>(())
+    /// ```
+    pub fn precise_signed_duration_with_base_offset(
+        &self,
+        duration: SignedDuration,
+        base: SignedDuration,
+    ) -> Result<SignedDuration, PrecisionOutOfRangeError> {
+        base.checked_add(self.precise_signed_duration(duration.checked_sub(base).ok_or(PrecisionOutOfRangeError)?)?)
+            .ok_or(PrecisionOutOfRangeError)
     }
 
     /// Applies the precision to the given time
@@ -368,7 +519,7 @@ impl Precision {
     ///
     /// # Errors
     ///
-    /// Returns [`PrecisionOutOfRangeDateError`] if the
+    /// Returns [`PrecisionOutOfRangeError`] if the
     /// transfer to UTC would represent a timestamp too small to be stored
     /// correctly or if the resulting time would result in a time that
     /// cannot be stored in [`Zoned`].
@@ -439,21 +590,21 @@ impl Precision {
     /// ```
     ///
     /// [1]: https://en.wikipedia.org/w/index.php?title=Unix_time&oldid=1345178064
-    pub fn precise_time(&self, time: &Zoned) -> Result<AmbiguousZoned, PrecisionOutOfRangeDateError> {
+    pub fn precise_time(&self, time: &Zoned) -> Result<AmbiguousZoned, PrecisionOutOfRangeError> {
         let utc_day_start = time
             .datetime()
             .start_of_day()
             .to_zoned(TimeZone::UTC)
-            .or(Err(PrecisionOutOfRangeDateError))?;
+            .or(Err(PrecisionOutOfRangeError))?;
         let duration_diff = time
             .datetime()
             .to_zoned(TimeZone::UTC)
-            .or(Err(PrecisionOutOfRangeDateError))?
+            .or(Err(PrecisionOutOfRangeError))?
             .timestamp()
             .duration_since(utc_day_start.timestamp());
         let precised_datetime = utc_day_start
             .checked_add(self.precise_signed_duration(duration_diff)?)
-            .or(Err(PrecisionOutOfRangeDateError))?
+            .or(Err(PrecisionOutOfRangeError))?
             .datetime();
 
         Ok(time.time_zone().to_ambiguous_zoned(precised_datetime))
@@ -477,7 +628,7 @@ impl Precision {
     ///
     /// # Errors
     ///
-    /// Returns [`PrecisionOutOfRangeDateError`] if the resulting time would result in a time
+    /// Returns [`PrecisionOutOfRangeError`] if the resulting time would result in a time
     /// that cannot be stored in [`Zoned`].
     ///
     /// # Panics
@@ -529,11 +680,11 @@ impl Precision {
         &self,
         time: &Zoned,
         base: Timestamp,
-    ) -> Result<Zoned, PrecisionOutOfRangeDateError> {
+    ) -> Result<Zoned, PrecisionOutOfRangeError> {
         let base = base.to_zoned(time.time_zone().clone());
 
         base.checked_add(self.precise_signed_duration(time.duration_since(&base))?)
-            .map_err(|_| PrecisionOutOfRangeDateError)
+            .map_err(|_| PrecisionOutOfRangeError)
     }
 }
 
@@ -549,17 +700,17 @@ impl Display for PrecisionCreationPrecisionIsZeroError {
 
 impl Error for PrecisionCreationPrecisionIsZeroError {}
 
-/// An operation produced an out-of-range date when using [`Precision`]
+/// An operation produced an out-of-range value when using [`Precision`]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct PrecisionOutOfRangeDateError;
+pub struct PrecisionOutOfRangeError;
 
-impl Display for PrecisionOutOfRangeDateError {
+impl Display for PrecisionOutOfRangeError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Operation produced an out-of-range date")
+        write!(f, "Operation produced an out-of-range value")
     }
 }
 
-impl Error for PrecisionOutOfRangeDateError {}
+impl Error for PrecisionOutOfRangeError {}
 
 /// Represents a running result
 ///


### PR DESCRIPTION
# Explanation

The recent introduction of `Precision::precise_signed_duration` helped set the foundation
for relative-bound precising. Therefore, there was no more obstacles to creating the relative
version of `intervals::ops::precision`.

<details>
<summary><h1>Changelog</h1></summary>

## Added

- Implemented `precise_duration_with_base_offset` on `Precision`
- Implemented `precise_duration_with_base_offset_via_signed` on `Precision`
- Implemented `precise_signed_duration_with_base_offset` on `Precision`
- Implemented relative version of `PreciseAbsoluteBound` and `PreciseAbsoluteInterval`

## Changed

- Renamed `PrecisionOutOfRangeDateError` to `PrecisionOutOfRangeError` to make the error more generic.
  Adjusted the error's message in consequence.

</details>
